### PR TITLE
EL TCK : Copy PR 1159 to refactor branch and remove deprecated method 

### DIFF
--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/staticfieldelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/staticfieldelresolver/ELClientIT.java
@@ -73,7 +73,7 @@ public class ELClientIT {
    * 
    * @test_Strategy: Verify the following method calls work as expected:
    *                 getValue() getType() setValue() isReadOnly()
-   *                 getCommonPropertyType() getFeatureDescriptors()
+   *                 getCommonPropertyType() 
    */
   @Test
   public void staticFieldELResolverTest() throws Exception {
@@ -163,13 +163,13 @@ public class ELClientIT {
     buf.append("getCommonPropertyType() returns " + commonPropertyType.getName()
         + TestUtil.NEW_LINE);
 
-    // getFeatureDescriptors()
-    context.setPropertyResolved(false);
-    Iterator<?> i = resolver.getFeatureDescriptors(context, base);
+    // getFeatureDescriptors() commenting below as the method is deprecated in EL 6.0
+    // context.setPropertyResolved(false);
+    // Iterator<?> i = resolver.getFeatureDescriptors(context, base);
 
-    if (i == null) {
-      buf.append("getFeatureDescriptors() returns null" + TestUtil.NEW_LINE);
-    }
+    // if (i == null) {
+    //   buf.append("getFeatureDescriptors() returns null" + TestUtil.NEW_LINE);
+    // }
 
     if (!pass) {
       throw new Exception(ELTestUtil.FAIL + TestUtil.NEW_LINE + buf.toString());

--- a/el/src/main/java/com/sun/ts/tests/el/spec/coercion/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/spec/coercion/ELClientIT.java
@@ -1784,7 +1784,7 @@ public class ELClientIT {
   public void elCoerceLambdaExpressionToFunctionalInterfaceTest() throws Exception {
 
     boolean fail = false;
-    boolean[] pass = { false, false, false, false, false };
+    boolean[] pass = { false, false, false, false, false, false };
     Object result = null;
 
     try {
@@ -1792,40 +1792,49 @@ public class ELClientIT {
       ELProcessor elp0 = new ELProcessor();
       elp0.defineFunction("", "", "com.sun.ts.tests.el.spec.coercion.ELClientIT", "testPredicateString");
       result = elp0.eval("testPredicateString(x -> x.equals('data'))");
-      pass[0] = ExprEval.compareClass(result, String.class)
-          && ExprEval.compareValue(result, "PASS");
+      pass[0] = ExprEval.compareClass(result, String.class) && ExprEval.compareValue(result, "PASS");
       
       // Coercible lambda expression where filter does not match
       ELProcessor elp1 = new ELProcessor();
       elp1.defineFunction("", "", "com.sun.ts.tests.el.spec.coercion.ELClientIT", "testPredicateString");
       result = elp1.eval("testPredicateString(x -> x.equals('other'))");
-      pass[1] = ExprEval.compareClass(result, String.class)
-          && ExprEval.compareValue(result, "BLOCK");
+      pass[1] = ExprEval.compareClass(result, String.class) && ExprEval.compareValue(result, "BLOCK");
 
       // Not a lambda expression
       ELProcessor elp2 = new ELProcessor();
       elp2.defineFunction("", "", "com.sun.ts.tests.el.spec.coercion.ELClientIT", "testPredicateString");
       try {
-        result = elp2.eval("testPredicateString('notLambdaExpression)");
+        result = elp2.eval("testPredicateString('notLambdaExpression')");
       } catch (ELException e) {
         pass[2] = true;
       }
 
+      /*
+       * Note: The following tests use compareTo(). When the target object (Long or String) is examined by reflection
+       * both compareTo(Object) and compareTo(Long)/compareTo(String) methods will be found as potential matches. The
+       * method matching rules (see section 1.2.1.2 of the specification) require that overload resolution has a higher
+       * precedence than coercion resolution so it is always the compareTo(Object) method that will be used for the
+       * followingtests.
+       */
+
       // Coercible lambda expression with wrong type
-      ELProcessor elp3 = new ELProcessor();
-      elp3.defineFunction("", "", "com.sun.ts.tests.el.spec.coercion.ELClientIT", "testPredicateString");
-      try {
-        result = elp3.eval("testPredicateLong(x -> x.equals('data'))");
-      } catch (ELException e) {
-        pass[3] = true;
-      }
-      
+      ELProcessor elp3 = new ELProcessor();      
+      elp3.defineFunction("", "", "com.sun.ts.tests.el.spec.coercion.ELClientIT", "testPredicateLong");
+      result = elp3.eval("testPredicateLong(x -> x.compareTo('data') == 0)");
+      pass[3] = ExprEval.compareClass(result, String.class) && ExprEval.compareValue(result, "BLOCK");
+
       // Coercible lambda expression where filter does not match and parameter needs to be coerced
       ELProcessor elp4 = new ELProcessor();
       elp4.defineFunction("", "", "com.sun.ts.tests.el.spec.coercion.ELClientIT", "testPredicateString");
-      result = elp4.eval("testPredicateString(x -> x.equals(1234))");
-      pass[4] = ExprEval.compareClass(result, String.class)
-          && ExprEval.compareValue(result, "BLOCK");
+      result = elp4.eval("testPredicateString(x -> x.compareTo(1234) == 0)");
+      pass[4] = ExprEval.compareClass(result, String.class) && ExprEval.compareValue(result, "BLOCK");
+
+      // Coercible lambda expression with coercible type but coercion rules mean this test fails
+      ELProcessor elp5 = new ELProcessor();
+      elp5.defineFunction("", "", "com.sun.ts.tests.el.spec.coercion.ELClientIT", "testPredicateLong");
+      result = elp5.eval("testPredicateLong(x -> x.compareTo('1234') == 0)");
+      pass[5] = ExprEval.compareClass(result, String.class) && ExprEval.compareValue(result, "BLOCK");
+
 
     } catch (Exception e) {
       logger.log(Logger.Level.ERROR, "Testing coercion of lambda expressions to functional interfaces " +


### PR DESCRIPTION
Describe the change:

- Copying the changes in PR https://github.com/jakartaee/platform-tck/pull/1159 to tckrefactor branch also.
- Removed the deprecated method getFeatureDescriptors() from the test.


