### PR TITLE
issues/1192 TCK challenge for adding support for running signature TCK tests on Java 21

### DIFF
--- a/src/com/sun/ts/tests/signaturetest/SigTestDriver.java
+++ b/src/com/sun/ts/tests/signaturetest/SigTestDriver.java
@@ -61,7 +61,7 @@ public class SigTestDriver extends SignatureTestDriver {
   
   private static final String EXCLUDE_JDK_CLASS_FLAG = "-IgnoreJDKClass";
 
-  private static String[] excludeJdkClasses = {
+  private static final String[] excludeJdkClasses = {
           "java.util.Map",
           "java.lang.Object",
           "java.io.ByteArrayInputStream",
@@ -71,8 +71,15 @@ public class SigTestDriver extends SignatureTestDriver {
           "java.io.OutputStream",
           "java.util.List",
           "java.util.Collection",
+          "java.util.concurrent.ExecutorService",
+          "java.util.concurrent.Future",
+          "java.util.HashSet",
+          "java.util.LinkedHashSet",
+          "java.util.SequencedCollection",
+          "java.util.SequencedSet",
           "java.lang.instrument.IllegalClassFormatException",
           "javax.transaction.xa.XAException",
+          "java.lang.AutoCloseable",
           "java.lang.annotation.Repeatable",
           "java.lang.InterruptedException",
           "java.lang.CloneNotSupportedException",


### PR DESCRIPTION
**Fixes Issue**
[platform-tck/issues/1192](https://github.com/jakartaee/platform-tck/issues/1192)

**Related Issue(s)**
https://github.com/jakartaee/security/issues/297
https://github.com/jakartaee/jaxb-tck/pull/81
https://issues.redhat.com/browse/WFLY-18816

**Describe the change**
Update the list of excluded JDK classes in SigTestDriver.java to skip validation of JDK (21) classes that have been modified.  This TCK challenge is in making further changes in support of what we previously addressed for https://github.com/jakartaee/platform-tck/issues/156

**Additional context**
In the near future, we should update the Signature test tooling to only validate classes in the `jakarta` namespace which JDK classes are not be expected to implement since only Jakarta EE SPEC APIs can use that package.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
