### PR TITLE
persistence/issues/388 Unique constraint creation

### DIFF
--- a/install/jpa/bin/ts.jtx
+++ b/install/jpa/bin/ts.jtx
@@ -29,3 +29,8 @@ com/sun/ts/tests/jpa/se/schemaGeneration/annotations/tableGenerator/Client.java#
 #
 #
 com/sun/ts/tests/jpa/core/query/language/Client.java#resultContainsFetchReference_from_standalone
+
+# https://github.com/jakartaee/persistence/issues/388 exclude Unique constraint creation tests 
+com/sun/ts/tests/jpa/se/schemaGeneration/annotations/index/Client.java#indexTest_from_standalone
+com/sun/ts/tests/jpa/se/schemaGeneration/annotations/uniqueConstraint/Client.java#uniqueConstraintTest_from_standalone
+

--- a/release/tools/jpa.xml
+++ b/release/tools/jpa.xml
@@ -22,7 +22,7 @@
     <import file="../../bin/xml/ts.common.props.xml"/>
 
     <property name="deliverable.version" value="3.1"/>
-    <property name="deliverable.tck.version" value="3.1.0"/>
+    <property name="deliverable.tck.version" value="3.1.1"/>
 
     <target name="init">
         <mkdir dir="${deliverable.bundle.dir}/bin"/>


### PR DESCRIPTION
Signed-off-by: Scott Marlow <smarlow@redhat.com>

**Fixes Issue**
Address TCK challenge https://github.com/jakartaee/persistence/issues/388 by producing a (Standalone) Persistence TCK 3.1.1 TCK that excludes challenged tests:
- com/sun/ts/tests/jpa/se/schemaGeneration/annotations/index/Client.java#indexTest and
- com/sun/ts/tests/jpa/se/schemaGeneration/annotations/uniqueConstraint/Client.java#uniqueConstraintTest

**Describe the change**
Exclude the above tests until the https://github.com/jakartaee/platform-tck/pull/1151 change is either back ported to the Persistence 3.1 TCK or available in a future Persistence TCK release.

**Additional context**
@lukasj please do let me know if you would prefer that the https://github.com/jakartaee/platform-tck/pull/1151 change is back ported to a Persistence 3.1 TCK release instead of excluding tests:
- com/sun/ts/tests/jpa/se/schemaGeneration/annotations/index/Client.java#indexTest and
- com/sun/ts/tests/jpa/se/schemaGeneration/annotations/uniqueConstraint/Client.java#uniqueConstraintTest

If/when the above mentioned changes are back ported to the Persistence 3.1 TCK, we will revert the change made to exclude tests in file install/jpa/bin/ts.jtx and build a new Persistence 3.1.nextVersion TCK.
