### PR TITLE
Fix jakartaee/persistence#591, Avoid calling fetch for the same attribute multiple times with different join types

### DIFF
--- a/src/com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java
+++ b/src/com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java
@@ -5218,9 +5218,9 @@ public class Client extends Util {
     try {
       getEntityTransaction().begin();
       CriteriaQuery<Customer> cquery = cbuilder.createQuery(Customer.class);
-      From<Customer, Customer> customer = cquery.from(Customer.class);
+      From<Customer, Customer> c1 = cquery.from(Customer.class);
 
-      JoinType jt = customer.fetch(Customer_.spouse).getJoinType();
+      JoinType jt = c1.fetch(Customer_.spouse).getJoinType();
       if (jt.equals(JoinType.INNER)) {
         TestUtil.logTrace("Received expected JoinType:" + jt.name());
         pass1 = true;
@@ -5228,7 +5228,8 @@ public class Client extends Util {
         TestUtil.logErr("Expected JoinType:" + JoinType.INNER.name()
             + ", actual:" + jt.name());
       }
-      jt = customer.fetch(Customer_.spouse, JoinType.INNER).getJoinType();
+      From<Customer, Customer> c2 = cquery.from(Customer.class);
+      jt = c2.fetch(Customer_.spouse, JoinType.INNER).getJoinType();
       if (jt.equals(JoinType.INNER)) {
         TestUtil.logTrace("Received expected JoinType:" + jt.name());
         pass2 = true;
@@ -5237,7 +5238,8 @@ public class Client extends Util {
         TestUtil.logErr("Expected JoinType:" + JoinType.INNER.name()
             + ", actual:" + jt.name());
       }
-      jt = customer.fetch(Customer_.spouse, JoinType.LEFT).getJoinType();
+      From<Customer, Customer> c3 = cquery.from(Customer.class);
+      jt = c3.fetch(Customer_.spouse, JoinType.LEFT).getJoinType();
       if (jt.equals(JoinType.LEFT)) {
         TestUtil.logTrace("Received expected JoinType:" + jt.name());
         pass3 = true;
@@ -5256,7 +5258,8 @@ public class Client extends Util {
        * ", actual:" + jt.name()); }
        */
 
-      Attribute attr = customer.fetch(Customer_.spouse).getAttribute();
+      From<Customer, Customer> c4 = cquery.from(Customer.class);
+      Attribute attr = c4.fetch(Customer_.spouse).getAttribute();
       if (attr.getName().equals(Customer_.spouse.getName())) {
         TestUtil.logTrace("Received expected attribute:" + attr.getName());
         pass4 = true;


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/persistence/issues/591

**Describe the change**
Avoid calling `FetchParent#fetch` multiple times for the same attribute with different join types.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
