### PR TITLE
Exclude challenged servlet tests in Platform TCK 8.0.2

### DIFF
--- a/install/jakartaee/bin/ts.jtx
+++ b/install/jakartaee/bin/ts.jtx
@@ -25,6 +25,9 @@
 #
 com/sun/ts/tests/servlet/api/javax_servlet_http/httpupgradehandler/URLClient.java#upgradeTest
 
+#TCK Challenge : https://github.com/jakartaee/platform-tck/issues/1176
+com/sun/ts/tests/servlet/ee/spec/security/runAs/Client.java#web_to_ejb_dd_runAs
+com/sun/ts/tests/servlet/ee/spec/security/runAs/Client.java#web_to_ejb_annotation_runAs
 
 ################
 # JSF


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/1176

**Describe the change**
Added the 2 servlet tests challenged to exclude list install/jakartaee/bin/ts.jtx
