### PR TITLE
ext library fix for jaspic tck with jdk 11 and GF 6.1

### DIFF
--- a/install/jaspic/bin/ts.jte.jdk11
+++ b/install/jaspic/bin/ts.jte.jdk11
@@ -229,7 +229,7 @@ s1as.targets=${s1as.server}
 #       app server's extension directory.  The CTS config.vi
 #       target will copy the CTS library jars to this location.
 ###############################################################
-extension.dir=${s1as.domain}/lib/ext
+extension.dir=${s1as.domain}/lib
 
 
 ###############################################################


### PR DESCRIPTION
Signed-off-by: gurunandan.rao@oracle.com <gurunandan.rao@oracle.com>

The PR is fix for JASPIC class-loading issue described with issue https://github.com/eclipse-ee4j/jakartaee-tck/issues/638.
