### PR TITLE
 ClassLoader issue in embedded Arquillian (additional null check)

### DIFF
--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
@@ -29,6 +29,7 @@ import java.util.Base64;
 @ApplicationScoped
 public class KeysProducer {
 
+    private static final String PUB_KEY = "/key.pub";
     private PublicKey publicKey;
 
     /**
@@ -40,7 +41,8 @@ public class KeysProducer {
         try {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             byte[] pubKeyData;
-            try (InputStream keyIS = classLoader.getResourceAsStream("/key.pub")) {
+            try (InputStream keyIS = classLoader != null ?
+                    classLoader.getResourceAsStream(PUB_KEY) : getClass().getResourceAsStream(PUB_KEY)) {
                 if (keyIS == null) {
                     throw new IllegalStateException("Failed to find /key.pub");
                 }


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/1187#issuecomment-1655868687

**Describe the change**
In case `ClassLoader classLoader = Thread.currentThread().getContextClassLoader();` returns null, it will use the previous approach.

**Additional context**
This is because of one comment of @scottmarlow 

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
