### PR TITLE
Fixed RESULT_FILE_NAME variable

### DIFF
--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -190,10 +190,8 @@ on_exit () {
     rm -f "${CTS_HOME}/args.txt"
 
     if [ -z "${vehicle}" ]; then
-      RESULT_FILE_NAME="${TEST_SUITE}-results.tar.gz"
       JUNIT_REPORT_FILE_NAME="${TEST_SUITE}-junitreports.tar.gz"
     else
-      RESULT_FILE_NAME="${TEST_SUITE}_${vehicle_name}-results.tar.gz"
       JUNIT_REPORT_FILE_NAME="${TEST_SUITE}_${vehicle_name}-junitreports.tar.gz"
       sed -i.bak "s/name=\"${TEST_SUITE}\"/name=\"${TEST_SUITE}_${vehicle_name}\"/g" "${WORKSPACE}/results/junitreports/${TEST_SUITE}-junit-report.xml"
       mv "${WORKSPACE}/results/junitreports/${TEST_SUITE}-junit-report.xml" "${WORKSPACE}/results/junitreports/${TEST_SUITE}_${vehicle_name}-junit-report.xml"
@@ -201,6 +199,11 @@ on_exit () {
     tar zcf "${JUNIT_REPORT_FILE_NAME}" -C "${WORKSPACE}" "results/junitreports/" || true
   fi
 
+  if [ -z "${vehicle}" ]; then
+    RESULT_FILE_NAME="${TEST_SUITE}-results.tar.gz"
+  else
+    RESULT_FILE_NAME="${TEST_SUITE}_${vehicle_name}-results.tar.gz"
+  fi
   tar zcf "${WORKSPACE}/${RESULT_FILE_NAME}" --ignore-failed-read -C "${WORKSPACE}"\
     "${CTS_HOME}/*.log"\
     "${JT_REPORT_DIR}"\


### PR DESCRIPTION
**Related Issue(s)**
See https://github.com/jakartaee/platform-tck/issues/1145 - fixes generating of a *results.tar.gz file when the build crashed. However the issue will need yet more work.

**Describe the change**
In https://github.com/jakartaee/platform-tck/pull/1144 I pushed changes which were already tested on master (at least I thought they were), but 10.0.1 crashed with them - and the change caused that logs were not collected because tests did not start because GF could not be stopped after changing the admin password. The result file is required to find out what happened.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
