### PR TITLE
EL TCK : Removed usage of lib.util and common modules, updated sigtest plugin

### DIFF
--- a/el/pom.xml
+++ b/el/pom.xml
@@ -69,9 +69,9 @@
             <scope>compile</scope>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
+            <version>2.1</version>
         </dependency>
 
     </dependencies>
@@ -167,9 +167,9 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.netbeans.tools</groupId>
+                        <groupId>jakarta.tck</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
-                        <version>1.4</version>
+                        <version>2.1</version>
                         <configuration>
                             <FileName>${project.build.directory}/jakarta.el.sig_${project.parent.version}</FileName>
                             <packages>jakarta.el</packages>

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -40,21 +40,6 @@
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>libutil</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>runtime</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>common</artifactId>
-            <version>${project.parent.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>signaturetest</artifactId>
             <version>${project.parent.version}</version>
         </dependency>

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/arrayelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/arrayelresolver/ELClientIT.java
@@ -21,8 +21,8 @@
 
 package com.sun.ts.tests.el.api.jakarta_el.arrayelresolver;
 
-import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 
@@ -260,7 +260,7 @@ public class ELClientIT {
 
       if (value != null) {
         pass = false;
-        buf.append("Expected Value: 'null'").append(TestUtil.NEW_LINE)
+        buf.append("Expected Value: 'null'").append(ELTestUtil.NL)
             .append("Received Value: ").append(value.toString());
       }
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/beanelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/beanelresolver/ELClientIT.java
@@ -17,8 +17,8 @@
 
 package com.sun.ts.tests.el.api.jakarta_el.beanelresolver;
 
-import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.util.SimpleBean;
@@ -118,8 +118,8 @@ public class ELClientIT {
     } catch (Exception ex) {
       pass = false;
       logger.log(Logger.Level.ERROR, "Test of a valid expression using a Bean with a read-only " +
-          "property implemented via default methods threw an Exception!" + TestUtil.NEW_LINE +
-          "Received: " + ex.toString() + TestUtil.NEW_LINE);
+          "property implemented via default methods threw an Exception!" + ELTestUtil.NL +
+          "Received: " + ex.toString() + ELTestUtil.NL);
 
       ex.printStackTrace();
     }
@@ -156,8 +156,8 @@ public class ELClientIT {
     } catch (Exception ex) {
       pass = false;
       logger.log(Logger.Level.ERROR, "Test of a valid expression using a Bean with a read-write " +
-          "property implemented via default methods threw an Exception!" + TestUtil.NEW_LINE +
-          "Received: " + ex.toString() + TestUtil.NEW_LINE);
+          "property implemented via default methods threw an Exception!" + ELTestUtil.NL +
+          "Received: " + ex.toString() + ELTestUtil.NL);
 
       ex.printStackTrace();
     }
@@ -231,8 +231,8 @@ public class ELClientIT {
             context, beanResolver, sb, "isName", types, values, Boolean.FALSE, buf);
       } else {
         pass = false;
-        buf.append("Unexpected Value returned!" + TestUtil.NEW_LINE
-            + "Expected: null" + TestUtil.NEW_LINE + "Recieved: "
+        buf.append("Unexpected Value returned!" + ELTestUtil.NL
+            + "Expected: null" + ELTestUtil.NL + "Recieved: "
             + result.getClass().getName());
       }
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/beannameelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/beannameelresolver/ELClientIT.java
@@ -24,7 +24,7 @@ package com.sun.ts.tests.el.api.jakarta_el.beannameelresolver;
 import java.util.Properties;
 
 
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.util.SimpleBean;
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/compositeelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/compositeelresolver/ELClientIT.java
@@ -24,8 +24,8 @@ package com.sun.ts.tests.el.api.jakarta_el.compositeelresolver;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.util.SimpleBean;
@@ -166,7 +166,7 @@ public class ELClientIT {
 
       compResolver.add(null);
 
-      buf.append(TestUtil.NEW_LINE + "Tested Failed, CompositeResolver.add(), "
+      buf.append(ELTestUtil.NL + "Tested Failed, CompositeResolver.add(), "
           + "should have thrown NullPointerException!");
       pass = false;
 
@@ -175,9 +175,9 @@ public class ELClientIT {
           + " null resolver to Composite.add()");
 
     } catch (Exception e) {
-      buf.append("test failed with: " + TestUtil.NEW_LINE + "EXPECTED: "
-          + "NullPointerException to be thrown " + TestUtil.NEW_LINE
-          + "RECEIVED: " + e.toString() + "" + TestUtil.NEW_LINE);
+      buf.append("test failed with: " + ELTestUtil.NL + "EXPECTED: "
+          + "NullPointerException to be thrown " + ELTestUtil.NL
+          + "RECEIVED: " + e.toString() + "" + ELTestUtil.NL);
       pass = false;
     }
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/elcontext/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/elcontext/ELClientIT.java
@@ -26,7 +26,7 @@ import java.util.Locale;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
+
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 
 import jakarta.el.ELContext;
@@ -79,7 +79,7 @@ public class ELClientIT {
 
     if (!testStr.equals(result)) {
       throw new Exception(ELTestUtil.FAIL + " Unexpected Context Returned!"
-          + TestUtil.NEW_LINE + "Expected: " + testStr + TestUtil.NEW_LINE
+          + ELTestUtil.NL + "Expected: " + testStr + ELTestUtil.NL
           + "Received: " + result);
     }
 
@@ -105,7 +105,7 @@ public class ELClientIT {
 
     if (!result.equalsIgnoreCase(disName)) {
       throw new Exception(ELTestUtil.FAIL + " Unexpected Locale Returned!"
-          + TestUtil.NEW_LINE + "Expected: " + disName + TestUtil.NEW_LINE
+          + ELTestUtil.NL + "Expected: " + disName + ELTestUtil.NL
           + "Received: " + result);
     }
 
@@ -130,7 +130,7 @@ public class ELClientIT {
     if (isProp) {
       throw new Exception(
           ELTestUtil.FAIL + " Unexpected result from isPropertyResolved()!"
-              + TestUtil.NEW_LINE + "Should have been false!");
+              + ELTestUtil.NL + "Should have been false!");
     }
 
     elc.setPropertyResolved(true);
@@ -139,7 +139,7 @@ public class ELClientIT {
     if (!isProp) {
       throw new Exception(
           ELTestUtil.FAIL + " Unexpected result from isPropertyResolved()!"
-              + TestUtil.NEW_LINE + "Should have been true!");
+              + ELTestUtil.NL + "Should have been true!");
     }
 
   } // end elContextIsSetPropertyResolvedTest

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/elresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/elresolver/ELClientIT.java
@@ -24,7 +24,7 @@ package com.sun.ts.tests.el.api.jakarta_el.elresolver;
 import java.util.Properties;
 
 
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.elcontext.BarELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.util.SimpleBean;

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/expression/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/expression/ELClientIT.java
@@ -24,8 +24,8 @@ package com.sun.ts.tests.el.api.jakarta_el.expression;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.common.el.api.expression.ExpressionTest;
+
+import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
 import com.sun.ts.tests.el.common.elcontext.SimpleELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.util.ResolverType;
@@ -91,7 +91,7 @@ public class ELClientIT {
 
       if (ExpressionTest.equalsTest(vexp1, null, buf)) {
         pass = false;
-        buf.append("ValueExpression tested equal to null" + TestUtil.NEW_LINE);
+        buf.append("ValueExpression tested equal to null" + ELTestUtil.NL);
       }
 
       MethodExpression mexp1 = expFactory.createMethodExpression(context,
@@ -99,7 +99,7 @@ public class ELClientIT {
 
       if (ExpressionTest.equalsTest(mexp1, null, buf)) {
         pass = false;
-        buf.append("MethodExpression tested equal to null" + TestUtil.NEW_LINE);
+        buf.append("MethodExpression tested equal to null" + ELTestUtil.NL);
       }
 
       // compare ValueExpressions to MethodExpressions
@@ -112,13 +112,13 @@ public class ELClientIT {
       if (ExpressionTest.equalsTest(vexp2, mexp2, buf)) {
         pass = false;
         buf.append("ValueExpression tested equal to " + "MethodExpression"
-            + TestUtil.NEW_LINE);
+            + ELTestUtil.NL);
       }
 
       if (ExpressionTest.equalsTest(mexp2, vexp2, buf)) {
         pass = false;
         buf.append("MethodExpression tested equal to " + "ValueExpression"
-            + TestUtil.NEW_LINE);
+            + ELTestUtil.NL);
       }
 
     } catch (Exception ex) {

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/expressionfactory/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/expressionfactory/ELClientIT.java
@@ -24,7 +24,7 @@ package com.sun.ts.tests.el.api.jakarta_el.expressionfactory;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
+
 import com.sun.ts.tests.el.common.elcontext.SimpleELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.util.ExprEval;
@@ -131,12 +131,12 @@ public class ELClientIT {
         } catch (NullPointerException npe) {
           pass = false;
           logger.log(Logger.Level.ERROR, ELTestUtil.FAIL + exprStr[i]);
-          TestUtil.printStackTrace(npe);
+          ELTestUtil.printStackTrace(npe);
           continue;
         } catch (ELException ee) {
           pass = false;
           logger.log(Logger.Level.ERROR, ELTestUtil.FAIL + exprStr[i]);
-          TestUtil.printStackTrace(ee);
+          ELTestUtil.printStackTrace(ee);
           continue;
         }
 
@@ -187,7 +187,7 @@ public class ELClientIT {
       } catch (Exception e) {
         pass = false;
         logger.log(Logger.Level.ERROR, "Exception: Test Case " + i);
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
       }
     }
 
@@ -245,7 +245,7 @@ public class ELClientIT {
         } catch (NullPointerException npe) {
           pass = false;
           logger.log(Logger.Level.ERROR, ELTestUtil.FAIL + exprStr[i]);
-          TestUtil.printStackTrace(npe);
+          ELTestUtil.printStackTrace(npe);
           continue;
         }
         pass = false;
@@ -300,12 +300,12 @@ public class ELClientIT {
         } catch (NullPointerException npe) {
           pass = false;
           logger.log(Logger.Level.ERROR, ELTestUtil.FAIL + exprStr[i]);
-          TestUtil.printStackTrace(npe);
+          ELTestUtil.printStackTrace(npe);
           continue;
         } catch (ELException ee) {
           pass = false;
           logger.log(Logger.Level.ERROR, ELTestUtil.FAIL + exprStr[i]);
-          TestUtil.printStackTrace(ee);
+          ELTestUtil.printStackTrace(ee);
           continue;
         }
 
@@ -377,13 +377,12 @@ public class ELClientIT {
         } catch (NullPointerException npe) {
           pass = false;
           logger.log(Logger.Level.ERROR, ELTestUtil.FAIL + exprStr[i]);
-          TestUtil.printStackTrace(npe);
+          ELTestUtil.printStackTrace(npe);
           continue;
         }
         pass = false;
         logger.log(Logger.Level.ERROR, "Failed. No ELException thrown when calling");
-        TestUtil
-            .logErr("createMethodExpression() with parameter " + exprStr[i]);
+        logger.log(Logger.Level.ERROR, "createMethodExpression() with parameter " + exprStr[i]);
       }
 
     } catch (Exception ex) {
@@ -474,7 +473,7 @@ public class ELClientIT {
       } catch (Exception e) {
         pass = false;
         logger.log(Logger.Level.ERROR, "Exception: Test Case " + i);
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
       }
     }
 
@@ -517,7 +516,7 @@ public class ELClientIT {
         pass = false;
         logger.log(Logger.Level.ERROR, "Test Case " + i + " threw an exception");
         logger.log(Logger.Level.ERROR, "but it was not an ELException");
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
       }
     }
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/functionmapper/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/functionmapper/ELClientIT.java
@@ -25,7 +25,7 @@ import java.lang.reflect.Method;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.elcontext.FuncMapperELContext;
 
 import jakarta.el.FunctionMapper;
@@ -78,10 +78,10 @@ public class ELClientIT {
 
     if (funcMapper.resolveFunction("foo", "bar") != null) {
       logger.log(Logger.Level.ERROR, "Expected call to resolveFunction() to unassigned "
-          + "function to return null" + TestUtil.NEW_LINE
+          + "function to return null" + ELTestUtil.NL
           + "Instead call returned: "
           + funcMapper.resolveFunction("foo", "bar").getName()
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL);
 
       throw new Exception("Resolved unassigned function");
     }
@@ -89,15 +89,15 @@ public class ELClientIT {
     Method method = funcMapper.resolveFunction("Int", "val");
     if (method == null) {
       logger.log(Logger.Level.ERROR, "Expected call to resolveFunction() to resolvable "
-          + "function to return a non-null value" + TestUtil.NEW_LINE);
+          + "function to return a non-null value" + ELTestUtil.NL);
 
       throw new Exception("Incorrect resolution: null method");
     } else {
       String methodSignature = method.toString();
       if (!methodSignature.equals(expected)) {
         logger.log(Logger.Level.ERROR, "Method Signature of resolved function is " + "invalid"
-            + TestUtil.NEW_LINE + "Expected value:" + expected
-            + TestUtil.NEW_LINE);
+            + ELTestUtil.NL + "Expected value:" + expected
+            + ELTestUtil.NL);
 
         throw new Exception("Incorrect resolution: wrong method Signature");
       }

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/listelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/listelresolver/ELClientIT.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Properties;
 
 
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/mapelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/mapelresolver/ELClientIT.java
@@ -25,7 +25,7 @@ import java.util.HashMap;
 import java.util.Properties;
 
 
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/methodexpression/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/methodexpression/ELClientIT.java
@@ -24,7 +24,7 @@ package com.sun.ts.tests.el.api.jakarta_el.methodexpression;
 import java.util.Properties;
 
 
-import com.sun.ts.tests.common.el.api.expression.ExpressionTest;
+import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
 import com.sun.ts.tests.el.common.elcontext.SimpleELContext;
 import com.sun.ts.tests.el.common.elcontext.VarMapperELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/methodinfo/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/methodinfo/ELClientIT.java
@@ -24,7 +24,7 @@ package com.sun.ts.tests.el.api.jakarta_el.methodinfo;
 import java.util.Properties;
 
 
-import com.sun.ts.tests.common.el.api.expression.ExpressionTest;
+import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
 import com.sun.ts.tests.el.common.elcontext.SimpleELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.util.ResolverType;

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/methodreference/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/methodreference/ELClientIT.java
@@ -17,9 +17,9 @@ package com.sun.ts.tests.el.api.jakarta_el.methodreference;
 
 import java.util.Properties;
 
-import com.sun.ts.lib.util.TestUtil;
+
 import com.sun.ts.tests.el.common.util.Fault;
-import com.sun.ts.tests.common.el.api.expression.ExpressionTest;
+import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
 import com.sun.ts.tests.el.common.elcontext.VarMapperELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.util.MethodsBean;
@@ -133,8 +133,8 @@ public class ELClientIT {
       }
       
     } catch (Exception ex) {
-      logger.log(Logger.Level.ERROR, "Test getMethodReference threw an Exception!" + TestUtil.NEW_LINE +
-          "Received: " + ex.toString() + TestUtil.NEW_LINE);
+      logger.log(Logger.Level.ERROR, "Test getMethodReference threw an Exception!" + ELTestUtil.NL +
+          "Received: " + ex.toString() + ELTestUtil.NL);
       ex.printStackTrace();
       throw new Fault(ex);
     }

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/recordelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/recordelresolver/ELClientIT.java
@@ -22,7 +22,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInfo;
 
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/resourcebundleelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/resourcebundleelresolver/ELClientIT.java
@@ -28,7 +28,7 @@ import java.util.ResourceBundle;
 import java.util.StringTokenizer;
 
 
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/staticfieldelresolver/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/staticfieldelresolver/ELClientIT.java
@@ -25,8 +25,8 @@ import java.util.Iterator;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.common.el.api.resolver.ResolverTest;
+
+import com.sun.ts.tests.el.common.api.resolver.ResolverTest;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 
 import jakarta.el.ELClass;
@@ -93,36 +93,36 @@ public class ELClientIT {
     context.setPropertyResolved(false);
     try {
       resolver.setValue(context, base, property, value);
-      buf.append(ELTestUtil.FAIL + TestUtil.NEW_LINE
+      buf.append(ELTestUtil.FAIL + ELTestUtil.NL
           + "Expected PropertyNotWritableException to be "
-          + "thrown when calling setValue()!" + TestUtil.NEW_LINE
-          + "No exception was thown!" + TestUtil.NEW_LINE);
+          + "thrown when calling setValue()!" + ELTestUtil.NL
+          + "No exception was thown!" + ELTestUtil.NL);
       pass = false;
 
     } catch (PropertyNotWritableException pnwe) {
-      buf.append(ELTestUtil.PASS + TestUtil.NEW_LINE
+      buf.append(ELTestUtil.PASS + ELTestUtil.NL
           + "PropertyNotWritableException Thrown as expected for "
-          + "setValue()!" + TestUtil.NEW_LINE);
+          + "setValue()!" + ELTestUtil.NL);
     } catch (Exception e) {
-      buf.append(ELTestUtil.FAIL + TestUtil.NEW_LINE
-          + "Wrong Exception Thrownfor setValue()!" + TestUtil.NEW_LINE
-          + "Expected: PropertyNotWritableException" + TestUtil.NEW_LINE
-          + "Received: " + e.getClass().getSimpleName() + TestUtil.NEW_LINE);
+      buf.append(ELTestUtil.FAIL + ELTestUtil.NL
+          + "Wrong Exception Thrownfor setValue()!" + ELTestUtil.NL
+          + "Expected: PropertyNotWritableException" + ELTestUtil.NL
+          + "Received: " + e.getClass().getSimpleName() + ELTestUtil.NL);
     }
 
     // getValue()
     context.setPropertyResolved(false);
     Object valueRetrieved = resolver.getValue(context, base, property);
     if (!context.isPropertyResolved()) {
-      buf.append("getValue() did not resolve" + TestUtil.NEW_LINE);
+      buf.append("getValue() did not resolve" + ELTestUtil.NL);
       pass = false;
     }
 
     if (valueRetrieved != value) {
-      buf.append("Invalid value from getValue():" + TestUtil.NEW_LINE
-          + "Value expected: " + value.toString() + TestUtil.NEW_LINE
+      buf.append("Invalid value from getValue():" + ELTestUtil.NL
+          + "Value expected: " + value.toString() + ELTestUtil.NL
           + "Value retrieved: " + valueRetrieved.toString()
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL);
       pass = false;
     }
 
@@ -130,30 +130,30 @@ public class ELClientIT {
     context.setPropertyResolved(false);
     Class<?> type = resolver.getType(context, base, property);
     if (!context.isPropertyResolved()) {
-      buf.append("getType() did not resolve" + TestUtil.NEW_LINE);
+      buf.append("getType() did not resolve" + ELTestUtil.NL);
       pass = false;
     } else if (type != null) {
-      buf.append("getType() returns " + type.getName() + " rather than null" + TestUtil.NEW_LINE);
+      buf.append("getType() returns " + type.getName() + " rather than null" + ELTestUtil.NL);
       pass = false;
     } else {
-      buf.append("getType() returns null" + TestUtil.NEW_LINE + "as expected." + TestUtil.NEW_LINE);
+      buf.append("getType() returns null" + ELTestUtil.NL + "as expected." + ELTestUtil.NL);
     }
 
     // isReadOnly
     context.setPropertyResolved(false);
     boolean nonWritable = resolver.isReadOnly(context, base, property);
     if (!context.isPropertyResolved()) {
-      buf.append("isReadOnly() did not resolve" + TestUtil.NEW_LINE);
+      buf.append("isReadOnly() did not resolve" + ELTestUtil.NL);
       pass = false;
 
     } else if (!nonWritable) {
-      buf.append("isReadOnly() returned unexpected value: " + TestUtil.NEW_LINE
-          + "Expected: false" + TestUtil.NEW_LINE + "Received: " + nonWritable
-          + TestUtil.NEW_LINE);
+      buf.append("isReadOnly() returned unexpected value: " + ELTestUtil.NL
+          + "Expected: false" + ELTestUtil.NL + "Received: " + nonWritable
+          + ELTestUtil.NL);
       pass = false;
 
     } else {
-      buf.append("isReadOnly() returns false as expected" + TestUtil.NEW_LINE);
+      buf.append("isReadOnly() returns false as expected" + ELTestUtil.NL);
     }
 
     // getCommonPropertyType()
@@ -161,18 +161,18 @@ public class ELClientIT {
     Class<?> commonPropertyType = (resolver.getCommonPropertyType(context,
         base));
     buf.append("getCommonPropertyType() returns " + commonPropertyType.getName()
-        + TestUtil.NEW_LINE);
+        + ELTestUtil.NL);
 
     // getFeatureDescriptors() commenting below as the method is deprecated in EL 6.0
     // context.setPropertyResolved(false);
     // Iterator<?> i = resolver.getFeatureDescriptors(context, base);
 
     // if (i == null) {
-    //   buf.append("getFeatureDescriptors() returns null" + TestUtil.NEW_LINE);
+    //   buf.append("getFeatureDescriptors() returns null" + ELTestUtil.NL);
     // }
 
     if (!pass) {
-      throw new Exception(ELTestUtil.FAIL + TestUtil.NEW_LINE + buf.toString());
+      throw new Exception(ELTestUtil.FAIL + ELTestUtil.NL + buf.toString());
     }
 
   } // End staticFieldELResolverTest
@@ -327,32 +327,32 @@ public class ELClientIT {
     try {
       resolver.getType(context, base, property);
       buf.append(ELTestUtil.FAIL + " getType() did not throw any exception."
-          + TestUtil.NEW_LINE + "Expected: PropertyNotFoundException "
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL + "Expected: PropertyNotFoundException "
+          + ELTestUtil.NL);
 
     } catch (PropertyNotFoundException pnfe) {
       buf.append(ELTestUtil.PASS);
 
     } catch (Exception e) {
       buf.append(ELTestUtil.FAIL + "Wrong Exception thrown for getType()!"
-          + TestUtil.NEW_LINE + " Expected: PropertyNotFoundException"
-          + TestUtil.NEW_LINE + "Received: " + e.getClass().getSimpleName());
+          + ELTestUtil.NL + " Expected: PropertyNotFoundException"
+          + ELTestUtil.NL + "Received: " + e.getClass().getSimpleName());
     }
 
     // getValue()
     try {
       resolver.getValue(context, base, property);
       buf.append(ELTestUtil.FAIL + " getValue() did not throw any exception."
-          + TestUtil.NEW_LINE + "Expected: PropertyNotFoundException "
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL + "Expected: PropertyNotFoundException "
+          + ELTestUtil.NL);
 
     } catch (PropertyNotFoundException pnfe) {
       buf.append(ELTestUtil.PASS);
 
     } catch (Exception e) {
       buf.append(ELTestUtil.FAIL + "Wrong Exception thrown getValue()!"
-          + TestUtil.NEW_LINE + " Expected: PropertyNotFoundException"
-          + TestUtil.NEW_LINE + "Received: " + e.getClass().getSimpleName());
+          + ELTestUtil.NL + " Expected: PropertyNotFoundException"
+          + ELTestUtil.NL + "Received: " + e.getClass().getSimpleName());
     }
 
   }// End testForPNFE

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/valueexpression/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/valueexpression/ELClientIT.java
@@ -22,8 +22,8 @@ import java.util.Hashtable;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.common.el.api.expression.ExpressionTest;
+
+import com.sun.ts.tests.el.common.api.expression.ExpressionTest;
 import com.sun.ts.tests.el.common.elcontext.BareBonesELContext;
 import com.sun.ts.tests.el.common.elcontext.SimpleELContext;
 import com.sun.ts.tests.el.common.elcontext.VRContext;
@@ -98,7 +98,7 @@ public class ELClientIT {
 
       // string variable
       // readOTestUtil.NEW_LINEy() and isLiteralText() expected to return false
-      buf.append("Testing expression 1 " + TestUtil.NEW_LINE);
+      buf.append("Testing expression 1 " + ELTestUtil.NL);
       String exprStr1 = "${foo}";
       ValueExpression vexp1 = expFactory.createValueExpression(context,
           exprStr1, String.class);
@@ -107,7 +107,7 @@ public class ELClientIT {
 
       // literal expression
       // readOTestUtil.NEW_LINEy() and isLiteralText() expected to return true
-      buf.append("Testing expression 2 " + TestUtil.NEW_LINE);
+      buf.append("Testing expression 2 " + ELTestUtil.NL);
       String exprStr2 = "foo";
       ValueExpression vexp2 = expFactory.createValueExpression(context,
           exprStr2, String.class);
@@ -117,7 +117,7 @@ public class ELClientIT {
       // expression that is not an l-value
       // readOTestUtil.NEW_LINEy() expected to return true
       // isLiteralText() expected to return false
-      buf.append("Testing expression 3 " + TestUtil.NEW_LINE);
+      buf.append("Testing expression 3 " + ELTestUtil.NL);
       String exprStr3 = "#{1 + 1}";
       ValueExpression vexp3 = expFactory.createValueExpression(context,
           exprStr3, Integer.class);
@@ -125,7 +125,7 @@ public class ELClientIT {
           Integer.class, Integer.valueOf(2), true, false, buf);
 
       // Expression test for ValueReference.
-      buf.append("Testing expression 4 " + TestUtil.NEW_LINE);
+      buf.append("Testing expression 4 " + ELTestUtil.NL);
       pass4 = true;
 
       ELContext contextTwo = new VRContext(testProps);
@@ -145,8 +145,8 @@ public class ELClientIT {
         if (base != null) {
           String baseName = base.getClass().getSimpleName();
           if (!"Worker".equals(baseName)) {
-            buf.append("Unexpected Base Value!" + TestUtil.NEW_LINE
-                + "Expected: Worker" + TestUtil.NEW_LINE + "Received: "
+            buf.append("Unexpected Base Value!" + ELTestUtil.NL
+                + "Expected: Worker" + ELTestUtil.NL + "Received: "
                 + baseName);
             pass4 = false;
           }
@@ -209,8 +209,8 @@ public class ELClientIT {
       vexp.getValue(null);
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to getValue() with null ELContext parameter "
-          + "did not" + TestUtil.NEW_LINE + " cause an exception to be thrown"
-          + TestUtil.NEW_LINE);
+          + "did not" + ELTestUtil.NL + " cause an exception to be thrown"
+          + ELTestUtil.NL);
 
     } catch (NullPointerException npe) {
       pass = true;
@@ -219,16 +219,16 @@ public class ELClientIT {
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to getValue() with null ELContext "
           + "parameter caused an exception to be thrown, but it was not a"
-          + TestUtil.NEW_LINE + " NullPointerException: " + e.toString()
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL + " NullPointerException: " + e.toString()
+          + ELTestUtil.NL);
     }
 
     try {
       vexp.setValue(null, "foo");
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to setValue() with null ELContext parameter "
-          + "did not" + TestUtil.NEW_LINE + " cause an exception to be thrown"
-          + TestUtil.NEW_LINE);
+          + "did not" + ELTestUtil.NL + " cause an exception to be thrown"
+          + ELTestUtil.NL);
 
     } catch (NullPointerException npe) {
       pass = true;
@@ -236,17 +236,17 @@ public class ELClientIT {
     } catch (Exception e) {
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to setValue() with null ELContext "
-          + "parameter caused" + TestUtil.NEW_LINE
-          + " an exception to be thrown, but it was not a" + TestUtil.NEW_LINE
-          + " NullPointerException: " + e.toString() + TestUtil.NEW_LINE);
+          + "parameter caused" + ELTestUtil.NL
+          + " an exception to be thrown, but it was not a" + ELTestUtil.NL
+          + " NullPointerException: " + e.toString() + ELTestUtil.NL);
     }
 
     try {
       vexp.isReadOnly(null);
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to isReadOTestUtil.NEW_LINEy() with null ELContext "
-          + "parameter did not" + TestUtil.NEW_LINE
-          + " cause an exception to be thrown" + TestUtil.NEW_LINE);
+          + "parameter did not" + ELTestUtil.NL
+          + " cause an exception to be thrown" + ELTestUtil.NL);
 
     } catch (NullPointerException npe) {
       pass = true;
@@ -254,17 +254,17 @@ public class ELClientIT {
     } catch (Exception e) {
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to isReadOTestUtil.NEW_LINEy() with null ELContext "
-          + "parameter caused" + TestUtil.NEW_LINE
-          + "an exception to be thrown, but it was not a" + TestUtil.NEW_LINE
-          + "NullPointerException: " + e.toString() + TestUtil.NEW_LINE);
+          + "parameter caused" + ELTestUtil.NL
+          + "an exception to be thrown, but it was not a" + ELTestUtil.NL
+          + "NullPointerException: " + e.toString() + ELTestUtil.NL);
     }
 
     try {
       vexp.getType(null);
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to getType() with null ELContext parameter "
-          + "did not" + TestUtil.NEW_LINE + "cause an exception to be thrown"
-          + TestUtil.NEW_LINE);
+          + "did not" + ELTestUtil.NL + "cause an exception to be thrown"
+          + ELTestUtil.NL);
 
     } catch (NullPointerException npe) {
       pass = true;
@@ -272,9 +272,9 @@ public class ELClientIT {
     } catch (Exception e) {
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to getType() with null ELContext parameter "
-          + "caused" + TestUtil.NEW_LINE
-          + "an exception to be thrown, but it was not a" + TestUtil.NEW_LINE
-          + "NullPointerException: " + e.toString() + TestUtil.NEW_LINE);
+          + "caused" + ELTestUtil.NL
+          + "an exception to be thrown, but it was not a" + ELTestUtil.NL
+          + "NullPointerException: " + e.toString() + ELTestUtil.NL);
     }
 
     // PropertyNotFoundException
@@ -282,8 +282,8 @@ public class ELClientIT {
       vexp.setValue(emptyContext, "foo");
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to setValue() for non-existent property did "
-          + "not cause" + TestUtil.NEW_LINE + "an exception to be thrown"
-          + TestUtil.NEW_LINE);
+          + "not cause" + ELTestUtil.NL + "an exception to be thrown"
+          + ELTestUtil.NL);
 
     } catch (PropertyNotFoundException pnfe) {
       pass = true;
@@ -292,15 +292,15 @@ public class ELClientIT {
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to setValue() for non-existent property "
           + "caused an exception to be thrown, but it was not a"
-          + TestUtil.NEW_LINE + "PropertyNotFoundException: " + e.toString()
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL + "PropertyNotFoundException: " + e.toString()
+          + ELTestUtil.NL);
     }
 
     try {
       vexp.getValue(emptyContext);
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to getValue() for non-existent property did "
-          + "not cause an exception to be thrown" + TestUtil.NEW_LINE);
+          + "not cause an exception to be thrown" + ELTestUtil.NL);
 
     } catch (PropertyNotFoundException pnfe) {
       pass = true;
@@ -309,7 +309,7 @@ public class ELClientIT {
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to getValue() for non-existent property "
           + "caused an exception to be thrown, but it was not a PropertyNotFoundException: "
-          + TestUtil.NEW_LINE + e.toString() + TestUtil.NEW_LINE);
+          + ELTestUtil.NL + e.toString() + ELTestUtil.NL);
     }
 
     try {
@@ -317,7 +317,7 @@ public class ELClientIT {
       pass = false;
       logger.log(Logger.Level.ERROR, 
           "Call to isReadOTestUtil.NEW_LINEy() for non-existent property did "
-              + "not cause an exception to be thrown" + TestUtil.NEW_LINE);
+              + "not cause an exception to be thrown" + ELTestUtil.NL);
 
     } catch (PropertyNotFoundException pnfe) {
       pass = true;
@@ -327,15 +327,15 @@ public class ELClientIT {
       logger.log(Logger.Level.ERROR, 
           "Call to isReadOTestUtil.NEW_LINEy() for non-existent property "
               + "caused an exception to be thrown, but it was not a"
-              + " PropertyNotFoundException: " + TestUtil.NEW_LINE
-              + e.toString() + TestUtil.NEW_LINE);
+              + " PropertyNotFoundException: " + ELTestUtil.NL
+              + e.toString() + ELTestUtil.NL);
     }
 
     try {
       vexp.getType(emptyContext);
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to getType() for non-existent property did not "
-          + "cause an exception to be thrown" + TestUtil.NEW_LINE);
+          + "cause an exception to be thrown" + ELTestUtil.NL);
 
     } catch (PropertyNotFoundException pnfe) {
       pass = true;
@@ -344,8 +344,8 @@ public class ELClientIT {
       pass = false;
       logger.log(Logger.Level.ERROR, "Call to getType() for non-existent property "
           + "caused an exception to be thrown, but it was not a"
-          + TestUtil.NEW_LINE + " PropertyNotFoundException: " + e.toString()
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL + " PropertyNotFoundException: " + e.toString()
+          + ELTestUtil.NL);
     }
 
     if (!pass) {
@@ -385,19 +385,19 @@ public class ELClientIT {
         ValueExpression evalvexp = expFactory.createValueExpression(context,
             "${" + testValue + "}", testClass);
         logger.log(Logger.Level.TRACE, "Eval Value Expression For Testing: "
-            + evalvexp.toString() + TestUtil.NEW_LINE);
+            + evalvexp.toString() + ELTestUtil.NL);
 
         // Set literal-expression
         ValueExpression literalvexp = expFactory.createValueExpression(context,
             "\"" + testValue + "\"", testClass);
         logger.log(Logger.Level.TRACE, "Literal Value Expression For Testing: "
-            + literalvexp.toString() + TestUtil.NEW_LINE);
+            + literalvexp.toString() + ELTestUtil.NL);
 
         // Set Composite Expression
         ValueExpression compositevexp = expFactory.createValueExpression(
             context, "#{" + testValue + "}" + " " + testValue, testClass);
         logger.log(Logger.Level.TRACE, "Composite Value Expression For Testing: "
-            + compositevexp.toString() + TestUtil.NEW_LINE);
+            + compositevexp.toString() + ELTestUtil.NL);
 
         // Test eval, literal, & composite expressions.
         if (!(ExpressionTest.expressionSerializableTest(evalvexp, buf)
@@ -467,14 +467,14 @@ public class ELClientIT {
           exprStr2, String.class);
 
       buf.append("vexp1 has value " + (String) vexp1.getValue(context)
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL);
       buf.append("vexp2 has value " + (String) vexp2.getValue(context)
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL);
 
       if (ExpressionTest.equalsTest(vexp1, vexp2, buf)) {
         pass = false;
         buf.append(
-            "Failed: case 1: same type and equal value" + TestUtil.NEW_LINE);
+            "Failed: case 1: same type and equal value" + ELTestUtil.NL);
       }
 
       // case 2: White space is ignored
@@ -487,7 +487,7 @@ public class ELClientIT {
           exprStr4, Object.class);
 
       if (!ExpressionTest.equalsTest(vexp3, vexp4, buf)) {
-        buf.append("Failed: case 2: white space" + TestUtil.NEW_LINE);
+        buf.append("Failed: case 2: white space" + ELTestUtil.NL);
         pass = false;
       }
 
@@ -501,7 +501,7 @@ public class ELClientIT {
           exprStr6, Object.class);
 
       if (!ExpressionTest.equalsTest(vexp5, vexp6, buf)) {
-        buf.append("Failed: case 3: equivalent operators" + TestUtil.NEW_LINE);
+        buf.append("Failed: case 3: equivalent operators" + ELTestUtil.NL);
         pass = false;
       }
 
@@ -515,7 +515,7 @@ public class ELClientIT {
           exprStr8, Object.class);
 
       if (ExpressionTest.equalsTest(vexp7, vexp8, buf)) {
-        buf.append("Failed: case 4: reversed operands" + TestUtil.NEW_LINE);
+        buf.append("Failed: case 4: reversed operands" + ELTestUtil.NL);
         pass = false;
       }
 
@@ -529,7 +529,7 @@ public class ELClientIT {
           exprStr10, Object.class);
 
       if (!ExpressionTest.equalsTest(vexp9, vexp10, buf)) {
-        buf.append("Failed: case 5: delimiters" + TestUtil.NEW_LINE);
+        buf.append("Failed: case 5: delimiters" + ELTestUtil.NL);
         pass = false;
       }
 

--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/variablemapper/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/variablemapper/ELClientIT.java
@@ -24,7 +24,7 @@ package com.sun.ts.tests.el.api.jakarta_el.variablemapper;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
+
 import com.sun.ts.tests.el.common.elcontext.VarMapperELContext;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 
@@ -87,9 +87,9 @@ public class ELClientIT {
     if (varMapper.resolveVariable("foo") != null) {
       pass = false;
       buf.append("Expected call to resolveVariable() to unassigned "
-          + "variable to return null" + TestUtil.NEW_LINE
+          + "variable to return null" + ELTestUtil.NL
           + "Instead call returned " + varMapper.resolveVariable("foo")
-          + TestUtil.NEW_LINE);
+          + ELTestUtil.NL);
     }
 
     ValueExpression vexp1 = expFactory.createValueExpression(context, "${bar}",
@@ -99,8 +99,8 @@ public class ELClientIT {
     if (vexp2 != null) {
       pass = false;
       buf.append("Expected call to setVariable() to return null "
-          + "for previously unassigned variable" + TestUtil.NEW_LINE
-          + "Instead return value was " + vexp2 + TestUtil.NEW_LINE);
+          + "for previously unassigned variable" + ELTestUtil.NL
+          + "Instead return value was " + vexp2 + ELTestUtil.NL);
     }
 
     ValueExpression vexp3 = varMapper.resolveVariable("foo");
@@ -108,8 +108,8 @@ public class ELClientIT {
     if (!vexp3.equals(vexp1)) {
       pass = false;
       buf.append("Expected call to resolveVariable() to assigned "
-          + "variable to return " + vexp1.toString() + TestUtil.NEW_LINE
-          + "Instead call returned " + vexp3.toString() + TestUtil.NEW_LINE);
+          + "variable to return " + vexp1.toString() + ELTestUtil.NL
+          + "Instead call returned " + vexp3.toString() + ELTestUtil.NL);
     }
 
     ValueExpression vexp4 = varMapper.setVariable("foo", null);
@@ -117,8 +117,8 @@ public class ELClientIT {
     if (!vexp4.equals(vexp1)) {
       pass = false;
       buf.append("Expected call to resolveVariable() to assigned "
-          + "variable to return " + vexp1.toString() + TestUtil.NEW_LINE
-          + "Instead call returned " + vexp4.toString() + TestUtil.NEW_LINE);
+          + "variable to return " + vexp1.toString() + ELTestUtil.NL
+          + "Instead call returned " + vexp4.toString() + ELTestUtil.NL);
     }
 
     ValueExpression vexp5 = varMapper.resolveVariable("foo");
@@ -126,8 +126,8 @@ public class ELClientIT {
     if (vexp5 != null) {
       pass = false;
       buf.append("Expected call to resolveVariable() to return null"
-          + " after unassignment" + TestUtil.NEW_LINE
-          + "Instead return value was " + vexp5 + TestUtil.NEW_LINE);
+          + " after unassignment" + ELTestUtil.NL
+          + "Instead return value was " + vexp5 + ELTestUtil.NL);
     }
 
     if (!pass)

--- a/el/src/main/java/com/sun/ts/tests/el/common/api/expression/ExpressionTest.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/api/expression/ExpressionTest.java
@@ -1,0 +1,407 @@
+/*
+ * Copyright (c) 2009, 2021 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.el.common.api.expression;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.lang.annotation.Annotation;
+
+import jakarta.el.ELContext;
+import jakarta.el.Expression;
+import jakarta.el.MethodExpression;
+import jakarta.el.MethodInfo;
+import jakarta.el.MethodReference;
+import jakarta.el.PropertyNotWritableException;
+import jakarta.el.ValueExpression;
+
+public class ExpressionTest {
+
+  // Set New Line from system prop, if not defined used "\n as default."
+  private static final String NLINE = System.getProperty("line.separator",
+      "\n");
+
+  private ExpressionTest() {
+  }
+
+  public static boolean testMethodInfo(MethodInfo minfo, String expectedName,
+      Class expectedReturnType, int expectedNumParams,
+      Class[] expectedParamTypes, StringBuffer buf) {
+
+    boolean pass = true;
+    String name = minfo.getName();
+    Class returnType = minfo.getReturnType();
+    Class[] paramTypes = minfo.getParamTypes();
+    int numParams = paramTypes.length;
+
+    if (!name.equals(expectedName)) {
+      buf.append("Did not get expected method name." + NLINE);
+      buf.append("Expected name = " + expectedName + NLINE);
+      buf.append("Computed name = " + name + NLINE);
+      pass = false;
+    }
+    if (!returnType.equals(expectedReturnType)) {
+      buf.append("Did not get expected return type." + NLINE);
+      buf.append(
+          "Expected return type = " + expectedReturnType.getName() + NLINE);
+      buf.append("Computed return type = " + returnType.getName() + NLINE);
+      pass = false;
+    }
+    if (numParams != expectedNumParams) {
+      buf.append("Did not get expected number of parameters." + NLINE);
+      buf.append(
+          "Expected number of parameters = " + expectedNumParams + NLINE);
+      buf.append("Computed number of parameters = " + numParams + NLINE);
+      pass = false;
+    } else {
+      for (int i = 0; i < numParams; ++i) {
+        if (!(paramTypes[i].equals(expectedParamTypes[i]))) {
+          buf.append("Did not get expected parameter type." + NLINE);
+          buf.append("Expected parameter type = "
+              + expectedParamTypes[i].getName() + NLINE);
+          buf.append(
+              "Computed parameter type = " + paramTypes[i].getName() + NLINE);
+          pass = false;
+        }
+      }
+    }
+    return pass;
+  }
+
+  public static boolean testMethodReference(MethodReference mref,
+      Object expectedBase, MethodInfo expectedMethodInfo,
+      Class<?>[] expectedAnnotationTypes,
+      Object[] expectedParamValues, StringBuffer buf) {
+
+    boolean pass = true;
+    
+    Object base = mref.getBase();
+    MethodInfo minfo = mref.getMethodInfo();
+    Annotation[] annotations = mref.getAnnotations();
+    Object[] parameterValues = mref.getEvaluatedParameters();
+    
+    if (base == null) {
+      buf.append("Did not get expected base object." + NLINE);
+      buf.append("Expected base = " + expectedBase + NLINE);
+      buf.append("Computed name = null" + NLINE);
+      pass = false;
+    } else if (!base.equals(expectedBase)) {
+      buf.append("Did not get expected base object." + NLINE);
+      buf.append("Expected base = " + expectedBase + NLINE);
+      buf.append("Computed base = " + base + NLINE);
+      pass = false;
+    }
+
+    if (minfo == null) {
+      buf.append("Did not get expected MethodInfo object." + NLINE);
+      buf.append("Expected MethodInfo = " + expectedMethodInfo + NLINE);
+      buf.append("Computed MethodInfo = null" + NLINE);
+      pass = false;
+    } else if (!minfo.equals(expectedMethodInfo)) {
+      buf.append("Did not get expected base object." + NLINE);
+      buf.append("Expected MethodInfo = " + expectedMethodInfo + NLINE);
+      buf.append("Computed MethodInfo = " + minfo + NLINE);
+      pass = false;
+    }
+
+    if (annotations == null) {
+      buf.append("Did not get expected annotation array." + NLINE);
+      buf.append("Computed array was null" + NLINE);
+      pass = false;
+    } else if (annotations.length != expectedAnnotationTypes.length) {
+      buf.append("Did not get expected number of annotations." + NLINE);
+      buf.append("Expected annotation array length = " + expectedAnnotationTypes.length + NLINE);
+      buf.append("Computed annotation array length = " + annotations.length + NLINE);
+      pass = false;
+    } else {
+      for (int i = 0; i < annotations.length; i++) {
+        if (!annotations[i].annotationType().equals(expectedAnnotationTypes[i])) {
+          buf.append("Did not get expected annotation type for array index = " + i + NLINE);
+          buf.append("Expected type = " + expectedAnnotationTypes[i] + NLINE);
+          buf.append("Computed type = " + annotations[i].getClass() + NLINE);
+          pass = false;
+        }
+      }
+    }
+
+    if (parameterValues == null) {
+      buf.append("Did not get expected parameter value array." + NLINE);
+      buf.append("Computed array was null" + NLINE);
+      pass = false;
+    } else if (parameterValues.length != expectedParamValues.length) {
+      buf.append("Did not get expected number of parameter values." + NLINE);
+      buf.append("Expected annotation array length = " + expectedParamValues.length + NLINE);
+      buf.append("Computed annotation array length = " + parameterValues.length + NLINE);
+      pass = false;
+    } else {
+      for (int i = 0; i < parameterValues.length; i++) {
+        if (!parameterValues[i].equals(expectedParamValues[i])) {
+          buf.append("Did not get expected parameter value for array index = " + i + NLINE);
+          buf.append("Expected type = " + expectedParamValues[i] + NLINE);
+          buf.append("Computed type = " + parameterValues[i] + NLINE);
+          pass = false;
+        }
+      }
+    }
+
+    return pass;
+  }
+
+  public static boolean testValueExpression(ValueExpression vexp,
+      ELContext context, String exprStr, Class expectedType,
+      Object expectedValue, boolean expectedReadOnly,
+      boolean expectedLiteralText, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getValue()
+    Object retrievedValue = vexp.getValue(context);
+    if (!retrievedValue.equals(expectedValue)) {
+      pass = false;
+      buf.append("getValue() does not return expected value" + NLINE);
+      buf.append("Expected value = " + expectedValue.toString() + NLINE);
+      buf.append("Computed value = " + retrievedValue.toString() + NLINE);
+    }
+
+    // setValue()
+    try {
+      vexp.setValue(context, "blue");
+      String newValue = (String) vexp.getValue(context);
+      if (expectedReadOnly) {
+        pass = false;
+        buf.append("setValue() succeeded on a read-only value" + NLINE);
+      } else if (!newValue.equals("blue")) {
+        pass = false;
+        buf.append(
+            "Did not get correct set value for " + "ValueExpression." + NLINE);
+        buf.append("Expected value = " + "blue" + NLINE);
+        buf.append("Computed value = " + newValue + NLINE);
+      }
+    } catch (PropertyNotWritableException pnwe) {
+      if (!expectedReadOnly) {
+        pass = false;
+        buf.append(
+            "setValue() threw " + "PropertyNotWritableException" + NLINE);
+        buf.append("on a writable value" + NLINE);
+      } else {
+        buf.append(
+            "PropertyNotWritableException caught as " + "expected." + NLINE);
+      }
+    }
+
+    // getType()
+    Class type = vexp.getType(context);
+    String typeName = (type == null) ? "null" : type.getName();
+    buf.append("Type retrieved is " + typeName + NLINE);
+
+    // getExpectedType()
+    Class retrievedType = vexp.getExpectedType();
+    if (!(retrievedType.equals(expectedType))) {
+      pass = false;
+      buf.append(
+          "getExpectedType() does not return expected " + "type" + NLINE);
+      buf.append("Expected type = " + expectedType.toString() + NLINE);
+      buf.append("Computed type = " + retrievedType.toString() + NLINE);
+    }
+
+    // isReadOnly()
+    if ((vexp.isReadOnly(context)) != expectedReadOnly) {
+      pass = false;
+      buf.append("isReadOnly() did not return " + expectedReadOnly + NLINE);
+    }
+
+    // isLiteralText()
+    if ((vexp.isLiteralText()) != expectedLiteralText) {
+      pass = false;
+      buf.append(
+          "isLiteralText() did not return " + expectedLiteralText + NLINE);
+    }
+
+    // getExpressionString()
+    String retrievedStr = vexp.getExpressionString();
+    if (!retrievedStr.equals(exprStr)) {
+      pass = false;
+      buf.append(
+          "getExpressionString() does not return expected " + "string" + NLINE);
+      buf.append("Expected string = " + exprStr + NLINE);
+      buf.append("Computed string = " + retrievedStr + NLINE);
+    }
+
+    return pass;
+  }
+
+  public static boolean testMethodExpression(MethodExpression mexp,
+      ELContext context, String exprStr, Object[] params,
+      Object expectedReturnValue, boolean expectedLiteralText,
+      StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getMethodInfo()
+    try {
+      MethodInfo minfo = mexp.getMethodInfo(context);
+    } catch (Exception e) {
+      pass = false;
+      buf.append("getMethodInfo() threw an unexpected exception" + NLINE);
+      buf.append(e.getMessage() + NLINE);
+    }
+
+    // invoke()
+    try {
+      Object returnValue = mexp.invoke(context, params);
+      if (returnValue == null) {
+        if (expectedReturnValue != null) {
+          pass = false;
+          buf.append("invoke() unexpectedly returned null" + NLINE);
+        }
+      } else if (expectedReturnValue == null) {
+        pass = false;
+        buf.append(
+            "invoke() unexpectedly returned non-null " + "value" + NLINE);
+      } else if (!returnValue.equals(expectedReturnValue)) {
+        pass = false;
+        buf.append(
+            "invoke() returned an object of wrong type or " + "value" + NLINE);
+        buf.append(
+            "Expected return value: " + expectedReturnValue.toString() + NLINE);
+        buf.append("Computed return value: " + returnValue.toString() + NLINE);
+      }
+    } catch (Exception e) {
+      pass = false;
+      buf.append("invoke() threw an unexpected exception" + NLINE);
+      buf.append(e.getMessage() + NLINE);
+    }
+
+    // isLiteralText()
+    if ((mexp.isLiteralText()) != expectedLiteralText) {
+      pass = false;
+      buf.append(
+          "isLiteralText() did not return " + expectedLiteralText + NLINE);
+    }
+
+    // getExpressionString()
+    String retrievedStr = mexp.getExpressionString();
+    if (!retrievedStr.equals(exprStr)) {
+      pass = false;
+      buf.append(
+          "getExpressionString() does not return expected " + "string" + NLINE);
+      buf.append("Expected string = " + exprStr + NLINE);
+      buf.append("Computed string = " + retrievedStr + NLINE);
+    }
+
+    return pass;
+  }
+
+  public static boolean equalsTest(Expression exp1, Expression exp2,
+      StringBuffer buf) {
+
+    String e1str = exp1.getExpressionString();
+    String e2str = (exp2 == null) ? null : exp2.getExpressionString();
+
+    buf.append("Testing equality: " + e1str + " and " + e2str + NLINE);
+
+    if (!exp1.equals(exp2)) {
+      if (exp2 != null) {
+        buf.append("Expression " + e1str + " is not equal to " + "Expression "
+            + e2str + NLINE);
+      }
+      return false;
+    } else {
+      int hcode1 = exp1.hashCode();
+      int hcode2 = exp2.hashCode();
+
+      if (hcode1 != hcode2) {
+        buf.append("Expressions " + e1str + " and " + e2str + " are "
+            + "equal, but their" + NLINE);
+        buf.append("hashcodes aren't the same." + NLINE);
+        buf.append("Hashcode for " + e1str + ": " + hcode1 + NLINE);
+        buf.append("Hashcode for " + e2str + ": " + hcode2 + NLINE);
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  public static boolean expressionSerializableTest(Expression exp,
+      StringBuffer buf) {
+
+    ObjectOutputStream out = null;
+    ObjectInputStream in = null;
+    Expression desexp = null;
+    ByteArrayOutputStream bos = null;
+
+    // Serialize the Expression.
+    try {
+      bos = new ByteArrayOutputStream();
+      out = new ObjectOutputStream(bos);
+      out.writeObject(exp);
+    } catch (IOException ioe) {
+      buf.append(
+          "Failed to serialize the Expression!" + NLINE + ioe.toString());
+      return false;
+    } finally {
+      if (out != null) {
+        try {
+          out.close();
+        } catch (Exception close) {
+          // Do not fail the test if close does not happen.
+        }
+      }
+    }
+
+    // Deserialize the Expression.
+    try {
+      byte[] byteBuf = bos.toByteArray();
+      in = new ObjectInputStream(new ByteArrayInputStream(byteBuf));
+      desexp = (Expression) in.readObject();
+    } catch (IOException ioe) {
+      buf.append(
+          "Failed to deserialize the Expression!" + NLINE + ioe.toString());
+      return false;
+    } catch (ClassNotFoundException cnfe) {
+      buf.append("Could not find class of serialized Expression" + NLINE
+          + cnfe.toString());
+      return false;
+    } finally {
+      if (in != null) {
+        try {
+          in.close();
+        } catch (Exception close) {
+          // Do not fail the test if close does not happen.
+        }
+      }
+    }
+
+    // Test Expression After Serialization
+    if (!equalsTest(desexp, exp, buf)) {
+      buf.append("'getExpressionString' after serialization took " + "place."
+          + NLINE + "Expected: " + exp.getExpressionString() + NLINE
+          + "Received: " + desexp.getExpressionString() + NLINE);
+      return false;
+    }
+
+    return true;
+  }
+}

--- a/el/src/main/java/com/sun/ts/tests/el/common/api/resolver/BarELResolver.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/api/resolver/BarELResolver.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2018, 2020 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.el.common.api.resolver;
+
+import java.util.Iterator;
+
+import jakarta.el.ELContext;
+import jakarta.el.ELException;
+import jakarta.el.ELResolver;
+import jakarta.el.PropertyNotWritableException;
+
+public class BarELResolver extends ELResolver {
+
+  public Object getValue(ELContext context, Object base, Object property)
+      throws ELException {
+    Object result = null;
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null) {
+      // Resolving first variable (e.g. ${Bar}).
+      // We only handle "Bar"
+      String propertyName = (String) property;
+      if (propertyName.equals("Bar")) {
+        result = "Foo";
+        context.setPropertyResolved(true);
+      }
+    }
+    return result;
+  }
+
+  public Class getType(ELContext context, Object base, Object property)
+      throws ELException {
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null && property instanceof String
+        && property.toString().equals("Bar")) {
+      context.setPropertyResolved(true);
+    }
+
+    // we never set a value
+    return null;
+  }
+
+  public void setValue(ELContext context, Object base, Object property,
+
+      Object value) throws ELException {
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null && property instanceof String
+        && property.toString().equals("Bar")) {
+      context.setPropertyResolved(true);
+      throw new PropertyNotWritableException();
+    }
+  }
+
+  public boolean isReadOnly(ELContext context, Object base, Object property)
+      throws ELException {
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null && property instanceof String
+        && property.toString().equals("Bar")) {
+      context.setPropertyResolved(true);
+    }
+
+    return true;
+  }
+
+  public Iterator getFeatureDescriptors(ELContext context, Object base) {
+    if (context == null)
+      throw new NullPointerException();
+    return null;
+  }
+
+  public Class getCommonPropertyType(ELContext context, Object base) {
+    if (context == null)
+      throw new NullPointerException();
+
+    if (base == null)
+      return String.class;
+    return null;
+  }
+}

--- a/el/src/main/java/com/sun/ts/tests/el/common/api/resolver/ResolverTest.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/api/resolver/ResolverTest.java
@@ -1,0 +1,542 @@
+/*
+ * Copyright (c) 2009, 2024 Oracle and/or its affiliates and others.
+ * All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.el.common.api.resolver;
+
+import java.util.Objects;
+
+import jakarta.el.BeanELResolver;
+import jakarta.el.CompositeELResolver;
+import jakarta.el.ELContext;
+import jakarta.el.ELResolver;
+import jakarta.el.MethodNotFoundException;
+import jakarta.el.PropertyNotFoundException;
+import jakarta.el.PropertyNotWritableException;
+
+public class ResolverTest {
+  private static final String NL = System.getProperty("line.separator", "\n");
+
+  /**
+   * Private as this class will only have static methods and members.
+   */
+  private ResolverTest() {
+  }
+
+  public static boolean testCompositeELResolver(ELContext elContext,
+      CompositeELResolver compResolver, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // add()
+    BarELResolver barResolver = new BarELResolver();
+    try {
+      compResolver.add(barResolver);
+      buf.append("add() tested successfully" + NL);
+
+    } catch (Exception e) {
+      buf.append("add() method Test Failed");
+      pass = false;
+    }
+
+    // setValue()
+    elContext.setPropertyResolved(false);
+    compResolver.setValue(elContext, null, "Nothing", "rien");
+    if (!elContext.isPropertyResolved()) {
+      buf.append(
+          "setValue() tested successfully on non-existent " + "property" + NL);
+    } else {
+      buf.append("setValue() set property resolved on non-existent "
+          + "property" + NL);
+      pass = false;
+    }
+
+    elContext.setPropertyResolved(false);
+    try {
+      compResolver.setValue(elContext, null, "Bar", "rien");
+      pass = false;
+    } catch (PropertyNotWritableException pnwe) {
+      buf.append(
+          "setValue() tested successfully on non-writable " + "property" + NL);
+      buf.append("PropertyNotWritableException caught as expected" + NL);
+    }
+
+    // getValue()
+    elContext.setPropertyResolved(false);
+    String result = (String) compResolver.getValue(elContext, null, "Bar");
+    if (!elContext.isPropertyResolved()) {
+      buf.append("getValue() did not resolve" + NL);
+      pass = false;
+    } else if (!result.equals("Foo")) {
+      buf.append("Invalid value from BarELResolver: " + result + NL);
+      pass = false;
+    } else {
+      buf.append("getValue() tested successfully" + NL);
+    }
+
+    // getType()
+    elContext.setPropertyResolved(false);
+    Class<?> type = compResolver.getType(elContext, null, "Bar");
+    if (!elContext.isPropertyResolved()) {
+      buf.append("getType() did not resolve" + NL);
+      pass = false;
+    } else if (type != null) {
+      buf.append("getType() returns " + type.getName() + NL);
+      buf.append("not expected result for non-writable property" + NL);
+      pass = false;
+    } else {
+      buf.append("getType() returns null as expected for non-writable "
+          + "property" + NL);
+    }
+
+    // isReadOnly
+    elContext.setPropertyResolved(false);
+    boolean nonWritable = compResolver.isReadOnly(elContext, null, "Bar");
+    if (!elContext.isPropertyResolved()) {
+      buf.append("isReadOnly() did not resolve" + NL);
+      pass = false;
+    } else if (!nonWritable) {
+      buf.append("isReadOnly() did not return true" + NL);
+      pass = false;
+    } else {
+      buf.append("isReadOnly() returns true as expected" + NL);
+    }
+
+    // getCommonPropertyType()
+    elContext.setPropertyResolved(false);
+    Class<?> commonPropertyType = (compResolver.getCommonPropertyType(elContext, null));
+    buf.append("getCommonPropertyType() returns ");
+    buf.append(commonPropertyType.getName() + NL);
+
+    return pass;
+  }
+
+  public static boolean testELResolver(ELContext elContext, ELResolver resolver,
+      Object base, Object property, Object value, StringBuffer buf,
+      boolean readOnly) {
+
+    boolean pass = true;
+
+    // setValue()
+    elContext.setPropertyResolved(false);
+    try {
+      resolver.setValue(elContext, base, property, value);
+      if (readOnly) {
+        buf.append("setValue() failed on non-writable property");
+        pass = false;
+      } else {
+        buf.append(
+            "setValue() tested successfully on writable " + "property" + NL);
+      }
+
+    } catch (PropertyNotWritableException pnwe) {
+      if (readOnly) {
+        buf.append("setValue() tested successfully on non-writable "
+            + "property" + NL);
+        buf.append("PropertyNotWritableException caught as expected" + NL);
+      } else {
+        buf.append("setValue() failed on non-writable property" + NL);
+        buf.append("Unexpected PropertyNotWritableException caught" + NL);
+        pass = false;
+      }
+    }
+
+    // getValue()
+    elContext.setPropertyResolved(false);
+    Object valueRetrieved = resolver.getValue(elContext, base, property);
+    if (!elContext.isPropertyResolved()) {
+      buf.append("getValue() did not resolve" + NL);
+      pass = false;
+    }
+
+    if (!readOnly && !Objects.equals(valueRetrieved, value)) {
+      if (valueRetrieved == null) {
+        buf.append("null value returned from getValue() method call!" + NL);
+        pass = false;
+      } else {
+        buf.append("Invalid value from getValue():" + NL);
+        buf.append("Value expected: " + value.toString() + NL);
+        buf.append("Value retrieved: " + valueRetrieved.toString() + NL);
+        pass = false;
+      }
+    } else {
+      buf.append("getValue() tested successfully" + NL);
+      if (!readOnly) {
+        buf.append("Value expected: " + value.toString() + NL);
+        buf.append("Value retrieved: " + valueRetrieved.toString() + NL);
+      }
+    }
+
+    // getType()
+    elContext.setPropertyResolved(false);
+    Class<?> type = resolver.getType(elContext, base, property);
+    if (!elContext.isPropertyResolved()) {
+      buf.append("getType() did not resolve" + NL);
+      pass = false;
+    } else if (type != null) {
+      buf.append("getType() returns " + type.getName() + NL);
+      if (readOnly) {
+        buf.append("result not expected!" + NL);
+        pass = false;
+      } else {
+        buf.append("non-null as expected" + NL);
+      }
+    } else {
+      buf.append("getType() returns null " + NL);
+      if (!readOnly) {
+        buf.append("result not expected!" + NL);
+        pass = false;
+      } else {
+        buf.append("as expected" + NL);
+      }
+    }
+
+    // isReadOnly
+    elContext.setPropertyResolved(false);
+    boolean nonWritable = resolver.isReadOnly(elContext, base, property);
+    if (!elContext.isPropertyResolved()) {
+      buf.append("isReadOnly() did not resolve" + NL);
+      pass = false;
+    } else if (nonWritable != readOnly) {
+      buf.append("isReadOnly() returned unexpected value: " + nonWritable + NL);
+      pass = false;
+    } else {
+      buf.append("isReadOnly() returns " + readOnly + " as expected" + NL);
+    }
+
+    // getCommonPropertyType()
+    elContext.setPropertyResolved(false);
+    Class<?> commonPropertyType = (resolver.getCommonPropertyType(elContext, base));
+    buf.append("getCommonPropertyType() returns ");
+    buf.append(commonPropertyType.getName() + "" + NL);
+
+    return pass;
+  }
+
+  /**
+   * Test the ELResolver.invoke() mthod.
+   * 
+   * @param elContext
+   *          - elContext
+   * @param resolver
+   *          - el Resolver to be tested.
+   * @param beanName
+   *          - The javabean to be used.
+   * @param methodName
+   *          - The method in the javabean to call.
+   * @param types
+   *          - The @class types of the aurgs for the method.
+   * @param values
+   *          - The args that you want to pass into the method.
+   * @param negTest
+   *          - Is this a negetive test or not(true, false).
+   * @param buf
+   *          - String buffer used to capture loggig info.
+   * @return
+   */
+  public static boolean testELResolverInvoke(ELContext elContext,
+      ELResolver resolver, Object beanName, Object methodName, Class<?>[] types,
+      Object[] values, Boolean negTest, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // invoke
+    elContext.setPropertyResolved(false);
+    try {
+      Boolean nameMatch = (Boolean) resolver.invoke(elContext, beanName,
+          methodName, types, values);
+
+      if (!nameMatch.booleanValue()) {
+        buf.append("invoke() did not Run properly." + NL);
+        pass = false;
+      }
+
+    } catch (MethodNotFoundException mnfe) {
+      if (negTest.booleanValue()) {
+        buf.append("Test Passed  invoke() threw MethodNotFoundException");
+      } else {
+        pass = false;
+        mnfe.printStackTrace();
+      }
+    } catch (Exception e) {
+      pass = false;
+      e.printStackTrace();
+    }
+
+    return pass;
+  }
+
+
+  // --- Start Negative Method Tests ---
+  public static boolean testELResolverNPE(ELResolver resolver, Object base,
+      Object property, Object value, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getType()
+    try {
+      resolver.getType(null, base, property);
+      pass = false;
+      buf.append("getType test failed with: " + NL
+          + "EXPECTED: NullPointerException to be thrown " + NL
+          + "RECEIVED: NO EXCEPTION THROWN AT ALL! " + NL);
+    } catch (Exception e) {
+      if (!(e instanceof NullPointerException)) {
+        buf.append("getType test failed with: " + NL + "EXPECTED: "
+            + "NullPointerException to be thrown " + NL + "RECEIVED: "
+            + e.toString() + NL);
+        pass = false;
+
+      } else {
+        buf.append("getType() test Passed: throws "
+            + "NullPointerException as expected " + NL);
+      }
+    }
+
+    // getValue
+    try {
+      resolver.getValue(null, base, property);
+      buf.append("Test Failed  getValue() did not throw any exception." + NL
+          + "Expected: NullPointerException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof NullPointerException)) {
+        buf.append("Test Failed  getValue() threw the wrong exception " + NL
+            + "Expected: NullPointerException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  getValue() threw NullPointerException " + NL);
+      }
+    }
+
+    // setValue()
+    try {
+      resolver.setValue(null, base, property, value);
+      buf.append("Test Failed  setValue() did not throw any exception." + NL
+          + "Expected: NullPointerException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof NullPointerException)) {
+        buf.append("Test Failed  setValue() threw the wrong exception " + NL
+            + "Expected: NullPointerException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  setValue() threw NullPointerException " + NL);
+      }
+    }
+
+    // isReadOnly()
+    try {
+      resolver.isReadOnly(null, base, property);
+      buf.append("Test Failed  isReadOnly() did not throw any exception." + NL
+          + "Expected: NullPointerException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof NullPointerException)) {
+        buf.append("Test Failed  isReadOnly() threw the wrong exception " + NL
+            + "Expected: NullPointerException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append(
+            "Test Passed  isReadOnly() NullPointerException " + "thrown " + NL);
+      }
+    }
+
+    return pass;
+  }
+
+  public static boolean testELResolverPNFE(ELContext elcontext,
+      ELResolver resolver, Object base, Object property, StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getType()
+    try {
+      resolver.getType(elcontext, base, property);
+      buf.append("Test Failed  getType() did not throw any exception." + NL
+          + "Expected: PropertyNotFoundException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotFoundException)) {
+        buf.append("Test Failed  getType() threw the wrong exception " + NL
+            + "Expected: PropertyNotFoundException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  getType() threw "
+            + "PropertyNotFoundException " + NL);
+      }
+    }
+
+    // isReadOnly()
+    try {
+      resolver.isReadOnly(elcontext, base, property);
+      buf.append("Test Failed  isReadOnly() did not throw any exception." + NL
+          + "Expected: PropertyNotFoundException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotFoundException)) {
+        buf.append("Test Failed  isReadOnly() threw the wrong exception " + NL
+            + "Expected: PropertyNotFoundException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  isReadOnly() threw "
+            + "PropertyNotFoundException " + NL);
+      }
+    }
+
+    // setValue()
+    try {
+      resolver.setValue(elcontext, base, property, "arbitrary value");
+      buf.append("Test Failed  setValue() did not throw any exception." + NL
+          + "Expected: PropertyNotFoundException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotFoundException)) {
+        buf.append("Test Failed  setValue() threw the wrong exception " + NL
+            + "Expected: PropertyNotFoundException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  setValue() threw "
+            + "PropertyNotFoundException " + NL);
+      }
+    }
+
+    if (!(resolver instanceof BeanELResolver)) {
+      return pass;
+    }
+
+    // getValue()
+    try {
+      resolver.getValue(elcontext, base, property);
+      buf.append("Test Failed  getValue() did not throw any exception." + NL
+          + "Expected: PropertyNotFoundException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotFoundException)) {
+        buf.append("Test Failed  getValue() threw the wrong exception " + NL
+            + "Expected: PropertyNotFoundException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  getValue() threw "
+            + "PropertyNotFoundException " + NL);
+      }
+    }
+
+    return pass;
+  }
+
+  public static boolean testELResolverIAE(ELContext elcontext,
+      ELResolver resolver, Object base, Object property, Object value,
+      StringBuffer buf) {
+
+    boolean pass = true;
+
+    // getValue()
+    try {
+      resolver.getValue(elcontext, base, value);
+      buf.append("Test Failed  getValue() did not throw any exception." + NL
+          + "Expected: IllegalArgumentException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof IllegalArgumentException)) {
+        buf.append("Test Failed  getValue() threw the wrong exception " + NL
+            + "Expected: IllegalArgumentException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  getValue() threw "
+            + "IllegalArgumentException " + NL);
+      }
+    }
+
+    // setValue()
+    try {
+      resolver.setValue(elcontext, base, property, value);
+      buf.append("Test Failed  setValue() did not throw any exception." + NL
+          + "Expected: IllegalArgumentException " + NL);
+
+      pass = false;
+    } catch (Exception e) {
+      if (!(e instanceof IllegalArgumentException)) {
+        buf.append("Test Failed  setValue() threw the wrong exception "
+            + "Expected: IllegalArgumentException " + NL + "Received: "
+            + e.toString());
+
+        pass = false;
+      } else {
+        buf.append("Test Passed  setValue() threw "
+            + "IllegalArgumentException " + NL);
+      }
+    }
+
+    return pass;
+  }
+
+  public static boolean testELResolverPNWE(ELContext elcontext,
+      ELResolver resolver, Object base, Object property, Object value,
+      StringBuffer buf) {
+
+    boolean pass = true;
+
+    // setValue()
+    try {
+      resolver.setValue(elcontext, base, property, value);
+      buf.append("Test Failed  setValue() did not throw any exception." + NL
+          + "Expected: PropertyNotWritableException " + NL);
+      pass = false;
+
+    } catch (Exception e) {
+      if (!(e instanceof PropertyNotWritableException)) {
+        buf.append("Test Failed  setValue() threw the wrong exception " + NL
+            + "Expected: PropertyNotWritableException " + NL + "Received: "
+            + e.toString());
+        pass = false;
+
+      } else {
+        buf.append("Test Passed  setValue() threw "
+            + "PropertyNotWritableException " + NL);
+      }
+    }
+
+    return pass;
+  }
+}

--- a/el/src/main/java/com/sun/ts/tests/el/common/elcontext/BarELContext.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/elcontext/BarELContext.java
@@ -21,7 +21,7 @@
 
 package com.sun.ts.tests.el.common.elcontext;
 
-import com.sun.ts.tests.common.el.api.resolver.BarELResolver;
+import com.sun.ts.tests.el.common.api.resolver.BarELResolver;
 
 import jakarta.el.ELContext;
 import jakarta.el.ELResolver;

--- a/el/src/main/java/com/sun/ts/tests/el/common/elcontext/SimpleELContext.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/elcontext/SimpleELContext.java
@@ -20,7 +20,7 @@
  */
 package com.sun.ts.tests.el.common.elcontext;
 
-import com.sun.ts.lib.util.TestUtil;
+
 import com.sun.ts.tests.el.common.elresolver.EmployeeELResolver;
 import com.sun.ts.tests.el.common.elresolver.VariableELResolver;
 import com.sun.ts.tests.el.common.elresolver.VectELResolver;

--- a/el/src/main/java/com/sun/ts/tests/el/common/elcontext/VRContext.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/elcontext/VRContext.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.el.common.elcontext;
 
 import java.util.Properties;
 
-import com.sun.ts.lib.util.TestUtil;
+
 import com.sun.ts.tests.el.api.jakarta_el.valueexpression.Worker;
 import com.sun.ts.tests.el.common.elresolver.VariableELResolver;
 import com.sun.ts.tests.el.common.functionmapper.TCKFunctionMapper;

--- a/el/src/main/java/com/sun/ts/tests/el/common/elcontext/VarMapperELContext.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/elcontext/VarMapperELContext.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.el.common.elcontext;
 
 import java.util.Properties;
 
-import com.sun.ts.lib.util.TestUtil;
+
 import com.sun.ts.tests.el.common.elresolver.VariableELResolver;
 
 import jakarta.el.CompositeELResolver;

--- a/el/src/main/java/com/sun/ts/tests/el/common/functionmapper/TCKFunctionMapper.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/functionmapper/TCKFunctionMapper.java
@@ -24,7 +24,7 @@ package com.sun.ts.tests.el.common.functionmapper;
 import java.lang.reflect.Method;
 import java.util.HashMap;
 
-import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.el.common.util.ELTestUtil;
 
 import jakarta.el.FunctionMapper;
 
@@ -51,7 +51,7 @@ public class TCKFunctionMapper extends FunctionMapper {
       fMap.put(KEY, clazz.getMethod("valueOf", String.class));
     } catch (NoSuchMethodException nsme) {
       logger.log(Logger.Level.ERROR, "CONSTRUCTOR: Can't find method!");
-      TestUtil.printStackTrace(nsme);
+      ELTestUtil.printStackTrace(nsme);
     }
   }
 
@@ -68,7 +68,7 @@ public class TCKFunctionMapper extends FunctionMapper {
       fMap.put(KEY, clazz.getMethod("toString", int.class));
     } catch (NoSuchMethodException nsme) {
       logger.log(Logger.Level.ERROR, "UPDATE: Can't find method!");
-      TestUtil.printStackTrace(nsme);
+      ELTestUtil.printStackTrace(nsme);
     }
   }
 }

--- a/el/src/main/java/com/sun/ts/tests/el/common/spec/Book.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/spec/Book.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright (c) 2007, 2018 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+/* 
+ * Simple multi-member class to be used for type coercion tests. 
+ */
+
+package com.sun.ts.tests.el.common.spec;
+
+public class Book {
+
+  private String title;
+
+  private String authors;
+
+  private String publisher;
+
+  private int year;
+
+  public Book(String title, String authors, String publisher, int year) {
+    this.title = title;
+    this.authors = authors;
+    this.publisher = publisher;
+    this.year = year;
+  }
+
+  public String getTitle() {
+    return title;
+  }
+
+  public String getAuthors() {
+    return authors;
+  }
+
+  public String getPublisher() {
+    return publisher;
+  }
+
+  public int getYear() {
+    return year;
+  }
+
+  public String toString() {
+    return getTitle();
+  }
+}

--- a/el/src/main/java/com/sun/ts/tests/el/common/util/ELTestUtil.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/util/ELTestUtil.java
@@ -22,9 +22,8 @@ package com.sun.ts.tests.el.common.util;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-
-import com.sun.ts.lib.harness.EETest.Fault;
-import com.sun.ts.lib.util.TestUtil;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 import java.lang.System.Logger;
 
@@ -223,4 +222,18 @@ public final class ELTestUtil {
     return FAIL + " Unexpected Exception Thrown!" + NL + "Expected: "
         + exceptionName + NL + "Received: ";
   }
+
+  public static void printStackTrace(Throwable e) {
+    if (e == null) {
+      return;
+    }
+    try {
+      StringWriter sw = new StringWriter();
+      PrintWriter writer = new PrintWriter(sw);
+      e.printStackTrace(writer);
+      writer.close();
+    } catch (Exception E) {
+    }
+  }
+
 }

--- a/el/src/main/java/com/sun/ts/tests/el/common/util/ExprEval.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/util/ExprEval.java
@@ -28,7 +28,7 @@ import java.math.RoundingMode;
 import java.util.Enumeration;
 import java.util.Hashtable;
 
-import com.sun.ts.lib.util.TestUtil;
+
 import com.sun.ts.tests.el.common.elcontext.SimpleELContext;
 
 import jakarta.el.ELContext;
@@ -275,8 +275,7 @@ public final class ExprEval {
 
       // add the object
       context.putContext(cl, value);
-      TestUtil
-          .logTrace("Adding value: " + "\"" + value + "\"" + " To Context!");
+      logger.log(Logger.Level.TRACE, "Adding value: " + "\"" + value + "\"" + " To Context!");
 
       // test the expression
       if (!(ExprEval.compareValue(exprVal, vexp.getValue(context)))) {

--- a/el/src/main/java/com/sun/ts/tests/el/common/util/Fault.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/util/Fault.java
@@ -20,7 +20,7 @@ package com.sun.ts.tests.el.common.util;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 
-import com.sun.ts.lib.util.TestUtil;
+
 
 /**
    * This exception must be thrown to signify a
@@ -40,7 +40,7 @@ import com.sun.ts.lib.util.TestUtil;
      */
     public Fault(String msg) {
       super(msg);
-      TestUtil.logErr(msg);
+      // TestUtil.logErr(msg);
     }
 
     /**

--- a/el/src/main/java/com/sun/ts/tests/el/common/util/Validator.java
+++ b/el/src/main/java/com/sun/ts/tests/el/common/util/Validator.java
@@ -24,8 +24,6 @@ package com.sun.ts.tests.el.common.util;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
-import com.sun.ts.lib.harness.EETest.Fault;
-import com.sun.ts.lib.util.TestUtil;
 
 import jakarta.el.ELProcessor;
 
@@ -60,7 +58,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testBigDecimal(BigDecimal testVal, Object expectedVal,
       String operator) throws Exception {
@@ -79,8 +76,7 @@ public class Validator {
       try {
         String expr = ExprEval.buildElExpr(true, operator);
         logger.log(Logger.Level.INFO, "expression to be evaluated is " + expr);
-        TestUtil
-            .logMsg("types are BigDecimal and " + testNum.getClass().getName());
+        logger.log(Logger.Level.INFO, "types are BigDecimal and " + testNum.getClass().getName());
 
         Object result = ExprEval.evaluateValueExpression(expr, values,
             Object.class);
@@ -113,11 +109,11 @@ public class Validator {
         }
 
       } catch (RuntimeException re) {
-        TestUtil.printStackTrace(re);
+        ELTestUtil.printStackTrace(re);
         throw new Exception(re);
 
       } catch (Exception e) {
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
         throw new Exception(e);
 
       } finally {
@@ -144,7 +140,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testFloat(Float testVal, Object expectedVal,
       String operator) throws Exception {
@@ -154,8 +149,7 @@ public class Validator {
 
     // For each NumberType in this list.
     for (int i = 0; TestNum.getNumberList().size() > i; i++) {
-      TestUtil
-          .logMsg("*** Start " + "\"" + "Float" + "\"" + " Test Sequence ***");
+      logger.log(Logger.Level.INFO, "*** Start " + "\"" + "Float" + "\"" + " Test Sequence ***");
 
       Object testNum = TestNum.getNumberList().get(i);
 
@@ -216,16 +210,15 @@ public class Validator {
         }
 
       } catch (RuntimeException re) {
-        TestUtil.printStackTrace(re);
+        ELTestUtil.printStackTrace(re);
         throw new Exception(re);
       } catch (Exception e) {
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
         throw new Exception(e);
 
       } finally {
         ExprEval.cleanup();
-        TestUtil
-            .logMsg("*** End " + "\"" + "Float" + "\"" + " Test Sequence ***");
+        logger.log(Logger.Level.INFO, "*** End " + "\"" + "Float" + "\"" + " Test Sequence ***");
       }
 
       if (!pass)
@@ -246,7 +239,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testDouble(Double testVal, Object expectedVal,
       String operator) throws Exception {
@@ -317,17 +309,16 @@ public class Validator {
         }
 
       } catch (RuntimeException re) {
-        TestUtil.printStackTrace(re);
+        ELTestUtil.printStackTrace(re);
         throw new Exception(re);
 
       } catch (Exception e) {
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
         throw new Exception(e);
 
       } finally {
         ExprEval.cleanup();
-        TestUtil
-            .logMsg("*** End " + "\"" + "Double" + "\"" + " Test Sequence ***");
+        logger.log(Logger.Level.INFO, "*** End " + "\"" + "Double" + "\"" + " Test Sequence ***");
       }
 
       if (!pass)
@@ -349,7 +340,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testNumericString(String testVal, Double expectedVal,
       String operator) throws Exception {
@@ -414,11 +404,11 @@ public class Validator {
         }
 
       } catch (RuntimeException re) {
-        TestUtil.printStackTrace(re);
+        ELTestUtil.printStackTrace(re);
         throw new Exception(re);
 
       } catch (Exception e) {
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
         throw new Exception(e);
 
       } finally {
@@ -445,7 +435,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testBigInteger(BigInteger testVal, Object expectedVal,
       String operator) throws Exception {
@@ -476,8 +465,7 @@ public class Validator {
       try {
         String expr = ExprEval.buildElExpr(true, operator);
         logger.log(Logger.Level.INFO, "expression to be evaluated is " + expr);
-        TestUtil
-            .logMsg("types are BigInteger and " + testNum.getClass().getName());
+        logger.log(Logger.Level.INFO, "types are BigInteger and " + testNum.getClass().getName());
 
         Object result = ExprEval.evaluateValueExpression(expr, values,
             Object.class);
@@ -512,11 +500,11 @@ public class Validator {
         }
 
       } catch (RuntimeException re) {
-        TestUtil.printStackTrace(re);
+        ELTestUtil.printStackTrace(re);
         throw new Exception(re);
 
       } catch (Exception e) {
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
         throw new Exception(e);
 
       } finally {
@@ -543,7 +531,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testLong(Long testVal, Object expectedVal, String operator)
       throws Exception {
@@ -553,8 +540,7 @@ public class Validator {
 
     // For each NumberType in this list.
     for (int i = 0; TestNum.getNumberList().size() > i; i++) {
-      TestUtil
-          .logMsg("*** Start " + "\"" + "Long" + "\"" + " Test Sequence ***");
+      logger.log(Logger.Level.INFO, "*** Start " + "\"" + "Long" + "\"" + " Test Sequence ***");
 
       Object testNum = TestNum.getNumberList().get(i);
 
@@ -608,17 +594,16 @@ public class Validator {
         }
 
       } catch (RuntimeException re) {
-        TestUtil.printStackTrace(re);
+        ELTestUtil.printStackTrace(re);
         throw new Exception(re);
 
       } catch (Exception e) {
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
         throw new Exception(e);
 
       } finally {
         ExprEval.cleanup();
-        TestUtil
-            .logMsg("*** End " + "\"" + "Long" + "\"" + " Test Sequence ***");
+        logger.log(Logger.Level.INFO, "*** End " + "\"" + "Long" + "\"" + " Test Sequence ***");
       }
 
       if (!pass)
@@ -639,7 +624,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testInteger(Integer testVal, Object expectedVal,
       String operator) throws Exception {
@@ -671,8 +655,7 @@ public class Validator {
       try {
         String expr = ExprEval.buildElExpr(true, operator);
         logger.log(Logger.Level.INFO, "expression to be evaluated is " + expr);
-        TestUtil
-            .logMsg("types are  Integer and " + testNum.getClass().getName());
+        logger.log(Logger.Level.INFO, "types are  Integer and " + testNum.getClass().getName());
 
         Object result = ExprEval.evaluateValueExpression(expr, values,
             Object.class);
@@ -706,11 +689,11 @@ public class Validator {
         }
 
       } catch (RuntimeException re) {
-        TestUtil.printStackTrace(re);
+        ELTestUtil.printStackTrace(re);
         throw new Exception(re);
 
       } catch (Exception e) {
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
         throw new Exception(e);
 
       } finally {
@@ -737,7 +720,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testShort(Short testVal, Object expectedVal,
       String operator) throws Exception {
@@ -747,8 +729,7 @@ public class Validator {
 
     // For each NumberType in this list.
     for (int i = 0; TestNum.getNumberList().size() > i; i++) {
-      TestUtil
-          .logMsg("*** Start " + "\"" + "Short" + "\"" + " Test Sequence ***");
+      logger.log(Logger.Level.INFO,"*** Start " + "\"" + "Short" + "\"" + " Test Sequence ***");
 
       Object testNum = TestNum.getNumberList().get(i);
 
@@ -800,17 +781,16 @@ public class Validator {
         }
 
       } catch (RuntimeException re) {
-        TestUtil.printStackTrace(re);
+        ELTestUtil.printStackTrace(re);
         throw new Exception(re);
 
       } catch (Exception e) {
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
         throw new Exception(e);
 
       } finally {
         ExprEval.cleanup();
-        TestUtil
-            .logMsg("*** End " + "\"" + "Short" + "\"" + " Test Sequence ***");
+        logger.log(Logger.Level.INFO, "*** End " + "\"" + "Short" + "\"" + " Test Sequence ***");
       }
 
       if (!pass)
@@ -831,7 +811,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testByte(Byte testVal, Object expectedVal, String operator)
       throws Exception {
@@ -841,8 +820,7 @@ public class Validator {
 
     // For each NumberType in this list.
     for (int i = 0; TestNum.getNumberList().size() > i; i++) {
-      TestUtil
-          .logMsg("*** Start " + "\"" + "Byte" + "\"" + " Test Sequence ***");
+      logger.log(Logger.Level.INFO, "*** Start " + "\"" + "Byte" + "\"" + " Test Sequence ***");
 
       Object testNum = TestNum.getNumberList().get(i);
 
@@ -894,17 +872,16 @@ public class Validator {
         }
 
       } catch (RuntimeException re) {
-        TestUtil.printStackTrace(re);
+        ELTestUtil.printStackTrace(re);
         throw new Exception(re);
 
       } catch (Exception e) {
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
         throw new Exception(e);
 
       } finally {
         ExprEval.cleanup();
-        TestUtil
-            .logMsg("*** End " + "\"" + "Byte" + "\"" + " Test Sequence ***");
+        logger.log(Logger.Level.INFO,"*** End " + "\"" + "Byte" + "\"" + " Test Sequence ***");
       }
 
       if (!pass)
@@ -926,7 +903,6 @@ public class Validator {
    * @param operator
    *          - The operator in which the operands are compared. (i.e. "+", "-",
    *          etc...)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   public static void testBoolean(boolean testValOne, Object testValTwo,
       Object expectedVal, String operator) throws Exception {
@@ -941,8 +917,7 @@ public class Validator {
           "*** Start " + "\"" + "Boolean" + "\"" + " Test Sequence ***");
       String expr = ExprEval.buildElExpr(true, operator);
       logger.log(Logger.Level.INFO, "expression to be evaluated is " + expr);
-      TestUtil
-          .logMsg("types are  Boolean and " + testValTwo.getClass().getName());
+      logger.log(Logger.Level.INFO, "types are  Boolean and " + testValTwo.getClass().getName());
 
       Object result = ExprEval.evaluateValueExpression(expr, values,
           Object.class);
@@ -961,17 +936,16 @@ public class Validator {
       }
 
     } catch (RuntimeException re) {
-      TestUtil.printStackTrace(re);
+      ELTestUtil.printStackTrace(re);
       throw new Exception(re);
 
     } catch (Exception e) {
-      TestUtil.printStackTrace(e);
+      ELTestUtil.printStackTrace(e);
       throw new Exception(e);
 
     } finally {
       ExprEval.cleanup();
-      TestUtil
-          .logMsg("*** End " + "\"" + "Boolean" + "\"" + " Test Sequence ***");
+      logger.log(Logger.Level.INFO, "*** End " + "\"" + "Boolean" + "\"" + " Test Sequence ***");
     }
 
     if (!pass)
@@ -995,11 +969,11 @@ public class Validator {
         throw new Exception("TEST FAILED: pass = false");
 
     } catch (RuntimeException re) {
-      TestUtil.printStackTrace(re);
+      ELTestUtil.printStackTrace(re);
       throw new Exception(re);
 
     } catch (Exception e) {
-      TestUtil.printStackTrace(e);
+      ELTestUtil.printStackTrace(e);
       throw new Exception(e);
 
     } finally {

--- a/el/src/main/java/com/sun/ts/tests/el/signaturetest/el/ELSigTestIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/signaturetest/el/ELSigTestIT.java
@@ -24,13 +24,11 @@ import java.io.File;
 
 import org.junit.jupiter.api.Test;
 
-import com.sun.javatest.Status;
 import com.sun.ts.tests.signaturetest.SigTest;
 import com.sun.ts.tests.signaturetest.SignatureTestDriver;
 import com.sun.ts.tests.signaturetest.SignatureTestDriverFactory;
 
 import java.util.Properties;
-import com.sun.ts.lib.util.TestUtil;
 import java.lang.System.Logger;
 
 /*

--- a/el/src/main/java/com/sun/ts/tests/el/spec/coercion/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/spec/coercion/ELClientIT.java
@@ -31,9 +31,9 @@ import java.util.Properties;
 import java.util.function.Predicate;
 
 
-import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.el.common.util.ExprEval;
 import com.sun.ts.tests.el.common.util.NameValuePair;
+import com.sun.ts.tests.el.common.util.ELTestUtil;
 
 import jakarta.el.ELException;
 import jakarta.el.ELProcessor;
@@ -682,7 +682,7 @@ public class ELClientIT {
     } catch (RuntimeException re) {
       throw new Exception(re);
     } catch (Exception e) {
-      TestUtil.printStackTrace(e);
+      ELTestUtil.printStackTrace(e);
       throw new Exception(e);
     }
 
@@ -749,7 +749,7 @@ public class ELClientIT {
 
     } catch (Exception e) {
       logger.log(Logger.Level.ERROR, "Exception thrown, but it was not an ELException");
-      TestUtil.printStackTrace(e);
+      ELTestUtil.printStackTrace(e);
     }
 
     if (!pass)
@@ -790,7 +790,7 @@ public class ELClientIT {
 
       } catch (Exception e) {
         logger.log(Logger.Level.ERROR, "Exception thrown, but it was not an ELException");
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
       }
 
       if (!pass)
@@ -807,7 +807,7 @@ public class ELClientIT {
 
       } catch (Exception e) {
         logger.log(Logger.Level.ERROR, "Exception thrown, but it was not an ELException");
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
       }
 
       if (!pass)
@@ -1744,7 +1744,7 @@ public class ELClientIT {
 
     } catch (Exception e) {
       logger.log(Logger.Level.ERROR, "Testing coercion to arrays " +
-          "threw an Exception!" + TestUtil.NEW_LINE + "Received: " + e.toString() + TestUtil.NEW_LINE);
+          "threw an Exception!" + ELTestUtil.NL + "Received: " + e.toString() + ELTestUtil.NL);
 
       throw new Exception(e);
     } finally {
@@ -1848,7 +1848,7 @@ public class ELClientIT {
       }
     } catch (Exception e) {
       logger.log(Logger.Level.ERROR, "Testing coercion of lambda expressions to functional interfaces " +
-          "threw an Exception!" + TestUtil.NEW_LINE + "Received: " + e.toString() + TestUtil.NEW_LINE);
+          "threw an Exception!" + ELTestUtil.NL + "Received: " + e.toString() + ELTestUtil.NL);
 
       throw new Exception(e);
     } finally {

--- a/el/src/main/java/com/sun/ts/tests/el/spec/collectionoperators/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/spec/collectionoperators/ELClientIT.java
@@ -24,7 +24,7 @@ package com.sun.ts.tests.el.spec.collectionoperators;
 import java.lang.reflect.Array;
 import java.util.Properties;
 
-import com.sun.ts.lib.util.TestUtil;
+
 import com.sun.ts.tests.el.common.util.DataBase;
 import com.sun.ts.tests.el.common.util.ELTestUtil;
 
@@ -521,7 +521,7 @@ public class ELClientIT {
     } catch (Exception e) {
       pass = false;
       logger.log(Logger.Level.ERROR, "Construction and use of a valid Set literal threw an Exception!" +
-          TestUtil.NEW_LINE + "Received: " + e.toString() + TestUtil.NEW_LINE);
+          ELTestUtil.NL + "Received: " + e.toString() + ELTestUtil.NL);
 
       e.printStackTrace();
     }
@@ -557,7 +557,7 @@ public class ELClientIT {
     } catch (Exception e) {
       pass = false;
       logger.log(Logger.Level.ERROR, "Construction and use of a valid List literal threw an Exception!" +
-          TestUtil.NEW_LINE + "Received: " + e.toString() + TestUtil.NEW_LINE);
+          ELTestUtil.NL + "Received: " + e.toString() + ELTestUtil.NL);
 
       e.printStackTrace();
     }
@@ -593,7 +593,7 @@ public class ELClientIT {
     } catch (Exception e) {
       pass = false;
       logger.log(Logger.Level.ERROR, "Construction and use of a valid Map literal threw an Exception!" +
-          TestUtil.NEW_LINE + "Received: " + e.toString() + TestUtil.NEW_LINE);
+          ELTestUtil.NL + "Received: " + e.toString() + ELTestUtil.NL);
 
       e.printStackTrace();
     }

--- a/el/src/main/java/com/sun/ts/tests/el/spec/language/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/spec/language/ELClientIT.java
@@ -25,8 +25,8 @@ import java.util.Hashtable;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.common.el.spec.Book;
+import com.sun.ts.tests.el.common.util.ELTestUtil;
+import com.sun.ts.tests.el.common.spec.Book;
 import com.sun.ts.tests.el.common.util.ExprEval;
 import com.sun.ts.tests.el.common.util.ResolverType;
 
@@ -172,7 +172,7 @@ public class ELClientIT {
         logger.log(Logger.Level.ERROR, "Test FAILED. " + expr[i] + " caused ");
         logger.log(Logger.Level.ERROR, "an exception, but it was not an ");
         logger.log(Logger.Level.ERROR, "ELException.");
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
       }
     }
 
@@ -213,7 +213,7 @@ public class ELClientIT {
         logger.log(Logger.Level.ERROR, "Test FAILED. " + expr[i] + " caused ");
         logger.log(Logger.Level.ERROR, "an exception, but it was not an ");
         logger.log(Logger.Level.ERROR, "ELException.");
-        TestUtil.printStackTrace(e);
+        ELTestUtil.printStackTrace(e);
       }
 
       if (!pass)
@@ -421,7 +421,7 @@ public class ELClientIT {
           && ExprEval.compareValue(expr, true));
 
     } catch (Exception e) {
-      TestUtil.printStackTrace(e);
+      ELTestUtil.printStackTrace(e);
       throw new Exception(e);
     }
 

--- a/el/src/main/java/com/sun/ts/tests/el/spec/mapper/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/spec/mapper/ELClientIT.java
@@ -24,7 +24,7 @@ package com.sun.ts.tests.el.spec.mapper;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.el.common.util.ELTestUtil;
 import com.sun.ts.tests.el.common.elcontext.FuncMapperELContext;
 import com.sun.ts.tests.el.common.elcontext.VarMapperELContext;
 import com.sun.ts.tests.el.common.functionmapper.TCKFunctionMapper;
@@ -126,14 +126,14 @@ public class ELClientIT {
       if (!(t instanceof ELException)) {
         logger.log(Logger.Level.ERROR, "Expected ELException to be thrown");
         logger.log(Logger.Level.ERROR, "instead threw " + t.toString());
-        TestUtil.printStackTrace(t);
+        ELTestUtil.printStackTrace(t);
         throw new Exception("ELException not thrown");
       }
       Throwable cause = t.getCause();
       if (!(cause instanceof NumberFormatException)) {
         logger.log(Logger.Level.ERROR, "Expected cause to be NumberFormatException");
         logger.log(Logger.Level.ERROR, "instead cause is " + cause.toString());
-        TestUtil.printStackTrace(cause);
+        ELTestUtil.printStackTrace(cause);
         throw new Exception("NumberFormatException not cause");
       }
     }

--- a/el/src/main/java/com/sun/ts/tests/el/spec/relationaloperator/ELClientIT.java
+++ b/el/src/main/java/com/sun/ts/tests/el/spec/relationaloperator/ELClientIT.java
@@ -26,7 +26,6 @@ import java.util.List;
 import java.util.Properties;
 
 
-import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.el.common.util.ExprEval;
 import com.sun.ts.tests.el.common.util.NameValuePair;
 import com.sun.ts.tests.el.common.util.TestNum;
@@ -1794,7 +1793,6 @@ public class ELClientIT {
    * @param booleanOperator
    *          - The operator in which the operands are compared. (i.e. ">, >=,
    *          <, <=, gt, ge, lt, le, ==, !=, eq, ne)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   private void testOperatorBoolean(BigDecimal testVal, Boolean expectedVal,
       String booleanOperator) throws Exception {
@@ -1855,7 +1853,6 @@ public class ELClientIT {
    * @param booleanOperator
    *          - The operator in which the operands are compared. (i.e. >, >=, <,
    *          <=, gt, ge, lt, le, ==, !=, eq, ne)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   private void testOperatorBoolean(BigInteger testVal, Boolean expectedVal,
       String booleanOperator) throws Exception {
@@ -1924,7 +1921,6 @@ public class ELClientIT {
    * @param booleanOperator
    *          - The operator in which the operands are compared. (i.e. ">, >=,
    *          <, <=, gt, ge, lt, le, ==, !=, eq, ne)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   private void testOperatorBoolean(Float testVal, Boolean expectedVal,
       String booleanOperator) throws Exception {
@@ -1992,7 +1988,6 @@ public class ELClientIT {
    * @param booleanOperator
    *          - The operator in which the operands are compared. (i.e. ">, >=,
    *          <, <=, gt, ge, lt, le, ==, !=, eq, ne)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   private void testOperatorBoolean(Double testVal, Boolean expectedVal,
       String booleanOperator) throws Exception {
@@ -2060,7 +2055,6 @@ public class ELClientIT {
    * @param booleanOperator
    *          - The operator in which the operands are compared. (i.e. ">, >=,
    *          <, <=, gt, ge, lt, le, ==, !=, eq, ne)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   private void testOperatorBoolean(Long testVal, Boolean expectedVal,
       String booleanOperator) throws Exception {
@@ -2068,8 +2062,7 @@ public class ELClientIT {
     boolean pass;
 
     for (int i = 0; numberList.size() > i; i++) {
-      TestUtil
-          .logTrace("*** Start " + "\"" + "Long" + "\"" + " Test Sequence ***");
+      logger.log(Logger.Level.TRACE, "*** Start " + "\"" + "Long" + "\"" + " Test Sequence ***");
 
       Object testNum = numberList.get(i);
 
@@ -2107,8 +2100,7 @@ public class ELClientIT {
 
       } finally {
         ExprEval.cleanup();
-        TestUtil
-            .logTrace("*** End " + "\"" + "Long" + "\"" + " Test Sequence ***");
+        logger.log(Logger.Level.TRACE, "*** End " + "\"" + "Long" + "\"" + " Test Sequence ***");
       }
 
       if (!pass)
@@ -2129,7 +2121,6 @@ public class ELClientIT {
    * @param booleanOperator
    *          - The operator in which the operands are compared. (i.e. ">, >=,
    *          <, <=, gt, ge, lt, le, ==, !=, eq, ne)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   private void testOperatorBoolean(Integer testVal, Boolean expectedVal,
       String booleanOperator) throws Exception {
@@ -2199,7 +2190,6 @@ public class ELClientIT {
    * @param booleanOperator
    *          - The operator in which the operands are compared. (i.e. ">, >=,
    *          <, <=, gt, ge, lt, le, ==, !=, eq, ne)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   private void testOperatorBoolean(Short testVal, Boolean expectedVal,
       String booleanOperator) throws Exception {
@@ -2263,7 +2253,6 @@ public class ELClientIT {
    * @param booleanOperator
    *          - The operator in which the operands are compared. (i.e. >, >=, <,
    *          <=, gt, ge, lt, le, ==, !=, eq, ne)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   private void testOperatorBoolean(Byte testVal, Boolean expectedVal,
       String booleanOperator) throws Exception {
@@ -2271,8 +2260,7 @@ public class ELClientIT {
     boolean pass;
 
     for (int i = 0; numberList.size() > i; i++) {
-      TestUtil
-          .logTrace("*** Start " + "\"" + "Byte" + "\"" + " Test Sequence ***");
+      logger.log(Logger.Level.TRACE, "*** Start " + "\"" + "Byte" + "\"" + " Test Sequence ***");
 
       Object testNum = numberList.get(i);
 
@@ -2305,8 +2293,7 @@ public class ELClientIT {
 
       } finally {
         ExprEval.cleanup();
-        TestUtil
-            .logTrace("*** End " + "\"" + "Byte" + "\"" + " Test Sequence ***");
+        logger.log(Logger.Level.TRACE, "*** End " + "\"" + "Byte" + "\"" + " Test Sequence ***");
       }
 
       if (!pass)
@@ -2327,7 +2314,6 @@ public class ELClientIT {
    * @param booleanOperator
    *          - The operator in which the operands are compared. (i.e. ">, >=,
    *          <, <=, gt, ge, lt, le, ==, !=, eq, ne)
-   * @throws com.sun.ts.lib.harness.EETest.Fault
    */
   private void testOperatorBoolean(Object testValOne, Object testValTwo,
       Boolean expectedVal, String booleanOperator) throws Exception {
@@ -2358,8 +2344,7 @@ public class ELClientIT {
 
     } finally {
       ExprEval.cleanup();
-      TestUtil
-          .logTrace("*** End " + "\"" + "String" + "\"" + " Test Sequence ***");
+      logger.log(Logger.Level.TRACE, "*** End " + "\"" + "String" + "\"" + " Test Sequence ***");
     }
 
     if (!pass)

--- a/glassfish-runner/el-tck/pom.xml
+++ b/glassfish-runner/el-tck/pom.xml
@@ -122,159 +122,10 @@
                 </executions>
             </plugin>
 
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <id>1-StopDomain1</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>stop-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>2-StartDomain1</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>start-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>3-Enable Trace requests</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>set</argument>
-                                <argument>server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>4-Delete User j2ee</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>--passwordfile</argument>
-                                <argument>${project.basedir}/j2ee.pass</argument>
-                                <argument>delete-file-user</argument>
-                                <argument>j2ee</argument>
-                            </arguments>
-                            <successCodes>
-                                <successCode>0</successCode>
-                                <successCode>1</successCode>
-                            </successCodes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>5-Add User j2ee</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>--passwordfile</argument>
-                                <argument>${project.basedir}/j2ee.pass</argument>
-                                <argument>create-file-user</argument>
-                                <argument>--groups</argument>
-                                <argument>staff:mgr</argument>
-                                <argument>j2ee</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>6-Delete User javajoe</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>--passwordfile</argument>
-                                <argument>${project.basedir}/javajoe.pass</argument>
-                                <argument>delete-file-user</argument>
-                                <argument>javajoe</argument>
-                            </arguments>
-                            <successCodes>
-                                <successCode>0</successCode>
-                                <successCode>1</successCode>
-                            </successCodes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>7-Add User javajoe</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>--passwordfile</argument>
-                                <argument>${project.basedir}/javajoe.pass</argument>
-                                <argument>create-file-user</argument>
-                                <argument>--groups</argument>
-                                <argument>guest</argument>
-                                <argument>javajoe</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>8-list users</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>list-file-users</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>9-StopDomain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>stop-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
             <!-- <plugin>
-                <groupId>org.netbeans.tools</groupId>
+                <groupId>jakarta.tck</groupId>
                 <artifactId>sigtest-maven-plugin</artifactId>
-                <version>1.5</version>
+                <version>2.1</version>
                 <configuration>
                     <sigfile>target/el-tck/jakarta.el.sig_6.0</sigfile>
                     <packages>jakarta.el</packages>
@@ -309,19 +160,11 @@
                             </additionalClasspathElements>
                             <dependenciesToScan>jakartatck:jakarta-expression-language-tck</dependenciesToScan>
                             <systemPropertyVariables>
-                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
-                                <webServerHost>localhost</webServerHost>
-                                <webServerPort>8080</webServerPort>
                                 <el.classes>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.el-api.jar:${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/expressly.jar</el.classes>
                                 <variable.mapper>org.glassfish.expressly.lang.VariableMapperImpl</variable.mapper>
                                 <junit.log.traceflag>true</junit.log.traceflag>
-                                <user>j2ee</user>
-                                <password>j2ee</password>
-                                <authuser>javajoe</authuser>
-                                <authpassword>javajoe</authpassword>
                                 <harness.log.traceflag>true</harness.log.traceflag>
                                 <cts.harness.debug>true</cts.harness.debug>
-                                <porting.ts.url.class.1>com.sun.ts.tests.websocket.lib.implementation.sun.common.SunRIURL</porting.ts.url.class.1>
                                 <jimage.dir>${project.build.directory}/jdk11-bundle</jimage.dir>
                                 <sigTestClasspath>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.el-api.jar:${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/expressly.jar:${project.build.directory}/jdk11-bundle/java.base:${project.build.directory}/jdk11-bundle/java.rmi:${project.build.directory}/jdk11-bundle/java.sql:${project.build.directory}/jdk11-bundle/java.naming</sigTestClasspath>
                             </systemPropertyVariables>


### PR DESCRIPTION
**Describe the change**

Applied below changes to EL-TCK module
- Updated the sigtest-maven-plugin to jakarta.tck:sigtest-maven-plugin:2.1
- Replaced use of TestUtil with ELTestUtil
- Copied classes from com.sun.ts.tests.common.el to com.sun.ts.tests.el.common 
- Removed usage of com.sun.ts.lib.harness.EETest.Fault