### PR TITLE
switch GroupId to jakarta.tck instead of jakartatck

### DIFF
--- a/appclient/pom.xml
+++ b/appclient/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/connector/pom.xml
+++ b/connector/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/core-profile-tck/pom.xml
+++ b/core-profile-tck/pom.xml
@@ -13,7 +13,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -23,7 +23,7 @@
      mvn -Pstaging clean install
   -->
   <parent>
-    <groupId>jakartatck</groupId>
+    <groupId>jakarta.tck</groupId>
     <version>10.0.0-SNAPSHOT</version>
     <artifactId>project</artifactId>
   </parent>

--- a/ejb/pom.xml
+++ b/ejb/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/ejb30-ws/pom.xml
+++ b/ejb30-ws/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/ejb30/pom.xml
+++ b/ejb30/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/ejb32/pom.xml
+++ b/ejb32/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/glassfish-runner/el-tck/pom.xml
+++ b/glassfish-runner/el-tck/pom.xml
@@ -54,7 +54,7 @@
             <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>${tck.artifactId}</artifactId>
             <version>${tck.version}</version>
         </dependency>
@@ -124,7 +124,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>jakartatck</groupId>
+                                    <groupId>jakarta.tck</groupId>
                                     <artifactId>${tck.artifactId}</artifactId>
                                     <version>${tck.version}</version>
                                     <type>zip</type>
@@ -349,7 +349,7 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.el-api.jar</additionalClasspathElement>
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/expressly.jar</additionalClasspathElement>
                             </additionalClasspathElements>
-                            <dependenciesToScan>jakartatck:jakarta-expression-language-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:jakarta-expression-language-tck</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <webServerHost>localhost</webServerHost>

--- a/glassfish-runner/jaxrs-platform-tck/pom.xml
+++ b/glassfish-runner/jaxrs-platform-tck/pom.xml
@@ -42,17 +42,17 @@
 
   <dependencies>
     <dependency>
-      <groupId>jakartatck</groupId>
+      <groupId>jakarta.tck</groupId>
       <artifactId>common</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>jakartatck</groupId>
+      <groupId>jakarta.tck</groupId>
       <artifactId>libutil</artifactId>
       <version>${project.version}</version>
     </dependency>
     <dependency>
-      <groupId>jakartatck</groupId>
+      <groupId>jakarta.tck</groupId>
       <artifactId>runtime</artifactId>
       <version>${project.version}</version>
     </dependency>
@@ -85,7 +85,7 @@
       </exclusions>
     </dependency>
     <dependency>
-      <groupId>jakartatck</groupId>
+      <groupId>jakarta.tck</groupId>
       <artifactId>${tck.artifactId}</artifactId>
       <version>${tck.version}</version>
       <scope>test</scope>
@@ -385,7 +385,7 @@
                   ${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/angus-activation.jar
                 </additionalClasspathElement>
               </additionalClasspathElements>
-              <dependenciesToScan>jakartatck:${tck.artifactId}</dependenciesToScan>
+              <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
               <systemPropertyVariables>
                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                 <servlet_adaptor>org.glassfish.jersey.servlet.ServletContainer</servlet_adaptor>

--- a/glassfish-runner/jpa-tck/pom.xml
+++ b/glassfish-runner/jpa-tck/pom.xml
@@ -28,7 +28,7 @@
         <relativePath>../pom.xml</relativePath>
     </parent>
     <properties>
-        <tck.artifactId>jakartatck.jpa-tck</tck.artifactId>
+        <tck.artifactId>jakarta.tck.jpa-tck</tck.artifactId>
         <tck.version>3.1.0</tck.version>
         <admin.user>admin</admin.user>
         <admin.pass>admin</admin.pass>
@@ -64,7 +64,7 @@
             <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -80,13 +80,13 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>jpa-tck</artifactId>
             <version>10.0.0-SNAPSHOT</version>
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>dbprocedures</artifactId>
             <version>10.0.0-SNAPSHOT</version>
             <scope>test</scope>
@@ -164,7 +164,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>jakartatck</groupId>
+                                    <groupId>jakarta.tck</groupId>
                                     <artifactId>dbprocedures</artifactId>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${project.build.directory}</outputDirectory>
@@ -310,7 +310,7 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/expressly.jar</additionalClasspathElement>
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/classmate.jar</additionalClasspathElement>
                             </additionalClasspathElements>
-                            <dependenciesToScan>jakartatck:jpa-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:jpa-tck</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <platform.mode>standalone</platform.mode>

--- a/glassfish-runner/jsp-tck/pom.xml
+++ b/glassfish-runner/jsp-tck/pom.xml
@@ -41,7 +41,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>${tck.artifactId}</artifactId>
             <version>${tck.version}</version>
         </dependency>
@@ -138,7 +138,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>jakartatck</groupId>
+                                    <groupId>jakarta.tck</groupId>
                                     <artifactId>${tck.artifactId}</artifactId>
                                     <version>${tck.version}</version>
                                     <type>zip</type>
@@ -343,7 +343,7 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.servlet.jsp-api.jar</additionalClasspathElement>
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.servlet.jsp.jstl-api.jar</additionalClasspathElement>
                             </additionalClasspathElements>
-                            <dependenciesToScan>jakartatck:${tck.artifactId}</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <webServerHome>${project.build.directory}/${glassfish.toplevel.dir}/glassfish</webServerHome>

--- a/glassfish-runner/pom.xml
+++ b/glassfish-runner/pom.xml
@@ -16,7 +16,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/glassfish-runner/servlet-tck/pom.xml
+++ b/glassfish-runner/servlet-tck/pom.xml
@@ -50,12 +50,12 @@
 
     <dependencies>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>servlet</artifactId>
             <version>10.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>libutil</artifactId>
             <version>10.0.0-SNAPSHOT</version>
         </dependency>
@@ -128,7 +128,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>jakartatck</groupId>
+                                    <groupId>jakarta.tck</groupId>
                                     <artifactId>libutil</artifactId>
                                     <type>jar</type>
                                     <overWrite>false</overWrite>
@@ -221,7 +221,7 @@
                     <failIfNoTests>false</failIfNoTests>
                     <failIfNoSpecifiedTests>true</failIfNoSpecifiedTests>
                     <dependenciesToScan>
-                        <dependenciesToScan>jakartatck:servlet</dependenciesToScan>
+                        <dependenciesToScan>jakarta.tck:servlet</dependenciesToScan>
                     </dependenciesToScan>
                     <includes>
                         <include>**/URLClient*</include>

--- a/glassfish-runner/websocket-platform-tck/pom.xml
+++ b/glassfish-runner/websocket-platform-tck/pom.xml
@@ -51,17 +51,17 @@
             <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>libutil</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>runtime</artifactId>
             <version>${project.version}</version>
         </dependency>
@@ -71,12 +71,12 @@
             <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>websocket-tck</artifactId>
             <version>10.0.0-SNAPSHOT</version>
         </dependency>
@@ -155,7 +155,7 @@
                         <configuration>
                             <artifactItems>
                                 <artifactItem>
-                                    <groupId>jakartatck</groupId>
+                                    <groupId>jakarta.tck</groupId>
                                     <artifactId>libutil</artifactId>
                                     <type>jar</type>
                                     <overWrite>false</overWrite>
@@ -348,7 +348,7 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/tyrus-container-grizzly-client.jar</additionalClasspathElement>
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/tyrus-spi.jar</additionalClasspathElement>
                             </additionalClasspathElements>
-                            <dependenciesToScan>jakartatck:websocket-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:websocket-tck</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>

--- a/glassfish-runner/websocket-tck/pom.xml
+++ b/glassfish-runner/websocket-tck/pom.xml
@@ -50,12 +50,12 @@
             <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>websocket-tck</artifactId>
             <version>10.0.0-SNAPSHOT</version>
         </dependency>
@@ -306,7 +306,7 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/tyrus-container-grizzly-client.jar</additionalClasspathElement>
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/tyrus-spi.jar</additionalClasspathElement>
                             </additionalClasspathElements>
-                            <dependenciesToScan>jakartatck:websocket-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:websocket-tck</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>

--- a/glassfishtck/pom.xml
+++ b/glassfishtck/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>jakartatck</groupId>
+    <groupId>jakarta.tck</groupId>
     <artifactId>project</artifactId>
     <version>10.0.0-SNAPSHOT</version>
   </parent>

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/internal/pom.xml
+++ b/internal/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>jakartatck</groupId>
+    <groupId>jakarta.tck</groupId>
     <artifactId>project</artifactId>
     <version>10.0.0-SNAPSHOT</version>
   </parent>

--- a/jacc/pom.xml
+++ b/jacc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/javaee/pom.xml
+++ b/javaee/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/javamail/pom.xml
+++ b/javamail/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>
@@ -97,7 +97,7 @@
         </dependency>
 
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>libutil</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/jaxws-common/pom.xml
+++ b/jaxws-common/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jaxws/pom.xml
+++ b/jaxws/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jdbc/pom.xml
+++ b/jdbc/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jms/pom.xml
+++ b/jms/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jpa_extras/pom.xml
+++ b/jpa_extras/pom.xml
@@ -20,7 +20,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jsonp/pom.xml
+++ b/jsonp/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jsp/pom.xml
+++ b/jsp/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jstl/pom.xml
+++ b/jstl/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jta/pom.xml
+++ b/jta/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jws-common/pom.xml
+++ b/jws-common/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/jws/pom.xml
+++ b/jws/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/libutil/pom.xml
+++ b/libutil/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <version>1.0.7</version>
     </parent>
 
-    <groupId>jakartatck</groupId>
+    <groupId>jakarta.tck</groupId>
     <artifactId>project</artifactId>
     <version>10.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/saaj/pom.xml
+++ b/saaj/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/signaturetest/pom.xml
+++ b/signaturetest/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>

--- a/webartifacts/jsf/pom.xml
+++ b/webartifacts/jsf/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/webartifacts/jsp/pom.xml
+++ b/webartifacts/jsp/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/webartifacts/jstl/pom.xml
+++ b/webartifacts/jstl/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/webartifacts/servlet/pom.xml
+++ b/webartifacts/servlet/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>

--- a/webservices12/pom.xml
+++ b/webservices12/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>jakartatck</groupId>
+    <groupId>jakarta.tck</groupId>
     <artifactId>project</artifactId>
     <version>10.0.0-SNAPSHOT</version>
   </parent>

--- a/webservices13/pom.xml
+++ b/webservices13/pom.xml
@@ -23,7 +23,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
-    <groupId>jakartatck</groupId>
+    <groupId>jakarta.tck</groupId>
     <artifactId>project</artifactId>
     <version>10.0.0-SNAPSHOT</version>
   </parent>

--- a/websocket/pom.xml
+++ b/websocket/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>
@@ -69,7 +69,7 @@
             <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/xa/pom.xml
+++ b/xa/pom.xml
@@ -21,7 +21,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakartatck</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
         <version>10.0.0-SNAPSHOT</version>
     </parent>


### PR DESCRIPTION
As per discussion on mailing list and Platform TCK call today (February 7, 2024) we should use `jakarta.tck` as the groupId for Platform TCKs.  

