### PR TITLE
Fix jakartaee/persistence#579, wrong query result type

### DIFF
--- a/src/com/sun/ts/tests/jpa/core/criteriaapi/From/Client.java
+++ b/src/com/sun/ts/tests/jpa/core/criteriaapi/From/Client.java
@@ -1516,7 +1516,7 @@ public class Client extends Util {
 
       getEntityTransaction().begin();
 
-      CriteriaQuery cquery = cbuilder.createQuery(Expression.class);
+      CriteriaQuery cquery = cbuilder.createQuery(Employee.class);
       From<Department, Department> department = cquery.from(Department.class);
       cquery.where(cbuilder.equal(department.get("id"), 1));
       cquery.select(department.get(Department_.lastNameEmployees));
@@ -1577,7 +1577,7 @@ public class Client extends Util {
 
       getEntityTransaction().begin();
 
-      CriteriaQuery cquery = cbuilder.createQuery(Expression.class);
+      CriteriaQuery cquery = cbuilder.createQuery(Employee.class);
       Path<Department> department = cquery.from(Department.class);
       cquery.where(cbuilder.equal(department.get("id"), 1));
       cquery.select(department.get(Department_.lastNameEmployees));


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/persistence/issues/579

**Describe the change**
Fixes the result type for the `CriteriaQuery` to be compatible with the selected result.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
