### PR TITLE
Update README.md with prebuild section for lib/javatest.jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
 # Platform TCK refactoring
 
+## One Time JavaTest Jar Install
+The JavaTest jar with GAV coords javatest:javatest:5.0 does not exist in Maven Central,
+so one needs to install the repo lib/javatest.jar into the local maven repo
+in order to build this repo with Maven. To do this, execute:
+```
+mvn install:install-file -Dfile=lib/javatest.jar -DgroupId=javatest -DartifactId=javatest -Dversion=5.0 -Dpackaging=jar
+```
+
 ## Build
+
 From the root folder, try:
 ```
 mvn clean install -Dmaven.compiler.failOnError=false > /tmp/build.txt


### PR DESCRIPTION
Add a pre-build section on installing the lib/javatest.jar into the local repo since the javatest:javatest:5.0 artifact does not exist in maven centrl.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
