### PR TITLE
EL 6.0 new tests

### DIFF
--- a/common/src/main/java/com/sun/ts/tests/common/el/api/resolver/ResolverTest.java
+++ b/common/src/main/java/com/sun/ts/tests/common/el/api/resolver/ResolverTest.java
@@ -24,6 +24,7 @@ import java.beans.FeatureDescriptor;
 import java.util.Enumeration;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Objects;
 
 import jakarta.el.ArrayELResolver;
 import jakarta.el.BeanELResolver;
@@ -172,7 +173,7 @@ public class ResolverTest {
       pass = false;
     }
 
-    if (!readOnly && valueRetrieved != value) {
+    if (!readOnly && !Objects.equals(valueRetrieved, value)) {
       if (valueRetrieved == null) {
         buf.append("null value returned from getValue() method call!" + NL);
         pass = false;

--- a/common/src/main/java/com/sun/ts/tests/common/el/api/resolver/ResolverTest.java
+++ b/common/src/main/java/com/sun/ts/tests/common/el/api/resolver/ResolverTest.java
@@ -20,19 +20,12 @@
  */
 package com.sun.ts.tests.common.el.api.resolver;
 
-import java.beans.FeatureDescriptor;
-import java.util.Enumeration;
-import java.util.Iterator;
-import java.util.Map;
 import java.util.Objects;
 
-import jakarta.el.ArrayELResolver;
 import jakarta.el.BeanELResolver;
 import jakarta.el.CompositeELResolver;
 import jakarta.el.ELContext;
 import jakarta.el.ELResolver;
-import jakarta.el.ListELResolver;
-import jakarta.el.MapELResolver;
 import jakarta.el.MethodNotFoundException;
 import jakarta.el.PropertyNotFoundException;
 import jakarta.el.PropertyNotWritableException;
@@ -289,67 +282,6 @@ public class ResolverTest {
     return pass;
   }
 
-  public static boolean testFeatureDescriptors(Iterator i, ELResolver resolver,
-      Object base, StringBuffer buf) {
-
-    if (i == null) {
-      buf.append("getFeatureDescriptors() returns null" + NL);
-      if (resolver instanceof ArrayELResolver
-          || resolver instanceof ListELResolver) {
-        return true;
-      } else if (resolver instanceof MapELResolver && !(base instanceof Map)) {
-        return true;
-      } else if (resolver instanceof BeanELResolver && base != null) {
-        return true;
-      } else if (resolver instanceof BarELResolver) {
-        return true;
-      } else {
-        return false;
-      }
-    }
-
-    while (i.hasNext()) {
-      Object obj = i.next();
-      if (!(obj instanceof FeatureDescriptor)) {
-        buf.append("getFeatureDescriptors() ");
-        buf.append(
-            "does not return a collection of " + "FeatureDescriptors" + NL);
-        return false;
-      } else {
-        int numAttribs = 0;
-        FeatureDescriptor fd = (FeatureDescriptor) obj;
-        Enumeration e = fd.attributeNames();
-        while (e.hasMoreElements()) {
-          String attrib = (String) e.nextElement();
-          if (attrib.equals("type")) {
-            ++numAttribs;
-            if (!(fd.getValue(attrib) instanceof Class)) {
-              buf.append("getFeatureDescriptors(): ");
-              buf.append("Invalid attribute for type." + NL);
-              return false;
-            }
-          }
-          if (attrib.equals("resolvableAtDesignTime")) {
-            ++numAttribs;
-            if (!(fd.getValue(attrib) instanceof Boolean)) {
-              buf.append("getFeatureDescriptors(): ");
-              buf.append(
-                  "Invalid attribute for " + "resolvableAtDesignTime." + NL);
-              return false;
-            }
-          }
-        }
-        if (numAttribs < 2) {
-          buf.append("getFeatureDescriptors(): ");
-          buf.append("Required attribute missing." + NL);
-          return false;
-        }
-      } // else
-    } // while
-
-    buf.append("Passed all getFeatureDescriptors() tests" + NL);
-    return true;
-  }
 
   // --- Start Negative Method Tests ---
   public static boolean testELResolverNPE(ELResolver resolver, Object base,

--- a/common/src/main/java/com/sun/ts/tests/common/el/api/resolver/ResolverTest.java
+++ b/common/src/main/java/com/sun/ts/tests/common/el/api/resolver/ResolverTest.java
@@ -99,7 +99,7 @@ public class ResolverTest {
 
     // getType()
     elContext.setPropertyResolved(false);
-    Class type = compResolver.getType(elContext, null, "Bar");
+    Class<?> type = compResolver.getType(elContext, null, "Bar");
     if (!elContext.isPropertyResolved()) {
       buf.append("getType() did not resolve" + NL);
       pass = false;
@@ -127,8 +127,7 @@ public class ResolverTest {
 
     // getCommonPropertyType()
     elContext.setPropertyResolved(false);
-    Class commonPropertyType = (compResolver.getCommonPropertyType(elContext,
-        null));
+    Class<?> commonPropertyType = (compResolver.getCommonPropertyType(elContext, null));
     buf.append("getCommonPropertyType() returns ");
     buf.append(commonPropertyType.getName() + NL);
 
@@ -193,7 +192,7 @@ public class ResolverTest {
 
     // getType()
     elContext.setPropertyResolved(false);
-    Class type = resolver.getType(elContext, base, property);
+    Class<?> type = resolver.getType(elContext, base, property);
     if (!elContext.isPropertyResolved()) {
       buf.append("getType() did not resolve" + NL);
       pass = false;
@@ -230,8 +229,7 @@ public class ResolverTest {
 
     // getCommonPropertyType()
     elContext.setPropertyResolved(false);
-    Class commonPropertyType = (resolver.getCommonPropertyType(elContext,
-        base));
+    Class<?> commonPropertyType = (resolver.getCommonPropertyType(elContext, base));
     buf.append("getCommonPropertyType() returns ");
     buf.append(commonPropertyType.getName() + "" + NL);
 
@@ -260,7 +258,7 @@ public class ResolverTest {
    * @return
    */
   public static boolean testELResolverInvoke(ELContext elContext,
-      ELResolver resolver, Object beanName, Object methodName, Class[] types,
+      ELResolver resolver, Object beanName, Object methodName, Class<?>[] types,
       Object[] values, Boolean negTest, StringBuffer buf) {
 
     boolean pass = true;
@@ -271,13 +269,13 @@ public class ResolverTest {
       Boolean nameMatch = (Boolean) resolver.invoke(elContext, beanName,
           methodName, types, values);
 
-      if (!nameMatch) {
+      if (!nameMatch.booleanValue()) {
         buf.append("invoke() did not Run properly." + NL);
         pass = false;
       }
 
     } catch (MethodNotFoundException mnfe) {
-      if (negTest) {
+      if (negTest.booleanValue()) {
         buf.append("Test Passed  invoke() threw MethodNotFoundException");
       } else {
         pass = false;

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021  Contributors to the Eclipse Foundation
+    Copyright (c) 2024  Contributors to the Eclipse Foundation
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -115,6 +115,12 @@
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <release>17</release>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/arrayelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/arrayelresolver/ELClientIT.java
@@ -21,8 +21,6 @@
 
 package com.sun.ts.tests.el.api.jakarta_el.arrayelresolver;
 
-import java.util.Properties;
-
 import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
@@ -258,7 +256,7 @@ public class ELClientIT {
     ELContext context = barebonesContext.getELContext();
 
     try {
-      Object value = resolver.getValue(context, names, 5);
+      Object value = resolver.getValue(context, names, Integer.valueOf(5));
 
       if (value != null) {
         pass = false;

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/arrayelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/arrayelresolver/ELClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2020 Oracle and/or its affiliates and others.
+ * Copyright (c) 2009, 2024 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -309,5 +309,35 @@ public class ELClientIT {
     if (!pass) {
       throw new Exception("Failed: No exception thrown.");
     }
+  }
+
+
+  /*
+   * @testName: arrayELResolverLengthTest
+   * 
+   * @test_Strategy: Verify that the length of an array is available as a read-only property.
+   */
+  @Test
+  public void arrayELResolverLengthTest() throws Exception {
+
+    boolean pass;
+    StringBuffer buf = new StringBuffer();
+    String[] colors = { "red", "blue", "green" };
+
+    try {
+      ArrayELResolver arrayResolver = new ArrayELResolver();
+      BareBonesELContext barebonesContext = new BareBonesELContext();
+      ELContext context = barebonesContext.getELContext();
+
+      pass = ResolverTest.testELResolver(context, arrayResolver, colors,
+          "length", "3", buf, true);
+    } catch (Exception ex) {
+      throw new Exception(ex);
+    }
+
+    if (!pass) {
+      throw new Exception(ELTestUtil.FAIL + buf.toString());
+    }
+    logger.log(Logger.Level.TRACE, buf.toString());
   }
 }

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/beanelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/beanelresolver/ELClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2009, 2021 Oracle and/or its affiliates and others.
+ * Copyright (c) 2009, 2024 Oracle and/or its affiliates and others.
  * All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -15,14 +15,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * $Id$
- */
-
 package com.sun.ts.tests.el.api.jakarta_el.beanelresolver;
-
-import java.util.Properties;
-
 
 import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
@@ -195,8 +188,7 @@ public class ELClientIT {
       Class<?>[] types = { String.class, String.class };
       String[] values = { "Doug", "Donahue" };
 
-      pass = ResolverTest.testELResolverInvoke(context, beanResolver, sb,
-          "isName", types, values, false, buf);
+      pass = ResolverTest.testELResolverInvoke(context, beanResolver, sb, "isName", types, values, Boolean.FALSE, buf);
     } catch (Exception ex) {
       throw new Exception(ex);
     }
@@ -234,8 +226,8 @@ public class ELClientIT {
 
       if (null == result) {
         // validate the new values.
-        pass = ResolverTest.testELResolverInvoke(context, beanResolver, sb,
-            "isName", types, values, false, buf);
+        pass = ResolverTest.testELResolverInvoke(
+            context, beanResolver, sb, "isName", types, values, Boolean.FALSE, buf);
       } else {
         pass = false;
         buf.append("Unexpected Value returned!" + TestUtil.NEW_LINE
@@ -275,8 +267,8 @@ public class ELClientIT {
       Class<?>[] types = { String.class, String.class };
       String[] values = { "Doug", "Donahue" };
 
-      pass = ResolverTest.testELResolverInvoke(context, beanResolver, sb,
-          "bogus_Method", types, values, true, buf);
+      pass = ResolverTest.testELResolverInvoke(
+          context, beanResolver, sb, "bogus_Method", types, values, Boolean.TRUE, buf);
 
     } catch (Exception ex) {
       throw new Exception(ex);

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/beanelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/beanelresolver/ELClientIT.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
 import java.lang.System.Logger;
+import java.util.TimeZone;
 
 public class ELClientIT {
 
@@ -379,6 +380,37 @@ public class ELClientIT {
     try {
       pass = ResolverTest.testELResolverPNWE(context, resolver, sb, "intention",
           "billy", buf);
+    } catch (Exception ex) {
+      throw new Exception(ex);
+    }
+
+    if (!pass) {
+      throw new Exception(ELTestUtil.FAIL + buf.toString());
+    }
+    logger.log(Logger.Level.TRACE, buf.toString());
+  }
+  
+  /**
+   * @testName: beanELResolverMethodVisibilityTest
+   * 
+   * @test_Strategy: Verify that API calls work as expected for a property that is not visible via the implementing
+   *                 class (it is in an internal, non-exported class) but is visible via an interface method:
+   *                 beanELResolver() getValue() getType() setValue() isReadOnly() getCommonPropertyType()
+   *                 getFeatureDescriptors()
+   */
+  @Test
+  public void beanELResolverMethodVisibilityTest() throws Exception {
+
+    boolean pass = false;
+    StringBuffer buf = new StringBuffer();
+    TimeZone tz = TimeZone.getDefault();
+    
+    try {
+      BeanELResolver beanResolver = new BeanELResolver();
+      BareBonesELContext barebonesContext = new BareBonesELContext();
+      ELContext context = barebonesContext.getELContext();
+
+      pass = ResolverTest.testELResolver(context, beanResolver, tz, "rawOffset", Integer.valueOf(0), buf, false);
     } catch (Exception ex) {
       throw new Exception(ex);
     }

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/optionalelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/optionalelresolver/ELClientIT.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.ts.tests.el.api.jakarta_el.optionalelresolver;
+
+import java.lang.System.Logger;
+import java.util.Optional;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
+import com.sun.ts.tests.el.common.util.ELTestUtil;
+
+import jakarta.el.BeanELResolver;
+import jakarta.el.CompositeELResolver;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.OptionalELResolver;
+import jakarta.el.PropertyNotWritableException;
+
+public class ELClientIT {
+
+  private static final Logger logger = System.getLogger(ELClientIT.class.getName());
+
+  @AfterEach
+  public void cleanup() throws Exception {
+    logger.log(Logger.Level.INFO, "Cleanup method called");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+  }
+
+  /**
+   * @testName: optionalELResolverEmptyNullTest
+   *
+   * @test_Strategy: Verify that API calls work as expected for: getValue() getType() setValue() isReadOnly()
+   * getCommonPropertyType() when the base object is an empty Optional and the property is null
+   */
+  @Test
+  public void optionalELResolverEmptyNullTest() throws Exception {
+
+    boolean pass = true;
+    StringBuffer buf = new StringBuffer();
+    Object testObject = Optional.empty();
+    
+    try {
+      pass = testOptionalELResolver(buf, testObject, null, null);
+    } catch (Exception ex) {
+      throw new Exception(ex);
+    }
+
+    if (!pass) {
+      throw new Exception(ELTestUtil.FAIL + buf.toString());
+    }
+    logger.log(Logger.Level.TRACE, buf.toString());
+  }
+  
+  /**
+   * @testName: optionalELResolverEmptyNonNullTest
+   *
+   * @test_Strategy: Verify that API calls work as expected for: getValue() getType() setValue() isReadOnly()
+   * getCommonPropertyType() when the base object is an empty Optional and the property is non-null
+   */
+  @Test
+  public void optionalELResolverEmptyNonNullTest() throws Exception {
+
+    boolean pass = true;
+    StringBuffer buf = new StringBuffer();
+    Object testObject = Optional.empty();
+    
+    try {
+      pass = testOptionalELResolver(buf, testObject, "property", Optional.empty());
+    } catch (Exception ex) {
+      throw new Exception(ex);
+    }
+
+    if (!pass) {
+      throw new Exception(ELTestUtil.FAIL + buf.toString());
+    }
+    logger.log(Logger.Level.TRACE, buf.toString());
+  }
+
+  /**
+   * @testName: optionalELResolverObjectNullTest
+   *
+   * @test_Strategy: Verify that API calls work as expected for: getValue() getType() setValue() isReadOnly()
+   * getCommonPropertyType() when the base object is an non-empty Optional and the property is null
+   */
+  @Test
+  public void optionalELResolverObjectNullTest() throws Exception {
+
+    boolean pass = true;
+    StringBuffer buf = new StringBuffer();
+    TestBean testBean = new TestBean("data");
+    Object testObject = Optional.of(testBean);
+    
+    try {
+      pass = testOptionalELResolver(buf, testObject, null, testBean);
+    } catch (Exception ex) {
+      throw new Exception(ex);
+    }
+
+    if (!pass) {
+      throw new Exception(ELTestUtil.FAIL + buf.toString());
+    }
+    logger.log(Logger.Level.TRACE, buf.toString());
+  }
+
+  /**
+   * @testName: optionalELResolverObjectNullTest
+   *
+   * @test_Strategy: Verify that API calls work as expected for: getValue() getType() setValue() isReadOnly()
+   * getCommonPropertyType() when the base object is an non-empty Optional and the property is non-null
+   */
+  @Test
+  public void optionalELResolverObjectNonNullTest() throws Exception {
+
+    boolean pass = true;
+    StringBuffer buf = new StringBuffer();
+    TestBean testBean = new TestBean("data");
+    Object testObject = Optional.of(testBean);
+    
+    try {
+      pass = testOptionalELResolver(buf, testObject, "propertyA", "data");
+    } catch (Exception ex) {
+      throw new Exception(ex);
+    }
+
+    if (!pass) {
+      throw new Exception(ELTestUtil.FAIL + buf.toString());
+    }
+    logger.log(Logger.Level.TRACE, buf.toString());
+  }
+
+  public static boolean testOptionalELResolver(StringBuffer buf, Object base, Object property, Object expectedValue) {
+    boolean pass = true;
+    
+    BareBonesELContext barebonesContext = new BareBonesELContext();
+    
+    // OptionalELResolver depends on BeanELResolver to resolve properties of an Optional
+    ELResolver resolver = barebonesContext.getELResolver();
+    BeanELResolver beanResolver = new BeanELResolver();
+    OptionalELResolver optionalResolver = new OptionalELResolver();
+    ((CompositeELResolver) resolver).add(optionalResolver);
+    ((CompositeELResolver) resolver).add(beanResolver);
+    
+    ELContext context = barebonesContext.getELContext();
+
+    // getValue()
+    Object result = resolver.getValue(context, base, property);
+    if (expectedValue == null && result != null || expectedValue != null && !expectedValue.equals(result)) {
+      buf.append("getValue(): Expected [" + expectedValue + "] but got [" + result + "]");
+      pass = false;
+    }
+    
+    // getType()
+    result = resolver.getType(context, base, property);
+    if (result != null) {
+      pass = false;
+    }
+    
+    // setValue()
+    try {
+      resolver.setValue(context, base, property, "anything");
+      pass = false;
+    } catch (PropertyNotWritableException pnwe) {
+      // Expected
+    }
+    
+    // isReadOnly()
+    boolean bResult = resolver.isReadOnly(context, base, property);
+    if (!bResult) {
+      pass = false;
+    }
+    
+    // getCommonPropertyType()
+    result = resolver.getCommonPropertyType(context, base);
+    if (result != Object.class) {
+      pass = false;
+    }
+
+    return pass;
+  }
+  
+  public class TestBean {
+    private final String propertyA; 
+    public TestBean(String propertyA) {
+      this.propertyA = propertyA;
+    }
+    public String getPropertyA() {
+      return propertyA;
+    }
+  }
+}

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/recordelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/recordelresolver/ELClientIT.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+package com.sun.ts.tests.el.api.jakarta_el.recordelresolver;
+
+import java.lang.System.Logger;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+
+import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
+import com.sun.ts.tests.el.common.util.ELTestUtil;
+
+import jakarta.el.ELContext;
+import jakarta.el.RecordELResolver;
+
+public class ELClientIT {
+
+  private static final Logger logger = System.getLogger(ELClientIT.class.getName());
+
+  @AfterEach
+  public void cleanup() throws Exception {
+    logger.log(Logger.Level.INFO, "Cleanup method called");
+  }
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+    logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+    logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+  }
+
+  /**
+   * @testName: recordELResolverTest
+   *
+   * @test_Strategy: Verify that API calls work as expected for: arrayELResolver() getValue() getType() setValue()
+   * isReadOnly() getCommonPropertyType() getFeatureDescriptors(). Records should behave similarly to read-only beans.
+   */
+  @Test
+  public void recordELResolverTest() throws Exception {
+
+    boolean pass;
+    StringBuffer buf = new StringBuffer();
+    TestRecord testRecord = new TestRecord("valueA", "valueB");
+
+    try {
+      RecordELResolver recordResolver = new RecordELResolver();
+      BareBonesELContext barebonesContext = new BareBonesELContext();
+      ELContext context = barebonesContext.getELContext();
+
+      pass = ResolverTest.testELResolver(context, recordResolver, testRecord, "propertyA", "newValue", buf, true);
+    } catch (Exception ex) {
+      throw new Exception(ex);
+    }
+
+    if (!pass) {
+      throw new Exception(ELTestUtil.FAIL + buf.toString());
+    }
+    logger.log(Logger.Level.TRACE, buf.toString());
+  }
+  
+  
+  public record TestRecord(String propertyA, String propertyB) { }
+}


### PR DESCRIPTION
**Fixes Issue**
New tests for functionality added in EL 6.0

**Related Issue(s)**
None.

**Describe the change**
- `ArrayELResiolver` tests extended to include new `length` property
- Add tests for new `RecordELResolver`
- Add tests for new `OptionalELResolver`
- Add test for method visibility clarification
There are also some clean-up commits (no functional changes) to the touched classes to fix various IDE warnings.

**Additional context**
None.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
