### PR TITLE
JUnit reports archive was created in user's home instead of a workspace dir

### DIFF
--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -197,7 +197,7 @@ on_exit () {
       sed -i.bak "s/name=\"${TEST_SUITE}\"/name=\"${TEST_SUITE}_${vehicle_name}\"/g" "${WORKSPACE}/results/junitreports/${TEST_SUITE}-junit-report.xml"
       mv "${WORKSPACE}/results/junitreports/${TEST_SUITE}-junit-report.xml" "${WORKSPACE}/results/junitreports/${TEST_SUITE}_${vehicle_name}-junit-report.xml"
     fi
-    tar zcf "${JUNIT_REPORT_FILE_NAME}" -C "${WORKSPACE}" "results/junitreports/" || true
+    tar zcf "${WORKSPACE}/${JUNIT_REPORT_FILE_NAME}" -C "${WORKSPACE}" "results/junitreports/" || true
   fi
 
   if [ -z "${vehicle}" ]; then


### PR DESCRIPTION
See https://ci.eclipse.org/jakartaee-tck/job/jakartaee-tck/job/10.0.x/21/console and then https://ci.eclipse.org/jakartaee-tck/view/EFTL-Certification-Jobs-10/job/10/job/eftl-jakartaeetck-run-100/162/console

```
+ JUNIT_REPORT_FILE_NAME=ejb-junitreports.tar.gz
+ tar zcf ejb-junitreports.tar.gz -C /home/jenkins/agent/workspace/jakartaee-tck_10.0.x results/junitreports/
+ '[' -z '' ']'
+ RESULT_FILE_NAME=ejb-results.tar.gz
+ tar zcf /home/jenkins/agent/workspace/jakartaee-tck_10.0.x/ejb-results.tar.gz --ignore-failed-read -C /home/jenkins/agent/workspace/jakartaee-tck_10.0.x '/home/tck/*.log' /home/tck/jakartaeetck-report /home/tck/jakartaeetck-work /home/jenkins/agent/workspace/jakartaee-tck_10.0.x/results/junitreports/ '/home/tck/jakartaeetck/bin/ts.*' /home/tck/vi/glassfish7/glassfish/domains/domain1/ /home/tck/ri/glassfish7/glassfish/domains/domain1/
```
```
+ for f in *junitreports.tar.gz
+ tar zxf '*junitreports.tar.gz' -C /home/jenkins/agent/workspace/10/eftl-jakartaeetck-run-100 --strip-components=5
tar (child): *junitreports.tar.gz: Cannot open: No such file or directory
tar (child): Error is not recoverable: exiting now
tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

After tar.gzipping the file should be stashed and unstashed to the eftl workspace. But as I forgot to add the correct path recently, it did not happened, it was just parsed after 10.0.x build by Jenkins.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
