### PR TITLE
for #1060, ensure that DataSourceDefinition has unique name

### DIFF
--- a/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/JsfClient.java.template
+++ b/src/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/singleton/JsfClient.java.template
@@ -38,7 +38,7 @@ import com.sun.ts.tests.ejb30.lite.packaging.war.datasource.common.DataSourceIF;
 
 // url is to be ignored
 @DataSourceDefinitions({
-@DataSourceDefinition(name="java:comp/env/compds",
+@DataSourceDefinition(name="java:comp/env/jsfcompds",
         className="@className@",
         portNumber=@portNumber@,
         serverName="@serverName@",
@@ -57,7 +57,7 @@ import com.sun.ts.tests.ejb30.lite.packaging.war.datasource.common.DataSourceIF;
         properties={@jdbc.datasource.props@},
         url="jdbc:derby://${derby.server}:${derby.port}/${derby.dbName};create=true"
 ),
-@DataSourceDefinition(name="java:comp/env/compds2",
+@DataSourceDefinition(name="java:comp/env/jsfcompds2",
         className="@className@",
         portNumber=@portNumber@,
         serverName="@serverName@",
@@ -82,11 +82,11 @@ public class JsfClient extends EJBLiteJsfClientBase implements Serializable {
     @Resource
     private DataSourceRepeatableBean dataSourceRBean;
     
-    @Resource(lookup="java:comp/env/compds")
-    private DataSource compds;
+    @Resource(lookup="java:comp/env/jsfcompds")
+    private DataSource jsfcompds;
     
-    @Resource(lookup="java:comp/env/compds2")
-    private DataSource compds2;
+    @Resource(lookup="java:comp/env/jsfcompds2")
+    private DataSource jsfcompds2;
     
     @Resource(lookup="java:comp/env/defaultds")
     private DataSource defaultds;
@@ -107,11 +107,11 @@ public class JsfClient extends EJBLiteJsfClientBase implements Serializable {
         Helper.getLogger().info("In postConstruct of " + this);
         
         verifyDataSource(getReasonBuffer(), c, "java:comp/env/defaultds", "java:comp/env/defaultds2", 
-                                               "java:comp/env/compds", "java:comp/env/compds2",
+                                               "java:comp/env/jsfcompds", "java:comp/env/jsfcompds2",
                                                "java:module/env/moduleds", "java:module/env/moduleds2");
-        verifyDataSource(getReasonBuffer(), c, defaultds, defaultds2, compds, compds2, moduleds, moduleds2);
+        verifyDataSource(getReasonBuffer(), c, defaultds, defaultds2, jsfcompds, jsfcompds2, moduleds, moduleds2);
 
-        verifyDataSource(getReasonBuffer(), c, compds, compds2);
+        verifyDataSource(getReasonBuffer(), c, jsfcompds, jsfcompds2);
     }
     
     /*


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

**Fixes Issue**

https://github.com/eclipse-ee4j/jakartaee-tck/issues/1060

**Describe the change**

The current tests do not need to use the same DataSourceDefinition names between Client + JsfClient tests, so this pull request updates the JsfClient tests to use a unique name which helps WildFly avoid failures.

GlassFish 7 still passes the updated tests on JDK11 (JDK17 should be the same) as per https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck-scottmarlow/job/issue_1060/2/

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @scottmarlow
