### PR TITLE
support JDK21 and security manager disabled.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -182,8 +182,8 @@ spec:
            description: 'List of standalone TCK bundle file names to be appended to the base url' )
     choice(name: 'PROFILE', choices: 'FULL\nWEB', 
            description: 'Profile to be used for running CTS either web/full' )
-    choice(name: 'JDK', choices: 'JDK11\nJDK17',
-           description: 'Java SE Version to be used for running TCK either JDK11/JDK17' )
+    choice(name: 'JDK', choices: 'JDK21',
+           description: 'Java SE Version to be used for running TCK either JDK21' )
     choice(name: 'LICENSE', choices: 'EPL\nEFTL',
            description: 'License file to be used to build the TCK bundle(s) either EPL(default) or Eclipse Foundation TCK License' )
     choice(name: 'AS_TRACE', choices: 'false\ntrue',

--- a/docker/build_jakartaeetck.sh
+++ b/docker/build_jakartaeetck.sh
@@ -18,6 +18,13 @@ if [ -z "$ANT_HOME" ]; then
   export ANT_HOME=/usr/share/ant/
 fi
 
+cd $WORKSPACE
+
+wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+tar -xvf jdk-21.tar.gz
+export JAVA_HOME=$WORKSPACE/jdk-21
+
+
 export PATH=$JAVA_HOME/bin:$ANT_HOME/bin:$PATH
 
 if [ -z "$WORKSPACE" ]; then

--- a/docker/build_standalone-tcks.sh
+++ b/docker/build_standalone-tcks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,6 +26,13 @@ fi
 if [ -z "$JAKARTA_JARS" ]; then
   export JAKARTA_JARS=$BASEDIR
 fi
+
+
+cd $WORKSPACE
+
+wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+tar -xvf jdk-21.tar.gz
+export JAVA_HOME=$WORKSPACE/jdk-21
 
 export PATH=$JAVA_HOME/bin:$ANT_HOME/bin:$PATH
 

--- a/docker/cajtck.sh
+++ b/docker/cajtck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,12 +53,22 @@ TS_HOME=$TCK_HOME/$TCK_NAME
 echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
+
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
+export PATH=$JAVA_HOME/bin:$PATH
+
+
 cd $TS_HOME/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
-export PATH=$JAVA_HOME/bin:$PATH
+
+
 
 which java
 java -version

--- a/docker/connectortck.sh
+++ b/docker/connectortck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -54,12 +54,19 @@ echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
 
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
+export PATH=$JAVA_HOME/bin:$PATH
+
+
 cd $TS_HOME/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
-export PATH=$JAVA_HOME/bin:$PATH
 
 which java
 java -version

--- a/docker/eltck.sh
+++ b/docker/eltck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -57,12 +57,18 @@ echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
 
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
+export PATH=$JAVA_HOME/bin:$PATH
+
 cd $TS_HOME/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
-export PATH=$JAVA_HOME/bin:$PATH
 
 which java
 java -version

--- a/docker/jacctck.sh
+++ b/docker/jacctck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,12 +53,17 @@ echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
 
-cd $TS_HOME/bin
+cd $WORKSPACE
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
 export PATH=$JAVA_HOME/bin:$PATH
+
+cd $TS_HOME/bin
 
 which java
 java -version

--- a/docker/jaxwstck.sh
+++ b/docker/jaxwstck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -54,12 +54,19 @@ TS_HOME=$TCK_HOME/$TCK_NAME
 echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
+
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
+export PATH=$JAVA_HOME/bin:$PATH
+
 cd $TS_HOME/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
-export PATH=$JAVA_HOME/bin:$PATH
 
 export ANT_OPTS="-Djavax.xml.accessExternalStylesheet=all -Djavax.xml.accessExternalSchema=all -Djavax.xml.accessExternalDTD=file,http,https"
 

--- a/docker/jmstck.sh
+++ b/docker/jmstck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,12 +52,18 @@ echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
 
-cd $TS_HOME/bin
+cd $WORKSPACE
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
 export PATH=$JAVA_HOME/bin:$PATH
+
+
+cd $TS_HOME/bin
 
 which java
 java -version

--- a/docker/jpatck.sh
+++ b/docker/jpatck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,12 +53,18 @@ echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
 
-cd $TS_HOME/bin
+cd $WORKSPACE
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
 export PATH=$JAVA_HOME/bin:$PATH
+
+
+cd $TS_HOME/bin
 
 which java
 java -version

--- a/docker/jsptck.sh
+++ b/docker/jsptck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,12 +53,19 @@ echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
 
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
+export PATH=$JAVA_HOME/bin:$PATH
+
+
 cd $TS_HOME/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
-export PATH=$JAVA_HOME/bin:$PATH
 
 which java
 java -version

--- a/docker/jstltck.sh
+++ b/docker/jstltck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,12 +53,19 @@ echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
 
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
+export PATH=$JAVA_HOME/bin:$PATH
+
+
 cd $TS_HOME/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
-export PATH=$JAVA_HOME/bin:$PATH
 
 which java
 java -version

--- a/docker/jtatck.sh
+++ b/docker/jtatck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -57,12 +57,18 @@ unzip -q ${TCK_HOME}/latest-glassfish.zip -d ${TCK_HOME}
 TS_HOME=$TCK_HOME/$TCK_NAME
 echo "TS_HOME $TS_HOME"
 
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
+export PATH=$JAVA_HOME/bin:$PATH
+
 cd ${TS_HOME}/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
-export PATH=$JAVA_HOME/bin:$PATH
 
 which java
 java -version

--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# Copyright (c) 2022 Contributors to the Eclipse Foundation
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
-# Copyright (c) 2019, 2022 Payara Foundation and/or its affiliates. All rights reserved.
+# Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2019, 2023 Payara Foundation and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -51,9 +51,17 @@ if [ -z "${GF_VI_TOPLEVEL_DIR}" ]; then
     export GF_VI_TOPLEVEL_DIR=glassfish7
 fi
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
+
+if [[ "$JDK" == "JDK19" || "$JDK" == "jdk19" ]];then
+  wget -q https://download.java.net/java/GA/jdk19.0.2/fdb695a9d9064ad6b064dc6df578380c/7/GPL/openjdk-19.0.2_linux-x64_bin.tar.gz -O jdk-19.tar.gz
+  tar -xvf jdk-19.tar.gz
+  export JAVA_HOME=$PWD/jdk-19.0.2
+elif [[ "$JDK" == "JDK20" || "$JDK" == "jdk20" ]];then
+  export JAVA_HOME=${JDK20_HOME}
+elif [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  export JAVA_HOME=${JDK21_HOME}
 fi
+
 export PATH=$JAVA_HOME/bin:$PATH
 
 export ANT_OPTS="-Xmx2G \
@@ -279,13 +287,13 @@ if [[ $test_suite == ejb30/lite* ]] || [[ "ejb30" == $test_suite ]] ; then
 fi
 
 # do ts.jte parameter substitution here of ${JVMOPTS_RUNTESTCOMMAND}
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  echo "update ts.jte for GlassFish to use --add-opens options for Java SE 17"
-  search="..JVMOPTS_RUNTESTCOMMAND."
-  replace="--add-opens=java.base\\/java.io=ALL-UNNAMED --add-opens=java.base\\/java.lang=ALL-UNNAMED --add-opens=java.base\\/java.util=ALL-UNNAMED --add-opens=java.base\\/sun.net.www.protocol.jrt=ALL-UNNAMED --add-opens=java.naming\\/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi\\/sun.rmi.transport=ALL-UNNAMED --add-opens=jdk.management\\/com.sun.management.internal=ALL-UNNAMED --add-exports=java.naming\\/com.sun.jndi.ldap=ALL-UNNAMED"
-  sed -i.bak "s/$search/$replace/" ${TS_HOME}/bin/ts.jte
-  echo "updated ts.jte to use -add-opens for Java SE 17 "
-fi
+#if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
+echo "update ts.jte for GlassFish to use --add-opens options for Java SE 17"
+search="..JVMOPTS_RUNTESTCOMMAND."
+replace="--add-opens=java.base\\/java.io=ALL-UNNAMED --add-opens=java.base\\/java.lang=ALL-UNNAMED --add-opens=java.base\\/java.util=ALL-UNNAMED --add-opens=java.base\\/sun.net.www.protocol.jrt=ALL-UNNAMED --add-opens=java.naming\\/javax.naming.spi=ALL-UNNAMED --add-opens=java.rmi\\/sun.rmi.transport=ALL-UNNAMED --add-opens=jdk.management\\/com.sun.management.internal=ALL-UNNAMED --add-exports=java.naming\\/com.sun.jndi.ldap=ALL-UNNAMED"
+sed -i.bak "s/$search/$replace/" ${TS_HOME}/bin/ts.jte
+echo "updated ts.jte to use -add-opens for Java SE "
+#fi
 
 echo "Configuring VI domain at ${CTS_HOME}/ri/${GF_VI_TOPLEVEL_DIR}/glassfish/domains/domain1"
 if [ -n "$GF_LOGGING_CFG_VI" ]; then

--- a/docker/saajtck.sh
+++ b/docker/saajtck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -54,12 +54,19 @@ echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
 
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
+export PATH=$JAVA_HOME/bin:$PATH
+
+
 cd $TS_HOME/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
-export PATH=$JAVA_HOME/bin:$PATH
 
 which java
 java -version

--- a/docker/securityapitck.sh
+++ b/docker/securityapitck.sh
@@ -59,12 +59,18 @@ rm -f $TS_HOME/lib/js-1.6R1.jar
 rm -f $TS_HOME/lib/jax-qname.jar
 
 chmod -R 777 $TS_HOME
-cd $TS_HOME/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
 export PATH=$JAVA_HOME/bin:$PATH
+
+cd $TS_HOME/bin
 
 which java
 java -version

--- a/docker/servlettck.sh
+++ b/docker/servlettck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -xe
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,12 +53,19 @@ echo "TS_HOME $TS_HOME"
 
 
 chmod -R 777 $TS_HOME
-cd $TS_HOME/bin
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
+cd $WORKSPACE
+
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
 export PATH=$JAVA_HOME/bin:$PATH
+
+
+cd $TS_HOME/bin
 
 
 which java

--- a/docker/websockettck.sh
+++ b/docker/websockettck.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -x
 
-# Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2018, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -53,12 +53,18 @@ echo "TS_HOME $TS_HOME"
 
 chmod -R 777 $TS_HOME
 
-cd $TS_HOME/bin
+cd $WORKSPACE
 
-if [[ "$JDK" == "JDK17" || "$JDK" == "jdk17" ]];then
-  export JAVA_HOME=${JDK17_HOME}
-fi
+if [[ "$JDK" == "JDK21" || "$JDK" == "jdk21" ]];then
+  wget https://download.java.net/java/early_access/jdk21/15/GPL/openjdk-21-ea+15_linux-x64_bin.tar.gz -O jdk-21.tar.gz
+  tar -xvf jdk-21.tar.gz
+  export JAVA_HOME=$WORKSPACE/jdk-21
+fi  
+
 export PATH=$JAVA_HOME/bin:$PATH
+
+
+cd $TS_HOME/bin
 
 
 which java

--- a/install/caj/bin/ts.jte
+++ b/install/caj/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -170,7 +170,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
 		SYSTEMROOT=${SYSTEMROOT} \
         ${JAVA_HOME}/bin/java \
 		-Djava.security.policy="${bin.dir}/harness.policy" \
-		-Djava.security.manager \
+		-DnoSecurityManager=true \
 		-Ddeliverable.class=${deliverable.class} \
         $testExecuteClass $testExecuteArgs
 

--- a/install/connector/bin/ts.jte
+++ b/install/connector/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -154,7 +154,7 @@ ri.asenv.loc=${connector.home}/config
 ri.imqbin.loc=${connector.home}/imq/bin
 ri.lib=${connector.home}/modules
 ri.imq.share.lib=${connector.home}/imq/lib
-ri.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}
+ri.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-DnoSecurityManager=true
 ri.java.endorsed.dirs=${endorsed.dirs}
 ri.applicationRoot=c:
 
@@ -171,7 +171,7 @@ s1as.domain=${s1as.domain.dir}/${s1as.domain.name}
 s1as.asenv.loc=${connector.home}/config
 s1as.imqbin.loc=${connector.home}/imq/bin
 s1as.imq.share.lib=${connector.home}/imq/lib
-s1as.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}
+s1as.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-DnoSecurityManager=true
 s1as.java.endorsed.dirs=${endorsed.dirs}
 s1as.applicationRoot=c:
 
@@ -327,6 +327,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
         -Dcom.sun.aas.configRoot=${connector.home}/config \
         -Djava.util.logging.config.file=${TS_HOME}/bin/client-logging.properties \
         -Dlogical.hostname.servlet=${logical.hostname.servlet} \
+        -DnoSecurityManager=true \
         -Ddeliverable.class=${deliverable.class} $testExecuteClass $testExecuteArgs
 
 

--- a/install/el/bin/ts.jte
+++ b/install/el/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2022 Oracle and/or its affiliates and others.
+# Copyright (c) 2013, 2023 Oracle and/or its affiliates and others.
 # All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -122,7 +122,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
                     windir=${windir} \
                     SYSTEMROOT=${SYSTEMROOT} \
                     ${JAVA_HOME}/bin/java \
-                    ${JAVA_OPTIONS} $testExecuteClass $testExecuteArgs
+                    ${JAVA_OPTIONS} -DnoSecurityManager=true $testExecuteClass $testExecuteArgs
 
 
 ########################################################

--- a/install/jacc/bin/ts.jte
+++ b/install/jacc/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -309,6 +309,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
         -Djava.protocol.handler.pkgs=javax.net.ssl \
         -Djavax.net.ssl.keyStore=${bin.dir}/certificates/clientcert.jks \
         -Djavax.net.ssl.keyStorePassword=changeit \
+        -DnoSecurityManager=true \
         -Djavax.net.ssl.trustStore=${jacc.home}/domains/domain1/config/cacerts.jks \
         -Ddeliverable.class=${deliverable.class} $testExecuteClass $testExecuteArgs
 

--- a/install/jakartaee/bin/ts.jte
+++ b/install/jakartaee/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2006, 2022 Oracle and/or its affiliates and others.
+# Copyright (c) 2006, 2023 Oracle and/or its affiliates and others.
 # All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -408,7 +408,7 @@ s1as.imqbin.loc=${javaee.home}/../mq/bin
 s1as.lib=${javaee.home}/lib
 s1as.modules=${javaee.home}/modules
 s1as.imq.share.lib=${javaee.home}/../mq/lib
-s1as.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Xmx4096m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}
+s1as.jvm.options=-Doracle.jdbc.J2EE13Compliant=true:-Xmx4096m:-Dj2eelogin.name=${user}:-Dj2eelogin.password=${password}:-Deislogin.name=${user1}:-Deislogin.password=${password1}:-Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds}:-DwebServerPort.2=${webServerPort.2}:-DwebServerHost.2=${webServerHost.2}:-DnoSecurityManager=true
 s1as.jvm.options.remove=-Xmx512m:${s1as.jvm.options}
 s1as.java.endorsed.dirs=${endorsed.dirs}
 s1as.applicationRoot=c:
@@ -1146,8 +1146,9 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
         -Dprovider.configuration.file=${provider.configuration.file} \
         -Djava.security.properties=${s1as.domain}/${sjsas.instance.config.dir}/ts.java.security \
         -Dlogical.hostname.servlet=${logical.hostname.servlet} \
+        -DnoSecurityManager=true \
         -Dcom.sun.aas.configRoot=${javaee.home}/config \
-        -Ddeliverable.class=${deliverable.class} $testExecuteClass $testExecuteArgs
+        -Ddeliverable.class=${deliverable.class} -DnoSecurityManager=true $testExecuteClass $testExecuteArgs
 
 ########################################################################
 ## Appclient Command line for the App Server under test
@@ -1200,6 +1201,7 @@ command.testExecuteAppClient= \
         -Dprovider.configuration.file=${provider.configuration.file} \
         -Djava.security.properties=${s1as.domain}/${sjsas.instance.config.dir}/ts.java.security \
         -Dcom.sun.aas.configRoot=${javaee.home}/config \
+        -DnoSecurityManager=true \
         -Ddeliverable.class=${deliverable.class} -javaagent:${javaee.home}/lib/gf-client.jar=arg=-configxml,arg=${ts.home}/tmp/appclient/s1as.sun-acc.xml,client=jar=$testExecuteArgs
 
 #-Ddeliverable.class=${deliverable.class} -javaagent:${javaee.home}/modules/gf-client.jar=arg=-configxml,arg=${s1as.domain}/config/sun-acc.xml,client=jar=$testExecuteArgs
@@ -1244,8 +1246,10 @@ command.testExecuteEjbEmbed=com.sun.ts.lib.harness.ExecTSTestCmd \
         SYSTEMROOT=${SYSTEMROOT} \
         ${JAVA_HOME}/bin/java \
         ${JVMOPTS_RUNTESTCOMMAND} \
+        -DnoSecurityManager=true \
         -Dcts.tmp=$harness.temp.directory \
         -Djava.util.logging.config.file=${TS_HOME}/bin/client-logging.properties \
+        -DnoSecurityManager=true \
         -Dtest.ejb.stateful.timeout.wait.seconds=${test.ejb.stateful.timeout.wait.seconds} \
         -Ddeliverable.class=${deliverable.class} $testExecuteClass $testExecuteArgs
 
@@ -1289,6 +1293,7 @@ command.testExecuteAppClient2= \
         -DwebServerHost.2=${webServerHost.2} \
         -DwebServerPort.2=${webServerPort.2} \
         -Dprovider.configuration.file=${provider.configuration.file} \
+        -DnoSecurityManager=true \
         -Djava.security.properties=${s1as.domain}/${sjsas.instance.config.dir}/ts.java.security \
         -Dcom.sun.aas.configRoot=${javaee.home.ri}/config \
         -Ddeliverable.class=${deliverable.class} -javaagent:${javaee.home.ri}/lib/gf-client.jar=arg=-configxml,arg=${ts.home}/tmp/appclient/ri.sun-acc.xml,client=jar=$testExecuteArgs
@@ -1329,6 +1334,7 @@ command.testExecute2=com.sun.ts.lib.harness.ExecTSTestCmd \
         ${RI_JAVA_HOME}/bin/java \
         ${JVMOPTS_RUNTESTCOMMAND} \
         -Dcts.tmp=$harness.temp.directory \
+        -DnoSecurityManager=true \
         -Djava.protocol.handler.pkgs=javax.net.ssl \
         -Djavax.net.ssl.keyStore=${bin.dir}/certificates/clientcert.jks \
         -Djavax.net.ssl.keyStorePassword=changeit \

--- a/install/jaxws/bin/ts.jte
+++ b/install/jaxws/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2022 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -358,7 +358,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
 		SYSTEMROOT=${SYSTEMROOT} \
         ${JAVA_HOME}/bin/java \
 		-Djava.security.policy="${bin.dir}/harness.policy" \
-		-Djava.security.manager \
+		-DnoSecurityManager=true \
 		-Ddeliverable.class=${deliverable.class} \
     	-Djava.io.tmpdir=${harness.temp.directory} \
         $testExecuteClass $testExecuteArgs
@@ -372,7 +372,7 @@ command.testExecute2=com.sun.ts.lib.harness.ExecTSTestCmd \
 		SYSTEMROOT=${SYSTEMROOT} \
         ${JAVA_HOME}/bin/java \
 		-Djava.security.policy="${bin.dir}/harness.policy" \
-		-Djava.security.manager \
+		-DnoSecurityManager=true \
 		-Ddeliverable.class=${deliverable.class} \
         $testExecuteClass $testExecuteArgs
 

--- a/install/jms/bin/ts.jte
+++ b/install/jms/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2009, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -177,7 +177,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
 		SYSTEMROOT=${SYSTEMROOT} \
         ${JAVA_HOME}/bin/java \
 		-Djava.security.policy="${bin.dir}/harness.policy" \
-		-Djava.security.manager \
+		-DnoSecurityManager=true \
 		-Ddeliverable.class=${deliverable.class} \
         $testExecuteClass $testExecuteArgs
 

--- a/install/jpa/bin/ts.jte
+++ b/install/jpa/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -234,6 +234,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
         -Dcts.tmp=$harness.temp.directory \
         -Dlog.file.location=$log.file.location \
         -Djava.security.policy=${bin.dir}/harness.policy \
+        -DnoSecurityManager=true \
         -Ddeliverable.class=${deliverable.class} $testExecuteClass $testExecuteArgs
 
 #########################################################################

--- a/install/jsp/bin/ts.jte
+++ b/install/jsp/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2012, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2012, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -154,7 +154,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
                     windir=${windir} \
                     SYSTEMROOT=${SYSTEMROOT} \
                     ${JAVA_HOME}/bin/java \
-                    ${JAVA_OPTIONS} $testExecuteClass $testExecuteArgs
+                    ${JAVA_OPTIONS} -DnoSecurityManager=true $testExecuteClass $testExecuteArgs
  
 ########################################################################
 # Environment ts_unix                                              

--- a/install/jstl/bin/ts.jte
+++ b/install/jstl/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -201,7 +201,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
                     windir=${windir} \
                     SYSTEMROOT=${SYSTEMROOT} \
                     ${JAVA_HOME}/bin/java \
-                    ${JAVA_OPTIONS} $testExecuteClass $testExecuteArgs
+                    ${JAVA_OPTIONS} -DnoSecurityManager=true $testExecuteClass $testExecuteArgs
 
 ########################################################
 # Environment ts_unix

--- a/install/jta/bin/ts.jte
+++ b/install/jta/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2008, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2008, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -156,7 +156,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
                     windir=${windir} \
                     SYSTEMROOT=${SYSTEMROOT} \
                     ${JAVA_HOME}/bin/java \
-                    ${JAVA_OPTIONS} $testExecuteClass $testExecuteArgs
+                    ${JAVA_OPTIONS} -DnoSecurityManager=true $testExecuteClass $testExecuteArgs
 
 ########################################################################
 # Environment ts_unix                                              

--- a/install/saaj/bin/ts.jte
+++ b/install/saaj/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2006, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2006, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -241,6 +241,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
         -Djava.security.policy="${bin.dir}/harness.policy" \
         -Djava.security.manager \
         -Ddeliverable.class=${deliverable.class} \
+        -DnoSecurityManager=true \
             $testExecuteClass $testExecuteArgs
 
 #########################################################################

--- a/install/servlet/bin/ts.jte
+++ b/install/servlet/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2009, 2022 Oracle and/or its affiliates and others.
+# Copyright (c) 2009, 2023 Oracle and/or its affiliates and others.
 # All rights reserved.
 #
 # This program and the accompanying materials are made available under the
@@ -175,6 +175,7 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
                     -Djavax.net.ssl.keyStore=${ts.home}/bin/certificates/clientcert.jks \
                     -Djavax.net.ssl.keyStorePassword=changeit \
                     -Djavax.net.ssl.trustStore=${web.home}/domains/domain1/config/cacerts.jks \
+                    -DnoSecurityManager=true \
                     ${JAVA_OPTIONS} $testExecuteClass $testExecuteArgs
 
 ########################################################################

--- a/install/websocket/bin/ts.jte
+++ b/install/websocket/bin/ts.jte
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2013, 2021 Oracle and/or its affiliates. All rights reserved.
+# Copyright (c) 2013, 2023 Oracle and/or its affiliates. All rights reserved.
 #
 # This program and the accompanying materials are made available under the
 # terms of the Eclipse Public License v. 2.0, which is available at
@@ -101,7 +101,8 @@ command.testExecute=com.sun.ts.lib.harness.ExecTSTestCmd \
                     -Djavax.net.ssl.keyStorePassword=changeit \
                     -Djavax.net.ssl.keyStore=${bin.dir}/certificates/clientcert.jks \
                     -Djavax.net.ssl.trustStore=${web.home}/domains/domain1/config/cacerts.jks \
-                    ${JAVA_OPTIONS} $testExecuteClass $testExecuteArgs
+                    -DnoSecurityManager=true \
+                    ${JAVA_OPTIONS} -DnoSecurityManager=true $testExecuteClass $testExecuteArgs
 
 ########################################################################
 # Environment ts_unix                                              


### PR DESCRIPTION
PR supports Platform TCK and Standalone TCK[ Annotations, EL, JAXWS, JMS, JPA, JSP, JSTL, JTA,SAAJ, SERVLET and WEBSOCKET] built with JDK 21- build 15. 
Also TCK  runs with JDK 21(build 15) and Security manager disabled.
The javatest jar has been built from latest source at  https://github.com/openjdk/jtharness.git

Standalone TCK CI run: https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-build-run/job/security-manager/12/#showFailuresLink
Platform TCK CI run: https://ci.eclipse.org/jakartaee-tck/job/guru/job/jakartaee-tck-build-run/job/security-manager/14/