### PR TITLE
ClassLoader issue in embedded Arquillian

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ target/
 .project
 /glassfish-runner/batch-tck/apitests/test.properties
 .classpath
+.factorypath
 .settings/
 classes/
 dist/

--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
@@ -38,8 +38,9 @@ public class KeysProducer {
     @PostConstruct
     private void loadKeys() {
         try {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             byte[] pubKeyData;
-            try (InputStream keyIS = getClass().getResourceAsStream("/key.pub")) {
+            try (InputStream keyIS = classLoader.getResourceAsStream("/key.pub")) {
                 if (keyIS == null) {
                     throw new IllegalStateException("Failed to find /key.pub");
                 }


### PR DESCRIPTION
**Fixes Issue**
https://github.com/helidon-io/helidon/issues/6884

**Related Issue(s)**
https://github.com/helidon-io/helidon/issues/6884

**Describe the change**
Using embedded Arquillian, there is only one JVM, so next line will not get the resource from the web application, it will get the test execution classpath (the file will not be found):
`getClass().getResourceAsStream("/key.pub")
`
This suggested fix is more flexible, because the web container is able to set its own class loader.

**Additional context**
I faced this issue integrating this in Helidon.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
