### PR TITLE
remove left over test code which can break when using an empty maven repository

### DIFF
--- a/servlet/src/main/java/com/sun/ts/tests/servlet/common/servlets/CommonServlets.java
+++ b/servlet/src/main/java/com/sun/ts/tests/servlet/common/servlets/CommonServlets.java
@@ -10,13 +10,8 @@ import com.sun.ts.tests.servlet.common.util.ServletTestUtil;
 import com.sun.ts.tests.servlet.common.util.StaticLog;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
-
-import java.io.File;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 public class CommonServlets {
 
@@ -26,17 +21,6 @@ public class CommonServlets {
 
     private CommonServlets() {
         List<JavaArchive> archives = new ArrayList<>();
-
-        File[] files = Maven.configureResolver().workOffline().loadPomFromFile("pom.xml")
-                .resolve("org.slf4j:slf4j-simple")
-                .withTransitivity()
-                .asFile();
-        List<JavaArchive> slf4jJars =
-                Arrays.stream(files).map(file -> ShrinkWrap.createFromZipFile(JavaArchive.class, file))
-                        .collect(Collectors.toList());
-
-        //archives.addAll(slf4jJars);
-
         archives.add(ShrinkWrap.create(JavaArchive.class, "common-servlets.jar")
                 .addClasses(GenericCheckTestResultServlet.class, GenericTCKServlet.class, RequestTestServlet.class,
                         HttpCheckTestResultServlet.class, HttpRequestTestServlet.class, RequestTests.class,


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

**Fixes Issue**
Specify the issue (link) that is solved with this pull request.

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
A clear and concise description of the change.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
