### PR TITLE
Fix jakartaee/persistence#591, Avoid calling fetch for the same attribute multiple times with different join types

### DIFF
--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client1.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client1.java
@@ -1503,16 +1503,17 @@ public class Client1 extends UtilCustomerData {
 		try {
 			getEntityTransaction().begin();
 			CriteriaQuery<Customer> cquery = cbuilder.createQuery(Customer.class);
-			From<Customer, Customer> customer = cquery.from(Customer.class);
+			From<Customer, Customer> c1 = cquery.from(Customer.class);
 
-			JoinType jt = customer.fetch(Customer_.spouse).getJoinType();
+			JoinType jt = c1.fetch(Customer_.spouse).getJoinType();
 			if (jt.equals(JoinType.INNER)) {
 				logger.log(Logger.Level.TRACE, "Received expected JoinType:" + jt.name());
 				pass1 = true;
 			} else {
 				logger.log(Logger.Level.ERROR, "Expected JoinType:" + JoinType.INNER.name() + ", actual:" + jt.name());
 			}
-			jt = customer.fetch(Customer_.spouse, JoinType.INNER).getJoinType();
+			From<Customer, Customer> c2 = cquery.from(Customer.class);
+			jt = c2.fetch(Customer_.spouse, JoinType.INNER).getJoinType();
 			if (jt.equals(JoinType.INNER)) {
 				logger.log(Logger.Level.TRACE, "Received expected JoinType:" + jt.name());
 				pass2 = true;
@@ -1520,7 +1521,8 @@ public class Client1 extends UtilCustomerData {
 			} else {
 				logger.log(Logger.Level.ERROR, "Expected JoinType:" + JoinType.INNER.name() + ", actual:" + jt.name());
 			}
-			jt = customer.fetch(Customer_.spouse, JoinType.LEFT).getJoinType();
+			From<Customer, Customer> c3 = cquery.from(Customer.class);
+			jt = c3.fetch(Customer_.spouse, JoinType.LEFT).getJoinType();
 			if (jt.equals(JoinType.LEFT)) {
 				logger.log(Logger.Level.TRACE, "Received expected JoinType:" + jt.name());
 				pass3 = true;
@@ -1538,7 +1540,8 @@ public class Client1 extends UtilCustomerData {
 			 * JoinType.RIGHT.name() + ", actual:" + jt.name()); }
 			 */
 
-			Attribute attr = customer.fetch(Customer_.spouse).getAttribute();
+			From<Customer, Customer> c4 = cquery.from(Customer.class);
+			Attribute attr = c4.fetch(Customer_.spouse).getAttribute();
 			if (attr.getName().equals(Customer_.spouse.getName())) {
 				logger.log(Logger.Level.TRACE, "Received expected attribute:" + attr.getName());
 				pass4 = true;


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/persistence/issues/591

**Describe the change**
Avoid calling `FetchParent#fetch` multiple times for the same attribute with different join types.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
