### PR TITLE
release (Jakarta EE 10) 10.0.3 Platform TCK to address signature test failures when running on Java 21

### DIFF
--- a/release/tools/jakartaee.xml
+++ b/release/tools/jakartaee.xml
@@ -30,7 +30,7 @@
     <property name="sjsas.internal.compat"         value="NULL"/>
     <property name="cts.internal.comment"          value=""/>
     <property name="deliverable.version"           value="10.0"/>
-    <property name="deliverable.tck.version"           value="10.0.2"/>
+    <property name="deliverable.tck.version"           value="10.0.3"/>
 
 	<property name="the.excludes" value="**/internal/**/*,
 	     **/jaxm/**/*, **/jaxm1.0.1/**/*,


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/1192

**Describe the change**
Release 10.0.3 Platform TCK to address Signature test failures on Java 21
