### PR TITLE
Integrate issue 1187 to branch 10.0.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ target/
 .project
 /glassfish-runner/batch-tck/apitests/test.properties
 .classpath
+.factorypath
 .settings/
 classes/
 dist/

--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
@@ -38,8 +38,9 @@ public class KeysProducer {
     @PostConstruct
     private void loadKeys() {
         try {
+            ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             byte[] pubKeyData;
-            try (InputStream keyIS = getClass().getResourceAsStream("/key.pub")) {
+            try (InputStream keyIS = classLoader.getResourceAsStream("/key.pub")) {
                 if (keyIS == null) {
                     throw new IllegalStateException("Failed to find /key.pub");
                 }

--- a/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
+++ b/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/rest/jsonb/cdi/KeysProducer.java
@@ -29,6 +29,7 @@ import java.util.Base64;
 @ApplicationScoped
 public class KeysProducer {
 
+    private static final String PUB_KEY = "/key.pub";
     private PublicKey publicKey;
 
     /**
@@ -40,7 +41,8 @@ public class KeysProducer {
         try {
             ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
             byte[] pubKeyData;
-            try (InputStream keyIS = classLoader.getResourceAsStream("/key.pub")) {
+            try (InputStream keyIS = classLoader != null ?
+                    classLoader.getResourceAsStream(PUB_KEY) : getClass().getResourceAsStream(PUB_KEY)) {
                 if (keyIS == null) {
                     throw new IllegalStateException("Failed to find /key.pub");
                 }


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/1187

**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1187

**Describe the change**
This issue happens when you run Arquillian tests within the same JVM.

getClass().getResourceAsSream() will look for resources in the maven configured path: /target/classes and /target/test-classes. The resource /key.pub will not be there, because it exists in the web application classpath, making the test to fail.

It is possible to handle this scenario obtaining the class loader in this way, because the Arquillian extension can set a different class loader:
ClassLoader classLoader = Thread.currentThread().getContextClassLoader();

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
