### PR TITLE
[763] Add missing exclusions from the CDI TCK's tck-tests.xml to the …

### DIFF
--- a/core-profile-tck/cdi-tck-suite/src/main/resources/cdi-lite-tck-suite.xml
+++ b/core-profile-tck/cdi-tck-suite/src/main/resources/cdi-lite-tck-suite.xml
@@ -34,5 +34,25 @@
             <package name="org.jboss.cdi.tck.tests.*" />
             <package name="org.jboss.cdi.tck.interceptors.tests.*" />
         </packages>
+        <classes>
+            <!-- https://github.com/jakartaee/cdi-tck/issues/453 -->
+            <class name="org.jboss.cdi.tck.tests.implementation.simple.lifecycle.SimpleBeanLifecycleTest">
+                <methods>
+                    <exclude name="testCreateReturnsSameBeanPushed"/>
+                </methods>
+            </class>
+            <class name="org.jboss.cdi.tck.tests.context.DestroyForSameCreationalContextTest">
+                <methods>
+                    <exclude name="testDestroyForSameCreationalContextOnly"/>
+                </methods>
+            </class>
+
+            <!-- https://github.com/jakartaee/cdi-tck/issues/485 -->
+            <class name="org.jboss.cdi.tck.tests.definition.bean.types.ManagedBeanTypesTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+        </classes>
     </test>
 </suite>


### PR DESCRIPTION
…Jakarta EE Core Profiles cdi-lite-tck-suite.xml.

**Fixes Issue**
Resolves #1196 

**Describe the change**
These exclusions are in the CDI TCK, however they were not migrated to the CDI Lite TCK exclusions.

**Additional context**
This fix will allow the Jakarta EE Core Profile to pass, assuming the container passes :), with Java 21.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow

CC @manovotn @Ladicek