### PR TITLE
EL TCK signature test , version and documentation update

### DIFF
--- a/el/docs/userguide/pom.xml
+++ b/el/docs/userguide/pom.xml
@@ -28,8 +28,8 @@
     <groupId>org.glassfish</groupId>
     <artifactId>tck_el</artifactId>
     <packaging>pom</packaging>
-    <version>5.0.0</version>
-    <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Expression Language for Jakarta EE, Release 5.0</name>
+    <version>6.0.0</version>
+    <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Expression Language for Jakarta EE, Release 6.0</name>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -37,9 +37,9 @@
         <maven.site.skip>true</maven.site.skip>
         <asciidoctorj.version>2.4.2</asciidoctorj.version>
         <asciidoctorj.diagram.version>2.1.0</asciidoctorj.diagram.version>
-        <asciidoctorj.maven.plugin.version>2.1.0</asciidoctorj.maven.plugin.version>
+        <asciidoctorj.maven.plugin.version>2.2.4</asciidoctorj.maven.plugin.version>
         <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
-        <jbake.maven.plugin.version>0.3.3</jbake.maven.plugin.version>
+        <jbake.maven.plugin.version>2.7.0-rc.7</jbake.maven.plugin.version>
         <freemarker.version>2.3.30</freemarker.version>
         <!-- status: DRAFT, BETA, etc., or blank for final -->
         <status></status>
@@ -82,8 +82,8 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>[1.8.0,)</version>
-                                    <message>You need JDK8 or newer</message>
+                                    <version>[17,)</version>
+                                    <message>You need JDK17 or newer</message>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>

--- a/el/docs/userguide/src/main/jbake/content/attributes.conf
+++ b/el/docs/userguide/src/main/jbake/content/attributes.conf
@@ -26,7 +26,7 @@
 :MavenVersion: 3.6.3+
 :JakartaEEVersion: 11
 :excludeListFileName: docs/TCK-Exclude-List.txt
-:TCKPackageName: jakarta-expression-language-tck-5.0.0.zip
+:TCKPackageName: jakarta-expression-language-tck-6.0.0.zip
 // Directory names used in examples in using.adoc.
 :sigTestDirectoryExample: com/sun/ts/tests/signaturetest/el
 :singleTestDirectoryExample: com/sun/ts/tests/el/api/client

--- a/el/docs/userguide/src/main/jbake/content/using-examples.inc
+++ b/el/docs/userguide/src/main/jbake/content/using-examples.inc
@@ -17,13 +17,31 @@ mvn verify
 
 Example 5-1 {TechnologyShortName} TCK Signature Tests
 
-To run the {TechnologyShortName} TCK signature tests, enter the
-following commands:
+To run the {TechnologyShortName} TCK signature tests, use the 
+sigtest-maven-plugin in the TCK runner as below.
 
-[source,subs="attributes"]
-----
-mvn verify -Dit.test=com.sun.ts.tests.el.signaturetest.**
-----
+=======================================================================
+<plugin>
+    <groupId>org.netbeans.tools</groupId>
+    <artifactId>sigtest-maven-plugin</artifactId>
+    <version>1.5</version>
+    <configuration>
+        <sigfile>path-to-sig-file-provided-with-TCK</sigfile>
+        <packages>jakarta.el</packages>
+        <classes>path-to-api-jar</classes>
+        <report>target/sig-report.txt</report>
+    </configuration>
+    <executions>
+        <execution>
+        <id>sigtest</id>
+        <goals>
+            <goal>check</goal>
+        </goals>
+        <phase>verify</phase>
+        </execution>
+    </executions>
+</plugin>
+=======================================================================
 
 [[GCMBV]]
 

--- a/el/docs/userguide/src/main/jbake/content/using.adoc
+++ b/el/docs/userguide/src/main/jbake/content/using.adoc
@@ -15,8 +15,8 @@ Executing Tests
 5 Executing Tests
 -----------------
 
-The {TechnologyShortName} TCK uses the Junit and Jboss Arquillian 
-frameworks to execute the tests.
+The {TechnologyShortName} TCK uses the Junit 
+framework to execute the tests.
 
 This chapter includes the following topics:
 
@@ -148,9 +148,32 @@ mvn verify -DexcludedGroups={groupsExample}
 The tests in the group +{groupsExample}+ is exclued from the run. 
 Multiple groups can be separated by comma.
 
+[[GBFVK]][[Running-Signature-Test]]
+
+5.3 Running Signature Test
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+sigtest-maven-plugin is used to run the EL signature test. Please refer the 
+sample provided in the platform TCK repository.
+
+[NOTE]
+=======================================================================
+
+Use below configuration while using sigtest-maven-plugin with goal as `check`.
+
+    <configuration>
+        <sigfile>path-to-sig-file-provided-with-TCK</sigfile>
+        <packages>jakarta.el</packages>
+        <classes><path-to-api-jar</classes>
+        <report>sig-report.txt</report>
+    </configuration>
+
+=======================================================================
+
+
 [[GCLRR]][[running-the-tck-against-the-ri]]
 
-5.3 Running the TCK Against another CI
+5.4 Running the TCK Against another CI
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Some test scenarios are designed to ensure that the configuration and deployment of
@@ -169,7 +192,7 @@ of the Tests."]
 
 [[GCLRZ]][[running-the-tck-against-a-vendors-implementation]]
 
-5.4 Running the TCK Against a Vendor's Implementation
+5.5 Running the TCK Against a Vendor's Implementation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This test scenario is one of the compatibility test phases that all
@@ -187,7 +210,7 @@ of the Tests."]
 
 [[GBFVK]][[test-reports]]
 
-5.5 Test Reports
+5.6 Test Reports
 ~~~~~~~~~~~~~~~~
 
 A set of report files is created for every test run. These report files

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -33,6 +33,10 @@
     <name>el-tck</name>
     <description>EL TCK</description>
 
+    <properties>
+        <jakarta.el-api.version>6.0.0-M1</jakarta.el-api.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>jakarta-expression-language-tck</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>6.0.0</version>
     <packaging>jar</packaging>
 
     <name>el-tck</name>

--- a/el/src/main/assembly/assembly.xml
+++ b/el/src/main/assembly/assembly.xml
@@ -31,6 +31,10 @@
             <source>${project.basedir}/src/main/resources/LICENSE_${license}.md</source>
             <destName>LICENSE.md</destName>
         </file>
+        <file>
+            <source>${project.basedir}/src/main/resources/jakarta.el.sig_6.0</source>
+            <destName>jakarta.el.sig_6.0</destName>
+        </file>
     </files>
     <fileSets>
         <fileSet>

--- a/el/src/main/resources/jakarta.el.sig_5.0
+++ b/el/src/main/resources/jakarta.el.sig_5.0
@@ -1,0 +1,434 @@
+#Signature file v4.1
+#Version 5.0
+
+CLSS public jakarta.el.ArrayELResolver
+cons public init()
+cons public init(boolean)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds isReadOnly
+
+CLSS public jakarta.el.BeanELResolver
+cons public init()
+cons public init(boolean)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Class<?>[],java.lang.Object[])
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds isReadOnly,properties
+hcls BPSoftReference,BeanProperties,BeanProperty,SoftConcurrentHashMap
+
+CLSS public jakarta.el.BeanNameELResolver
+cons public init(jakarta.el.BeanNameResolver)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds beanNameResolver
+
+CLSS public abstract jakarta.el.BeanNameResolver
+cons public init()
+meth public boolean canCreateBean(java.lang.String)
+meth public boolean isNameResolved(java.lang.String)
+meth public boolean isReadOnly(java.lang.String)
+meth public java.lang.Object getBean(java.lang.String)
+meth public void setBeanValue(java.lang.String,java.lang.Object)
+supr java.lang.Object
+
+CLSS public jakarta.el.CompositeELResolver
+cons public init()
+meth public <%0 extends java.lang.Object> {%%0} convertToType(jakarta.el.ELContext,java.lang.Object,java.lang.Class<{%%0}>)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Class<?>[],java.lang.Object[])
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+meth public void add(jakarta.el.ELResolver)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds elResolvers,size
+hcls CompositeIterator
+
+CLSS public jakarta.el.ELClass
+cons public init(java.lang.Class<?>)
+meth public java.lang.Class<?> getKlass()
+supr java.lang.Object
+hfds klass
+
+CLSS public abstract jakarta.el.ELContext
+cons public init()
+meth public <%0 extends java.lang.Object> {%%0} convertToType(java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract jakarta.el.ELResolver getELResolver()
+meth public abstract jakarta.el.FunctionMapper getFunctionMapper()
+meth public abstract jakarta.el.VariableMapper getVariableMapper()
+meth public boolean isLambdaArgument(java.lang.String)
+meth public boolean isPropertyResolved()
+meth public jakarta.el.ImportHandler getImportHandler()
+meth public java.lang.Object getContext(java.lang.Class<?>)
+meth public java.lang.Object getLambdaArgument(java.lang.String)
+meth public java.util.List<jakarta.el.EvaluationListener> getEvaluationListeners()
+meth public java.util.Locale getLocale()
+meth public void addEvaluationListener(jakarta.el.EvaluationListener)
+meth public void enterLambdaScope(java.util.Map<java.lang.String,java.lang.Object>)
+meth public void exitLambdaScope()
+meth public void notifyAfterEvaluation(java.lang.String)
+meth public void notifyBeforeEvaluation(java.lang.String)
+meth public void notifyPropertyResolved(java.lang.Object,java.lang.Object)
+meth public void putContext(java.lang.Class<?>,java.lang.Object)
+meth public void setLocale(java.util.Locale)
+meth public void setPropertyResolved(boolean)
+meth public void setPropertyResolved(java.lang.Object,java.lang.Object)
+supr java.lang.Object
+hfds importHandler,lambdaArgs,listeners,locale,map,resolved
+
+CLSS public jakarta.el.ELContextEvent
+cons public init(jakarta.el.ELContext)
+meth public jakarta.el.ELContext getELContext()
+supr java.util.EventObject
+hfds serialVersionUID
+
+CLSS public abstract interface jakarta.el.ELContextListener
+intf java.util.EventListener
+meth public abstract void contextCreated(jakarta.el.ELContextEvent)
+
+CLSS public jakarta.el.ELException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.RuntimeException
+hfds serialVersionUID
+
+CLSS public jakarta.el.ELManager
+cons public init()
+meth public jakarta.el.ELContext setELContext(jakarta.el.ELContext)
+meth public jakarta.el.StandardELContext getELContext()
+meth public java.lang.Object defineBean(java.lang.String,java.lang.Object)
+meth public static jakarta.el.ExpressionFactory getExpressionFactory()
+meth public void addBeanNameResolver(jakarta.el.BeanNameResolver)
+meth public void addELResolver(jakarta.el.ELResolver)
+meth public void addEvaluationListener(jakarta.el.EvaluationListener)
+meth public void importClass(java.lang.String)
+meth public void importPackage(java.lang.String)
+meth public void importStatic(java.lang.String)
+meth public void mapFunction(java.lang.String,java.lang.String,java.lang.reflect.Method)
+meth public void setVariable(java.lang.String,jakarta.el.ValueExpression)
+supr java.lang.Object
+hfds elContext
+
+CLSS public jakarta.el.ELProcessor
+cons public init()
+meth public <%0 extends java.lang.Object> {%%0} eval(java.lang.String)
+meth public <%0 extends java.lang.Object> {%%0} getValue(java.lang.String,java.lang.Class<{%%0}>)
+meth public jakarta.el.ELManager getELManager()
+meth public void defineBean(java.lang.String,java.lang.Object)
+meth public void defineFunction(java.lang.String,java.lang.String,java.lang.String,java.lang.String) throws java.lang.ClassNotFoundException,java.lang.NoSuchMethodException
+meth public void defineFunction(java.lang.String,java.lang.String,java.lang.reflect.Method) throws java.lang.NoSuchMethodException
+meth public void setValue(java.lang.String,java.lang.Object)
+meth public void setVariable(java.lang.String,java.lang.String)
+supr java.lang.Object
+hfds elManager,factory
+
+CLSS public abstract jakarta.el.ELResolver
+cons public init()
+fld public final static java.lang.String RESOLVABLE_AT_DESIGN_TIME = "resolvableAtDesignTime"
+fld public final static java.lang.String TYPE = "type"
+meth public <%0 extends java.lang.Object> {%%0} convertToType(jakarta.el.ELContext,java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public abstract java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public abstract void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+meth public java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Class<?>[],java.lang.Object[])
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+supr java.lang.Object
+
+CLSS public abstract jakarta.el.EvaluationListener
+cons public init()
+meth public void afterEvaluation(jakarta.el.ELContext,java.lang.String)
+meth public void beforeEvaluation(jakarta.el.ELContext,java.lang.String)
+meth public void propertyResolved(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+supr java.lang.Object
+
+CLSS public abstract jakarta.el.Expression
+cons public init()
+intf java.io.Serializable
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract boolean isLiteralText()
+meth public abstract int hashCode()
+meth public abstract java.lang.String getExpressionString()
+supr java.lang.Object
+hfds serialVersionUID
+
+CLSS public abstract jakarta.el.ExpressionFactory
+cons public init()
+meth public abstract <%0 extends java.lang.Object> {%%0} coerceToType(java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract jakarta.el.MethodExpression createMethodExpression(jakarta.el.ELContext,java.lang.String,java.lang.Class<?>,java.lang.Class<?>[])
+meth public abstract jakarta.el.ValueExpression createValueExpression(jakarta.el.ELContext,java.lang.String,java.lang.Class<?>)
+meth public abstract jakarta.el.ValueExpression createValueExpression(java.lang.Object,java.lang.Class<?>)
+meth public jakarta.el.ELResolver getStreamELResolver()
+meth public java.util.Map<java.lang.String,java.lang.reflect.Method> getInitFunctionMap()
+meth public static jakarta.el.ExpressionFactory newInstance()
+meth public static jakarta.el.ExpressionFactory newInstance(java.util.Properties)
+supr java.lang.Object
+
+CLSS public abstract jakarta.el.FunctionMapper
+cons public init()
+meth public abstract java.lang.reflect.Method resolveFunction(java.lang.String,java.lang.String)
+meth public void mapFunction(java.lang.String,java.lang.String,java.lang.reflect.Method)
+supr java.lang.Object
+
+CLSS public jakarta.el.ImportHandler
+cons public init()
+meth public java.lang.Class<?> resolveClass(java.lang.String)
+meth public java.lang.Class<?> resolveStatic(java.lang.String)
+meth public void importClass(java.lang.String)
+meth public void importPackage(java.lang.String)
+meth public void importStatic(java.lang.String)
+supr java.lang.Object
+hfds classMap,classNameMap,notAClass,packages,staticNameMap
+
+CLSS public jakarta.el.LambdaExpression
+cons public init(java.util.List<java.lang.String>,jakarta.el.ValueExpression)
+meth public !varargs java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object[])
+meth public !varargs java.lang.Object invoke(java.lang.Object[])
+meth public void setELContext(jakarta.el.ELContext)
+supr java.lang.Object
+hfds context,envirArgs,expression,formalParameters
+
+CLSS public jakarta.el.ListELResolver
+cons public init()
+cons public init(boolean)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds isReadOnly,theUnmodifiableListClass
+
+CLSS public jakarta.el.MapELResolver
+cons public init()
+cons public init(boolean)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds isReadOnly,theUnmodifiableMapClass
+
+CLSS public abstract jakarta.el.MethodExpression
+cons public init()
+meth public abstract jakarta.el.MethodInfo getMethodInfo(jakarta.el.ELContext)
+meth public abstract java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object[])
+meth public boolean isParametersProvided()
+meth public jakarta.el.MethodReference getMethodReference(jakarta.el.ELContext)
+supr jakarta.el.Expression
+hfds serialVersionUID
+
+CLSS public jakarta.el.MethodInfo
+cons public init(java.lang.String,java.lang.Class<?>,java.lang.Class<?>[])
+meth public boolean equals(java.lang.Object)
+meth public int hashCode()
+meth public java.lang.Class<?> getReturnType()
+meth public java.lang.Class<?>[] getParamTypes()
+meth public java.lang.String getName()
+supr java.lang.Object
+hfds name,paramTypes,returnType
+
+CLSS public jakarta.el.MethodNotFoundException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.el.ELException
+hfds serialVersionUID
+
+CLSS public jakarta.el.MethodReference
+cons public init(java.lang.Object,jakarta.el.MethodInfo,java.lang.annotation.Annotation[],java.lang.Object[])
+meth public boolean equals(java.lang.Object)
+meth public int hashCode()
+meth public jakarta.el.MethodInfo getMethodInfo()
+meth public java.lang.Object getBase()
+meth public java.lang.Object[] getEvaluatedParameters()
+meth public java.lang.annotation.Annotation[] getAnnotations()
+supr java.lang.Object
+hfds annotations,base,evaluatedParameters,methodInfo
+
+CLSS public jakarta.el.PropertyNotFoundException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.el.ELException
+hfds serialVersionUID
+
+CLSS public jakarta.el.PropertyNotWritableException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.el.ELException
+hfds serialVersionUID
+
+CLSS public jakarta.el.ResourceBundleELResolver
+cons public init()
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+
+CLSS public jakarta.el.StandardELContext
+cons public init(jakarta.el.ELContext)
+cons public init(jakarta.el.ExpressionFactory)
+meth public jakarta.el.ELResolver getELResolver()
+meth public jakarta.el.FunctionMapper getFunctionMapper()
+meth public jakarta.el.VariableMapper getVariableMapper()
+meth public java.lang.Object getContext(java.lang.Class<?>)
+meth public void addELResolver(jakarta.el.ELResolver)
+meth public void putContext(java.lang.Class<?>,java.lang.Object)
+supr jakarta.el.ELContext
+hfds beans,customResolvers,delegate,elResolver,functionMapper,initFunctionMap,streamELResolver,variableMapper
+hcls DefaultFunctionMapper,DefaultVariableMapper,LocalBeanNameResolver
+
+CLSS public jakarta.el.StaticFieldELResolver
+cons public init()
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Class<?>[],java.lang.Object[])
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+
+CLSS public abstract jakarta.el.TypeConverter
+cons public init()
+meth public abstract <%0 extends java.lang.Object> {%%0} convertToType(jakarta.el.ELContext,java.lang.Object,java.lang.Class<{%%0}>)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.util.Iterator<java.beans.FeatureDescriptor> getFeatureDescriptors(jakarta.el.ELContext,java.lang.Object)
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="5.0")
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+
+CLSS public abstract jakarta.el.ValueExpression
+cons public init()
+meth public abstract <%0 extends java.lang.Object> {%%0} getValue(jakarta.el.ELContext)
+meth public abstract boolean isReadOnly(jakarta.el.ELContext)
+meth public abstract java.lang.Class<?> getExpectedType()
+meth public abstract java.lang.Class<?> getType(jakarta.el.ELContext)
+meth public abstract void setValue(jakarta.el.ELContext,java.lang.Object)
+meth public jakarta.el.ValueReference getValueReference(jakarta.el.ELContext)
+supr jakarta.el.Expression
+hfds serialVersionUID
+
+CLSS public jakarta.el.ValueReference
+cons public init(java.lang.Object,java.lang.Object)
+intf java.io.Serializable
+meth public java.lang.Object getBase()
+meth public java.lang.Object getProperty()
+supr java.lang.Object
+hfds base,property,serialVersionUID
+
+CLSS public abstract jakarta.el.VariableMapper
+cons public init()
+meth public abstract jakarta.el.ValueExpression resolveVariable(java.lang.String)
+meth public abstract jakarta.el.ValueExpression setVariable(java.lang.String,jakarta.el.ValueExpression)
+supr java.lang.Object
+
+CLSS public abstract interface java.io.Serializable
+
+CLSS public java.lang.Exception
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Throwable
+
+CLSS public java.lang.Object
+cons public init()
+meth protected java.lang.Object clone() throws java.lang.CloneNotSupportedException
+meth protected void finalize() throws java.lang.Throwable
+ anno 0 java.lang.Deprecated(boolean forRemoval=false, java.lang.String since="9")
+meth public boolean equals(java.lang.Object)
+meth public final java.lang.Class<?> getClass()
+meth public final void notify()
+meth public final void notifyAll()
+meth public final void wait() throws java.lang.InterruptedException
+meth public final void wait(long) throws java.lang.InterruptedException
+meth public final void wait(long,int) throws java.lang.InterruptedException
+meth public int hashCode()
+meth public java.lang.String toString()
+
+CLSS public java.lang.RuntimeException
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Exception
+
+CLSS public java.lang.Throwable
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+intf java.io.Serializable
+meth public final java.lang.Throwable[] getSuppressed()
+meth public final void addSuppressed(java.lang.Throwable)
+meth public java.lang.StackTraceElement[] getStackTrace()
+meth public java.lang.String getLocalizedMessage()
+meth public java.lang.String getMessage()
+meth public java.lang.String toString()
+meth public java.lang.Throwable fillInStackTrace()
+meth public java.lang.Throwable getCause()
+meth public java.lang.Throwable initCause(java.lang.Throwable)
+meth public void printStackTrace()
+meth public void printStackTrace(java.io.PrintStream)
+meth public void printStackTrace(java.io.PrintWriter)
+meth public void setStackTrace(java.lang.StackTraceElement[])
+supr java.lang.Object
+
+CLSS public abstract interface java.util.EventListener
+
+CLSS public java.util.EventObject
+cons public init(java.lang.Object)
+fld protected java.lang.Object source
+intf java.io.Serializable
+meth public java.lang.Object getSource()
+meth public java.lang.String toString()
+supr java.lang.Object
+

--- a/el/src/main/resources/jakarta.el.sig_6.0
+++ b/el/src/main/resources/jakarta.el.sig_6.0
@@ -1,0 +1,435 @@
+#Signature file v4.1
+#Version 6.0
+
+CLSS public jakarta.el.ArrayELResolver
+cons public init()
+cons public init(boolean)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds LENGTH_PROPERTY_NAME,isReadOnly
+
+CLSS public jakarta.el.BeanELResolver
+cons public init()
+cons public init(boolean)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Class<?>[],java.lang.Object[])
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds isReadOnly,properties
+hcls BPSoftReference,BeanProperties,BeanProperty,SoftConcurrentHashMap
+
+CLSS public jakarta.el.BeanNameELResolver
+cons public init(jakarta.el.BeanNameResolver)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds beanNameResolver
+
+CLSS public abstract jakarta.el.BeanNameResolver
+cons public init()
+meth public boolean canCreateBean(java.lang.String)
+meth public boolean isNameResolved(java.lang.String)
+meth public boolean isReadOnly(java.lang.String)
+meth public java.lang.Object getBean(java.lang.String)
+meth public void setBeanValue(java.lang.String,java.lang.Object)
+supr java.lang.Object
+
+CLSS public jakarta.el.CompositeELResolver
+cons public init()
+meth public <%0 extends java.lang.Object> {%%0} convertToType(jakarta.el.ELContext,java.lang.Object,java.lang.Class<{%%0}>)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Class<?>[],java.lang.Object[])
+meth public void add(jakarta.el.ELResolver)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds elResolvers,size
+
+CLSS public jakarta.el.ELClass
+cons public init(java.lang.Class<?>)
+meth public java.lang.Class<?> getKlass()
+supr java.lang.Object
+hfds klass
+
+CLSS public abstract jakarta.el.ELContext
+cons public init()
+meth public <%0 extends java.lang.Object> {%%0} convertToType(java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract jakarta.el.ELResolver getELResolver()
+meth public abstract jakarta.el.FunctionMapper getFunctionMapper()
+meth public abstract jakarta.el.VariableMapper getVariableMapper()
+meth public boolean isLambdaArgument(java.lang.String)
+meth public boolean isPropertyResolved()
+meth public jakarta.el.ImportHandler getImportHandler()
+meth public java.lang.Object getContext(java.lang.Class<?>)
+meth public java.lang.Object getLambdaArgument(java.lang.String)
+meth public java.util.List<jakarta.el.EvaluationListener> getEvaluationListeners()
+meth public java.util.Locale getLocale()
+meth public void addEvaluationListener(jakarta.el.EvaluationListener)
+meth public void enterLambdaScope(java.util.Map<java.lang.String,java.lang.Object>)
+meth public void exitLambdaScope()
+meth public void notifyAfterEvaluation(java.lang.String)
+meth public void notifyBeforeEvaluation(java.lang.String)
+meth public void notifyPropertyResolved(java.lang.Object,java.lang.Object)
+meth public void putContext(java.lang.Class<?>,java.lang.Object)
+meth public void setLocale(java.util.Locale)
+meth public void setPropertyResolved(boolean)
+meth public void setPropertyResolved(java.lang.Object,java.lang.Object)
+supr java.lang.Object
+hfds importHandler,lambdaArgs,listeners,locale,map,resolved
+
+CLSS public jakarta.el.ELContextEvent
+cons public init(jakarta.el.ELContext)
+meth public jakarta.el.ELContext getELContext()
+supr java.util.EventObject
+hfds serialVersionUID
+
+CLSS public abstract interface jakarta.el.ELContextListener
+intf java.util.EventListener
+meth public abstract void contextCreated(jakarta.el.ELContextEvent)
+
+CLSS public jakarta.el.ELException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.RuntimeException
+hfds serialVersionUID
+
+CLSS public jakarta.el.ELManager
+cons public init()
+meth public jakarta.el.ELContext setELContext(jakarta.el.ELContext)
+meth public jakarta.el.StandardELContext getELContext()
+meth public java.lang.Object defineBean(java.lang.String,java.lang.Object)
+meth public static jakarta.el.ExpressionFactory getExpressionFactory()
+meth public void addBeanNameResolver(jakarta.el.BeanNameResolver)
+meth public void addELResolver(jakarta.el.ELResolver)
+meth public void addEvaluationListener(jakarta.el.EvaluationListener)
+meth public void importClass(java.lang.String)
+meth public void importPackage(java.lang.String)
+meth public void importStatic(java.lang.String)
+meth public void mapFunction(java.lang.String,java.lang.String,java.lang.reflect.Method)
+meth public void setVariable(java.lang.String,jakarta.el.ValueExpression)
+supr java.lang.Object
+hfds elContext,exprFactory
+
+CLSS public jakarta.el.ELProcessor
+cons public init()
+meth public <%0 extends java.lang.Object> {%%0} eval(java.lang.String)
+meth public <%0 extends java.lang.Object> {%%0} getValue(java.lang.String,java.lang.Class<{%%0}>)
+meth public jakarta.el.ELManager getELManager()
+meth public void defineBean(java.lang.String,java.lang.Object)
+meth public void defineFunction(java.lang.String,java.lang.String,java.lang.String,java.lang.String) throws java.lang.ClassNotFoundException,java.lang.NoSuchMethodException
+meth public void defineFunction(java.lang.String,java.lang.String,java.lang.reflect.Method) throws java.lang.NoSuchMethodException
+meth public void setValue(java.lang.String,java.lang.Object)
+meth public void setVariable(java.lang.String,java.lang.String)
+supr java.lang.Object
+hfds elManager,factory
+
+CLSS public abstract jakarta.el.ELResolver
+cons public init()
+meth public <%0 extends java.lang.Object> {%%0} convertToType(jakarta.el.ELContext,java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public abstract java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public abstract java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public abstract void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+meth public java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Class<?>[],java.lang.Object[])
+supr java.lang.Object
+
+CLSS public abstract jakarta.el.EvaluationListener
+cons public init()
+meth public void afterEvaluation(jakarta.el.ELContext,java.lang.String)
+meth public void beforeEvaluation(jakarta.el.ELContext,java.lang.String)
+meth public void propertyResolved(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+supr java.lang.Object
+
+CLSS public abstract jakarta.el.Expression
+cons public init()
+intf java.io.Serializable
+meth public abstract boolean equals(java.lang.Object)
+meth public abstract boolean isLiteralText()
+meth public abstract int hashCode()
+meth public abstract java.lang.String getExpressionString()
+supr java.lang.Object
+hfds serialVersionUID
+
+CLSS public abstract jakarta.el.ExpressionFactory
+cons public init()
+meth public abstract <%0 extends java.lang.Object> {%%0} coerceToType(java.lang.Object,java.lang.Class<{%%0}>)
+meth public abstract jakarta.el.MethodExpression createMethodExpression(jakarta.el.ELContext,java.lang.String,java.lang.Class<?>,java.lang.Class<?>[])
+meth public abstract jakarta.el.ValueExpression createValueExpression(jakarta.el.ELContext,java.lang.String,java.lang.Class<?>)
+meth public abstract jakarta.el.ValueExpression createValueExpression(java.lang.Object,java.lang.Class<?>)
+meth public jakarta.el.ELResolver getStreamELResolver()
+meth public java.util.Map<java.lang.String,java.lang.reflect.Method> getInitFunctionMap()
+meth public static jakarta.el.ExpressionFactory newInstance()
+meth public static jakarta.el.ExpressionFactory newInstance(java.util.Properties)
+supr java.lang.Object
+
+CLSS public abstract jakarta.el.FunctionMapper
+cons public init()
+meth public abstract java.lang.reflect.Method resolveFunction(java.lang.String,java.lang.String)
+meth public void mapFunction(java.lang.String,java.lang.String,java.lang.reflect.Method)
+supr java.lang.Object
+
+CLSS public jakarta.el.ImportHandler
+cons public init()
+meth public java.lang.Class<?> resolveClass(java.lang.String)
+meth public java.lang.Class<?> resolveStatic(java.lang.String)
+meth public void importClass(java.lang.String)
+meth public void importPackage(java.lang.String)
+meth public void importStatic(java.lang.String)
+supr java.lang.Object
+hfds classMap,classNameMap,notAClass,packages,staticNameMap
+
+CLSS public jakarta.el.LambdaExpression
+cons public init(java.util.List<java.lang.String>,jakarta.el.ValueExpression)
+meth public !varargs java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object[])
+meth public !varargs java.lang.Object invoke(java.lang.Object[])
+meth public void setELContext(jakarta.el.ELContext)
+supr java.lang.Object
+hfds context,envirArgs,expression,formalParameters
+
+CLSS public jakarta.el.ListELResolver
+cons public init()
+cons public init(boolean)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds isReadOnly,theUnmodifiableListClass
+
+CLSS public jakarta.el.MapELResolver
+cons public init()
+cons public init(boolean)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+hfds isReadOnly,theUnmodifiableMapClass
+
+CLSS public abstract jakarta.el.MethodExpression
+cons public init()
+meth public abstract jakarta.el.MethodInfo getMethodInfo(jakarta.el.ELContext)
+meth public abstract java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object[])
+meth public boolean isParametersProvided()
+meth public jakarta.el.MethodReference getMethodReference(jakarta.el.ELContext)
+supr jakarta.el.Expression
+hfds serialVersionUID
+
+CLSS public jakarta.el.MethodInfo
+cons public init(java.lang.String,java.lang.Class<?>,java.lang.Class<?>[])
+meth public boolean equals(java.lang.Object)
+meth public int hashCode()
+meth public java.lang.Class<?> getReturnType()
+meth public java.lang.Class<?>[] getParamTypes()
+meth public java.lang.String getName()
+supr java.lang.Object
+hfds name,paramTypes,returnType
+
+CLSS public jakarta.el.MethodNotFoundException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.el.ELException
+hfds serialVersionUID
+
+CLSS public jakarta.el.MethodReference
+cons public init(java.lang.Object,jakarta.el.MethodInfo,java.lang.annotation.Annotation[],java.lang.Object[])
+meth public boolean equals(java.lang.Object)
+meth public int hashCode()
+meth public jakarta.el.MethodInfo getMethodInfo()
+meth public java.lang.Object getBase()
+meth public java.lang.Object[] getEvaluatedParameters()
+meth public java.lang.annotation.Annotation[] getAnnotations()
+supr java.lang.Object
+hfds annotations,base,evaluatedParameters,methodInfo
+
+CLSS public jakarta.el.OptionalELResolver
+cons public init()
+meth public <%0 extends java.lang.Object> {%%0} convertToType(jakarta.el.ELContext,java.lang.Object,java.lang.Class<{%%0}>)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+
+CLSS public jakarta.el.PropertyNotFoundException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.el.ELException
+hfds serialVersionUID
+
+CLSS public jakarta.el.PropertyNotWritableException
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr jakarta.el.ELException
+hfds serialVersionUID
+
+CLSS public jakarta.el.RecordELResolver
+cons public init()
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+
+CLSS public jakarta.el.ResourceBundleELResolver
+cons public init()
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+
+CLSS public jakarta.el.StandardELContext
+cons public init(jakarta.el.ELContext)
+cons public init(jakarta.el.ExpressionFactory)
+meth public jakarta.el.ELResolver getELResolver()
+meth public jakarta.el.FunctionMapper getFunctionMapper()
+meth public jakarta.el.VariableMapper getVariableMapper()
+meth public java.lang.Object getContext(java.lang.Class<?>)
+meth public void addELResolver(jakarta.el.ELResolver)
+meth public void putContext(java.lang.Class<?>,java.lang.Object)
+supr jakarta.el.ELContext
+hfds beans,customResolvers,delegate,elResolver,functionMapper,initFunctionMap,streamELResolver,variableMapper
+hcls DefaultFunctionMapper,DefaultVariableMapper,LocalBeanNameResolver
+
+CLSS public jakarta.el.StaticFieldELResolver
+cons public init()
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object invoke(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Class<?>[],java.lang.Object[])
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+
+CLSS public abstract jakarta.el.TypeConverter
+cons public init()
+meth public abstract <%0 extends java.lang.Object> {%%0} convertToType(jakarta.el.ELContext,java.lang.Object,java.lang.Class<{%%0}>)
+meth public boolean isReadOnly(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Class<?> getCommonPropertyType(jakarta.el.ELContext,java.lang.Object)
+meth public java.lang.Class<?> getType(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public java.lang.Object getValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object)
+meth public void setValue(jakarta.el.ELContext,java.lang.Object,java.lang.Object,java.lang.Object)
+supr jakarta.el.ELResolver
+
+CLSS public abstract jakarta.el.ValueExpression
+cons public init()
+meth public abstract <%0 extends java.lang.Object> {%%0} getValue(jakarta.el.ELContext)
+meth public abstract boolean isReadOnly(jakarta.el.ELContext)
+meth public abstract java.lang.Class<?> getExpectedType()
+meth public abstract java.lang.Class<?> getType(jakarta.el.ELContext)
+meth public abstract void setValue(jakarta.el.ELContext,java.lang.Object)
+meth public jakarta.el.ValueReference getValueReference(jakarta.el.ELContext)
+supr jakarta.el.Expression
+hfds serialVersionUID
+
+CLSS public jakarta.el.ValueReference
+cons public init(java.lang.Object,java.lang.Object)
+intf java.io.Serializable
+meth public java.lang.Object getBase()
+meth public java.lang.Object getProperty()
+supr java.lang.Object
+hfds base,property,serialVersionUID
+
+CLSS public abstract jakarta.el.VariableMapper
+cons public init()
+meth public abstract jakarta.el.ValueExpression resolveVariable(java.lang.String)
+meth public abstract jakarta.el.ValueExpression setVariable(java.lang.String,jakarta.el.ValueExpression)
+supr java.lang.Object
+
+CLSS public abstract interface java.io.Serializable
+
+CLSS public java.lang.Exception
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Throwable
+hfds serialVersionUID
+
+CLSS public java.lang.Object
+cons public init()
+meth protected java.lang.Object clone() throws java.lang.CloneNotSupportedException
+meth protected void finalize() throws java.lang.Throwable
+ anno 0 java.lang.Deprecated(boolean forRemoval=true, java.lang.String since="9")
+meth public boolean equals(java.lang.Object)
+meth public final java.lang.Class<?> getClass()
+meth public final void notify()
+meth public final void notifyAll()
+meth public final void wait() throws java.lang.InterruptedException
+meth public final void wait(long) throws java.lang.InterruptedException
+meth public final void wait(long,int) throws java.lang.InterruptedException
+meth public int hashCode()
+meth public java.lang.String toString()
+
+CLSS public java.lang.RuntimeException
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+supr java.lang.Exception
+hfds serialVersionUID
+
+CLSS public java.lang.Throwable
+cons protected init(java.lang.String,java.lang.Throwable,boolean,boolean)
+cons public init()
+cons public init(java.lang.String)
+cons public init(java.lang.String,java.lang.Throwable)
+cons public init(java.lang.Throwable)
+intf java.io.Serializable
+meth public final java.lang.Throwable[] getSuppressed()
+meth public final void addSuppressed(java.lang.Throwable)
+meth public java.lang.StackTraceElement[] getStackTrace()
+meth public java.lang.String getLocalizedMessage()
+meth public java.lang.String getMessage()
+meth public java.lang.String toString()
+meth public java.lang.Throwable fillInStackTrace()
+meth public java.lang.Throwable getCause()
+meth public java.lang.Throwable initCause(java.lang.Throwable)
+meth public void printStackTrace()
+meth public void printStackTrace(java.io.PrintStream)
+meth public void printStackTrace(java.io.PrintWriter)
+meth public void setStackTrace(java.lang.StackTraceElement[])
+supr java.lang.Object
+hfds CAUSE_CAPTION,EMPTY_THROWABLE_ARRAY,NULL_CAUSE_MESSAGE,SELF_SUPPRESSION_MESSAGE,SUPPRESSED_CAPTION,SUPPRESSED_SENTINEL,UNASSIGNED_STACK,backtrace,cause,depth,detailMessage,serialVersionUID,stackTrace,suppressedExceptions
+hcls PrintStreamOrWriter,SentinelHolder,WrappedPrintStream,WrappedPrintWriter
+
+CLSS public abstract interface java.util.EventListener
+
+CLSS public java.util.EventObject
+cons public init(java.lang.Object)
+fld protected java.lang.Object source
+intf java.io.Serializable
+meth public java.lang.Object getSource()
+meth public java.lang.String toString()
+supr java.lang.Object
+hfds serialVersionUID
+

--- a/glassfish-runner/el-tck/pom.xml
+++ b/glassfish-runner/el-tck/pom.xml
@@ -32,7 +32,7 @@
         <glassfish.toplevel.dir>glassfish7</glassfish.toplevel.dir>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.artifactId>jakarta-expression-language-tck</tck.artifactId>
-        <tck.version>6.0.0-SNAPSHOT</tck.version>
+        <tck.version>6.0.0</tck.version>
     </properties>
 
     <dependencyManagement>

--- a/glassfish-runner/el-tck/pom.xml
+++ b/glassfish-runner/el-tck/pom.xml
@@ -32,7 +32,7 @@
         <glassfish.toplevel.dir>glassfish7</glassfish.toplevel.dir>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.artifactId>jakarta-expression-language-tck</tck.artifactId>
-        <tck.version>6.0.0</tck.version>
+        <tck.version>6.0.0-SNAPSHOT</tck.version>
     </properties>
 
     <dependencyManagement>
@@ -55,8 +55,8 @@
         </dependency>
         <dependency>
             <groupId>jakartatck</groupId>
-            <artifactId>jakarta-expression-language-tck</artifactId>
-            <version>6.0.0-SNAPSHOT</version>
+            <artifactId>${tck.artifactId}</artifactId>
+            <version>${tck.version}</version>
         </dependency>
         <!-- <dependency>
             <groupId>org.glassfish.main.common</groupId>
@@ -105,6 +105,33 @@
                                 <unzip dest="target/" src="target/glassfish.zip"></unzip>
                                 <chmod dir="target/glassfish7/glassfish/bin/asadmin" perm="777"></chmod>
                             </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.2.0</version>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakartatck</groupId>
+                                    <artifactId>${tck.artifactId}</artifactId>
+                                    <version>${tck.version}</version>
+                                    <type>zip</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>
@@ -291,7 +318,7 @@
                 <artifactId>sigtest-maven-plugin</artifactId>
                 <version>1.5</version>
                 <configuration>
-                    <sigfile>jakarta.el.sig_6.0</sigfile>
+                    <sigfile>target/el-tck/jakarta.el.sig_6.0</sigfile>
                     <packages>jakarta.el</packages>
                     <classes>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.el-api.jar</classes>
                     <report>target/sig-report.txt</report>

--- a/glassfish-runner/el-tck/pom.xml
+++ b/glassfish-runner/el-tck/pom.xml
@@ -29,6 +29,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <glassfish.toplevel.dir>glassfish7</glassfish.toplevel.dir>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.artifactId>jakarta-expression-language-tck</tck.artifactId>
         <tck.version>6.0.0</tck.version>
@@ -57,16 +58,59 @@
             <artifactId>jakarta-expression-language-tck</artifactId>
             <version>6.0.0-SNAPSHOT</version>
         </dependency>
-        <dependency>
+        <!-- <dependency>
             <groupId>org.glassfish.main.common</groupId>
             <artifactId>simple-glassfish-api</artifactId>
             <version>${glassfish.container.version}</version>
+        </dependency> -->
+        <dependency>
+            <groupId>org.netbeans.tools</groupId>
+            <artifactId>sigtest-maven-plugin</artifactId>
+            <version>1.5</version>
         </dependency>
     </dependencies>
 
     <build>
         <plugins>
             <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <url>https://github.com/eclipse-ee4j/glassfish/releases/download/8.0.0-M1/glassfish-8.0.0-M1.zip</url>
+                            <outputFileName>glassfish.zip</outputFileName>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>1.8</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <tasks>
+                                <echo message="unzipping file"></echo>
+                                <unzip dest="target/" src="target/glassfish.zip"></unzip>
+                                <chmod dir="target/glassfish7/glassfish/bin/asadmin" perm="777"></chmod>
+                            </tasks>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.2.0</version>
@@ -91,7 +135,8 @@
                         </configuration>
                     </execution>
                 </executions>
-            </plugin>
+            </plugin> -->
+
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>exec-maven-plugin</artifactId>
@@ -241,6 +286,27 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.netbeans.tools</groupId>
+                <artifactId>sigtest-maven-plugin</artifactId>
+                <version>1.5</version>
+                <configuration>
+                    <sigfile>jakarta.el.sig_6.0</sigfile>
+                    <packages>jakarta.el</packages>
+                    <classes>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.el-api.jar</classes>
+                    <report>target/sig-report.txt</report>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>sigtest</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.0.0-M5</version>

--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <jakarta.batch-api.version>2.0.0</jakarta.batch-api.version>
         <!-- Jakarta Enterprise beans -->
         <jakarta.ejb-api.version>4.0.0</jakarta.ejb-api.version>
-        <jakarta.el-api.version>5.0.1</jakarta.el-api.version>
+        <jakarta.el-api.version>6.0.0-M1</jakarta.el-api.version>
         <jakarta.faces-api.version>3.0.0</jakarta.faces-api.version>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <!-- Jakarta Interceptors -->


### PR DESCRIPTION
**Describe the change**
- Generated new signature file for EL , 
- Updated the TCK runner to execute signature tests with Glassfish 8.0.0-M1
- Updated the EL api to latest 6.0.0-M1 for EE11
- Updated the documentation

Notes:
- Post this change the plan is to stage the new refactored Expression language TCK from tckrefactor branch using Jenkins job. 
- There is 1 test failure pending to be resolved,  ELClientIT.elCoerceLambdaExpressionToFunctionalInterfaceTest with glassfish8 which is related to https://github.com/jakartaee/platform-tck/pull/1159 . Will track the same via separate issue.
Update: https://github.com/jakartaee/platform-tck/pull/1215 fixes the failing test.

