### PR TITLE
Setting correct folder for beans.xml

### DIFF
--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/json/ApplicationJsonpIT.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/json/ApplicationJsonpIT.java
@@ -50,7 +50,7 @@ public class ApplicationJsonpIT {
                 .addClass(JsonProviderProducer.class)
                 .addClass(Utils.class)
                 .addAsServiceProvider(JsonProvider.class, CustomJsonProvider.class)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "classes/META-INF/beans.xml");
         System.out.printf("test archive: %s\n", archive.toString(true));
         archive.as(ZipExporter.class).exportTo(new File("/tmp/" + archive.getName()), true);
         return archive;

--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/jsonb/JsonbApplicationIT.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/jsonb/JsonbApplicationIT.java
@@ -51,7 +51,7 @@ public class JsonbApplicationIT {
                 .addClass(JsonbProviderProducer.class)
                 .addClass(Utils.class)
                 .addAsServiceProvider(JsonbProvider.class, CustomJsonbProvider.class)
-                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "classes/META-INF/beans.xml");
         System.out.printf("test archive: %s\n", archive.toString(true));
         archive.as(ZipExporter.class).exportTo(new File("/tmp/" + archive.getName()), true);
         return archive;


### PR DESCRIPTION
**Fixes Issue**
https://github.com/helidon-io/helidon/issues/6799

**Related Issue(s)**
https://github.com/helidon-io/helidon/issues/6799

**Describe the change**
There are a couple of tests here that creates the beans.xml in `WEB-INF`. Correct me if I am wrong, but I think the correct folder is `WEB-INF/classes/META-INF`.

**Additional context**
This makes some issues in Helidon Arquillian container because when it does not find a beans.xml it will create a default one. I can fix it in Helidon if this PR does not make sense.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
