### PR TITLE
let GH run just the last commit and cancel build in progress

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,6 +26,10 @@ permissions:
   id-token: write
   checks: write
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 


### PR DESCRIPTION
@scottmarlow consider adding this so there's only the last commit being checked by GH action build