### PR TITLE
[tckrefactor] Jakarta Persistence 3.2 - EntityManager and PersistenceUnitUtil tests

### DIFF
--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
@@ -117,8 +117,15 @@ public class Client3 extends PMClientBase {
             }
 
         } catch (Exception e) {
-            getEntityTransaction().rollback();
             logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        } finally {
+            try {
+                if (getEntityTransaction().isActive()) {
+                    getEntityTransaction().rollback();
+                }
+            } catch (Exception fe) {
+                logger.log(Logger.Level.ERROR, "Unexpected exception rolling back TX:", fe);
+            }
         }
         if (!pass1 || !pass2) {
             throw new Exception("getReferenceForExistingEntityTest failed");
@@ -169,8 +176,15 @@ public class Client3 extends PMClientBase {
                 logger.log(Logger.Level.ERROR, "Fetched entity is not same as expected.");
             }
         } catch (Exception e) {
-            getEntityTransaction().rollback();
             logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        } finally {
+            try {
+                if (getEntityTransaction().isActive()) {
+                    getEntityTransaction().rollback();
+                }
+            } catch (Exception fe) {
+                logger.log(Logger.Level.ERROR, "Unexpected exception rolling back TX:", fe);
+            }
         }
         if (!pass) {
             throw new Exception("runWithConnectionTest failed");
@@ -215,8 +229,15 @@ public class Client3 extends PMClientBase {
                 logger.log(Logger.Level.ERROR, "Fetched entity is not same as expected.");
             }
         } catch (Exception e) {
-            getEntityTransaction().rollback();
             logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        } finally {
+            try {
+                if (getEntityTransaction().isActive()) {
+                    getEntityTransaction().rollback();
+                }
+            } catch (Exception fe) {
+                logger.log(Logger.Level.ERROR, "Unexpected exception rolling back TX:", fe);
+            }
         }
         if (!pass) {
             throw new Exception("callWithConnectionTest failed");
@@ -235,7 +256,6 @@ public class Client3 extends PMClientBase {
                 logger.log(Logger.Level.ERROR, "Fetched entity is not same as expected.");
             }
         } catch (Exception e) {
-            getEntityTransaction().rollback();
             logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
         }
         if (!pass) {
@@ -256,7 +276,6 @@ public class Client3 extends PMClientBase {
                 logger.log(Logger.Level.ERROR, "Fetched entity is not same as expected.");
             }
         } catch (Exception e) {
-            getEntityTransaction().rollback();
             logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
         }
         if (!pass) {
@@ -276,7 +295,6 @@ public class Client3 extends PMClientBase {
                 logger.log(Logger.Level.ERROR, "CacheRetrieveMode property is not set.");
             }
         } catch (Exception e) {
-            getEntityTransaction().rollback();
             logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
         }
         if (!pass) {
@@ -296,7 +314,6 @@ public class Client3 extends PMClientBase {
                 logger.log(Logger.Level.ERROR, "CacheStoreMode property is not set.");
             }
         } catch (Exception e) {
-            getEntityTransaction().rollback();
             logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
         }
         if (!pass) {

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
@@ -36,7 +36,6 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 public class Client3 extends PMClientBase {
 
@@ -133,13 +132,10 @@ public class Client3 extends PMClientBase {
             Order order = new Order(0, 000, "desc0");
             // Verify that getReference() to order fails
             // EntityNotFoundException shall be thrown on non-existing entity access
-            Order reference = getEntityManager().getReference(order);
+            Order referenceOrder = getEntityManager().getReference(order);
+            String description = referenceOrder.getdescription();
         } catch (EntityNotFoundException enfe) {
-            if (enfe.getMessage().contains("Could not find Entity")) {
-                pass = true;
-            } else {
-                logger.log(Logger.Level.ERROR, "Unexpected exception message: " + enfe.getMessage());
-            }
+            pass = true;
         } catch (Exception e) {
             logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
         }

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client3.java
@@ -1,0 +1,361 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package ee.jakarta.tck.persistence.core.entityManager2;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.CacheRetrieveMode;
+import jakarta.persistence.CacheStoreMode;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.persistence.FindOption;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.RefreshOption;
+import jakarta.persistence.Timeout;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.lang.System.Logger;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+public class Client3 extends PMClientBase {
+
+    private static final Logger logger = System.getLogger(Client3.class.getName());
+
+    Order[] orders = new Order[5];
+
+    Map map = new HashMap<String, Object>();
+
+    String dataBaseName = null;
+
+    public Client3() {
+    }
+
+    public JavaArchive createDeployment() throws Exception {
+
+        String pkgNameWithoutSuffix = Client3.class.getPackageName();
+        String pkgName = pkgNameWithoutSuffix + ".";
+        String[] classes = {pkgName + "DoesNotExist", pkgName + "Employee", pkgName + "Order"};
+        return createDeploymentJar("jpa_core_entityManager3.jar", pkgNameWithoutSuffix, classes);
+
+    }
+
+    /*
+     * setupOrderData() is called before each test
+     *
+     * @class.setup_props: jdbc.db;
+     */
+    @BeforeEach
+    public void setupOrderData() throws Exception {
+        logger.log(Logger.Level.TRACE, "setupOrderData");
+        try {
+            super.setup();
+            createDeployment();
+            removeTestData();
+            createOrderData();
+            map.putAll(getEntityManager().getProperties());
+            map.put("foo", "bar");
+            displayMap(map);
+            dataBaseName = System.getProperty("jdbc.db");
+        } catch (Exception e) {
+            logger.log(Logger.Level.ERROR, "Exception: ", e);
+            throw new Exception("Setup failed:", e);
+        }
+    }
+
+    @AfterEach
+    public void cleanupData() throws Exception {
+        try {
+            logger.log(Logger.Level.TRACE, "Cleanup data");
+            removeTestData();
+            cleanup();
+        } finally {
+            removeTestJarFromCP();
+        }
+    }
+
+    @Test
+    public void getReferenceForExistingEntityTest() throws Exception {
+        boolean pass1 = false;
+        boolean pass2 = false;
+        try {
+            getEntityTransaction().begin();
+            Order order = new Order(1, 111, "desc1");
+            Order reference = getEntityManager().getReference(order);
+            // Verify that access to entity attribute works
+            String orderDescription = reference.getdescription();
+            getEntityTransaction().commit();
+
+            if (reference instanceof Order) {
+                pass1 = true;
+            } else {
+                logger.log(Logger.Level.ERROR, "Fetched entity is not same as expected.");
+            }
+            if (orderDescription != null) {
+                pass2 = true;
+            } else {
+                logger.log(Logger.Level.ERROR, "Access to entity attribute doesn't work.");
+            }
+
+        } catch (Exception e) {
+            getEntityTransaction().rollback();
+            logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        }
+        if (!pass1 || !pass2) {
+            throw new Exception("getReferenceForExistingEntityTest failed");
+        }
+    }
+
+    @Test
+    public void getReferenceForNonExistingEntityTest() throws Exception {
+        boolean pass = false;
+        try {
+            Order order = new Order(0, 000, "desc0");
+            // Verify that getReference() to order fails
+            // EntityNotFoundException shall be thrown on non-existing entity access
+            Order reference = getEntityManager().getReference(order);
+        } catch (EntityNotFoundException enfe) {
+            if (enfe.getMessage().contains("Could not find Entity")) {
+                pass = true;
+            } else {
+                logger.log(Logger.Level.ERROR, "Unexpected exception message: " + enfe.getMessage());
+            }
+        } catch (Exception e) {
+            logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        }
+        if (!pass) {
+            throw new Exception("getReferenceForNonExistingEntityTest failed");
+        }
+    }
+
+    @Test
+    public void runWithConnectionTest() throws Exception {
+        boolean pass = false;
+        Order newOrder = new Order(50, 5555, "desc55");
+        try {
+            getEntityTransaction().begin();
+            getEntityManager().<Connection>runWithConnection(
+                    connection -> {
+                        try (PreparedStatement stmt = connection.prepareStatement(
+                                "INSERT INTO PURCHASE_ORDER(ID, TOTAL, DESCRIPTION) VALUES(?, ?, ?)")) {
+                            stmt.setInt(1, newOrder.getId());
+                            stmt.setInt(2, newOrder.getTotal());
+                            stmt.setString(3, newOrder.getdescription());
+                            stmt.executeUpdate();
+                        }
+                    }
+            );
+            getEntityTransaction().commit();
+            Order foundOrder = getEntityManager().find(Order.class, newOrder.getId());
+            if (foundOrder.equals(newOrder)) {
+                pass = true;
+            } else {
+                logger.log(Logger.Level.ERROR, "Fetched entity is not same as expected.");
+            }
+        } catch (Exception e) {
+            getEntityTransaction().rollback();
+            logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        }
+        if (!pass) {
+            throw new Exception("runWithConnectionTest failed");
+        }
+    }
+
+    @Test
+    public void callWithConnectionTest() throws Exception {
+        boolean pass = false;
+        Order newOrder = new Order(60, 6666, "desc66");
+        try {
+            getEntityTransaction().begin();
+            Order selectedOrder = getEntityManager().<Connection, Order>callWithConnection(
+                    connection -> {
+                        try (PreparedStatement stmt = connection.prepareStatement(
+                                "INSERT INTO PURCHASE_ORDER(ID, TOTAL, DESCRIPTION) VALUES(?, ?, ?)")) {
+                            stmt.setInt(1, newOrder.getId());
+                            stmt.setInt(2, newOrder.getTotal());
+                            stmt.setString(3, newOrder.getdescription());
+                            stmt.executeUpdate();
+                        }
+                        Order order = new Order();
+                        try (PreparedStatement stmt = connection.prepareStatement(
+                                "SELECT * FROM PURCHASE_ORDER WHERE ID = ?")) {
+                            stmt.setInt(1, newOrder.getId());
+                            stmt.execute();
+                            ResultSet rSet = stmt.getResultSet();
+                            rSet.next();
+                            order.setId(rSet.getInt(1));
+                            order.setTotal(rSet.getInt(2));
+                            order.setdescription(rSet.getString(3));
+                            rSet.close();
+                        }
+                        return order;
+                    }
+            );
+            getEntityTransaction().commit();
+            Order foundOrder = getEntityManager().find(Order.class, newOrder.getId());
+            if (foundOrder.equals(selectedOrder)) {
+                pass = true;
+            } else {
+                logger.log(Logger.Level.ERROR, "Fetched entity is not same as expected.");
+            }
+        } catch (Exception e) {
+            getEntityTransaction().rollback();
+            logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        }
+        if (!pass) {
+            throw new Exception("callWithConnectionTest failed");
+        }
+    }
+
+    @Test
+    public void findOptionsTest() throws Exception {
+        boolean pass = false;
+        try {
+            FindOption[] findOptions = new FindOption[]{CacheRetrieveMode.BYPASS, CacheStoreMode.BYPASS, LockModeType.NONE};
+            Order foundOrder = getEntityManager().find(Order.class, orders[0].getId(), findOptions);
+            if (foundOrder.equals(orders[0])) {
+                pass = true;
+            } else {
+                logger.log(Logger.Level.ERROR, "Fetched entity is not same as expected.");
+            }
+        } catch (Exception e) {
+            getEntityTransaction().rollback();
+            logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        }
+        if (!pass) {
+            throw new Exception("findOptionsTest failed");
+        }
+    }
+
+    @Test
+    public void refreshOptionsTest() throws Exception {
+        boolean pass = false;
+        try {
+            Order order = getEntityManager().find(Order.class, orders[0].getId());
+            RefreshOption[] refreshOptions = new RefreshOption[]{CacheStoreMode.BYPASS, LockModeType.NONE, Timeout.seconds(10)};
+            getEntityManager().refresh(order, refreshOptions);
+            if (order.equals(orders[0])) {
+                pass = true;
+            } else {
+                logger.log(Logger.Level.ERROR, "Fetched entity is not same as expected.");
+            }
+        } catch (Exception e) {
+            getEntityTransaction().rollback();
+            logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        }
+        if (!pass) {
+            throw new Exception("refreshOptionsTest failed");
+        }
+    }
+
+    @Test
+    public void setCacheRetrieveModeTest() throws Exception {
+        boolean pass = false;
+        try {
+            EntityManager em = getEntityManager();
+            em.setCacheRetrieveMode(CacheRetrieveMode.USE);
+            if (CacheRetrieveMode.USE == em.getCacheRetrieveMode()) {
+                pass = true;
+            } else {
+                logger.log(Logger.Level.ERROR, "CacheRetrieveMode property is not set.");
+            }
+        } catch (Exception e) {
+            getEntityTransaction().rollback();
+            logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        }
+        if (!pass) {
+            throw new Exception("setCacheRetrieveModeTest failed");
+        }
+    }
+
+    @Test
+    public void setCacheStoreModeTest() throws Exception {
+        boolean pass = false;
+        try {
+            EntityManager em = getEntityManager();
+            em.setCacheStoreMode(CacheStoreMode.BYPASS);
+            if (CacheStoreMode.BYPASS == em.getCacheStoreMode()) {
+                pass = true;
+            } else {
+                logger.log(Logger.Level.ERROR, "CacheStoreMode property is not set.");
+            }
+        } catch (Exception e) {
+            getEntityTransaction().rollback();
+            logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        }
+        if (!pass) {
+            throw new Exception("setCacheStoreModeTest failed");
+        }
+    }
+
+
+    private void createOrderData() {
+
+        try {
+            getEntityTransaction().begin();
+            logger.log(Logger.Level.INFO, "Creating Orders");
+            orders[0] = new Order(1, 111, "desc1");
+            orders[1] = new Order(2, 222, "desc2");
+            orders[2] = new Order(3, 333, "desc3");
+            orders[3] = new Order(4, 444, "desc4");
+            orders[4] = new Order(5, 555, "desc5");
+            for (Order o : orders) {
+                logger.log(Logger.Level.TRACE, "Persisting order:" + o.toString());
+                getEntityManager().persist(o);
+            }
+            getEntityTransaction().commit();
+        } catch (Exception e) {
+            logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+        } finally {
+            try {
+                if (getEntityTransaction().isActive()) {
+                    getEntityTransaction().rollback();
+                }
+            } catch (Exception fe) {
+                logger.log(Logger.Level.ERROR, "Unexpected exception rolling back TX:", fe);
+            }
+        }
+    }
+
+    private void removeTestData() {
+        logger.log(Logger.Level.TRACE, "removeTestData");
+        if (getEntityTransaction().isActive()) {
+            getEntityTransaction().rollback();
+        }
+        try {
+            getEntityTransaction().begin();
+            getEntityManager().createNativeQuery("DELETE FROM PURCHASE_ORDER").executeUpdate();
+            getEntityTransaction().commit();
+        } catch (Exception e) {
+            logger.log(Logger.Level.ERROR, "Exception encountered while removing entities:", e);
+        } finally {
+            try {
+                if (getEntityTransaction().isActive()) {
+                    getEntityTransaction().rollback();
+                }
+            } catch (Exception re) {
+                logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
+            }
+        }
+    }
+}

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Order.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Order.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,6 +19,8 @@ package ee.jakarta.tck.persistence.core.entityManager2;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+
+import java.util.Objects;
 
 @Entity
 @Table(name = "PURCHASE_ORDER")
@@ -79,5 +81,18 @@ public class Order implements java.io.Serializable {
 
 	public String toString() {
 		return "Order id=" + getId() + ", total=" + getTotal() + ", desc=" + getdescription();
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (o == null || getClass() != o.getClass()) return false;
+		Order order = (Order) o;
+		return id == order.id && total == order.total && Objects.equals(description, order.description);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(id, total, description);
 	}
 }

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
@@ -125,6 +125,14 @@ public class Client extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
 			pass = false;
+		} finally {
+			try {
+				if (getEntityTransaction().isActive()) {
+					getEntityTransaction().rollback();
+				}
+			} catch (Exception fe) {
+				logger.log(Logger.Level.ERROR, "Unexpected exception rolling back TX:", fe);
+			}
 		}
 		if (!pass) {
 			throw new Exception("getIdentifierTest failed");
@@ -175,6 +183,14 @@ public class Client extends PMClientBase {
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
 			pass = false;
+		} finally {
+			try {
+				if (getEntityTransaction().isActive()) {
+					getEntityTransaction().rollback();
+				}
+			} catch (Exception fe) {
+				logger.log(Logger.Level.ERROR, "Unexpected exception rolling back TX:", fe);
+			}
 		}
 		if (!pass) {
 			throw new Exception("getVersionTest failed");

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2011, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2011, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,10 +14,12 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package ee.jakarta.tck.persistence.core.persistenceUtilUtil;
+package ee.jakarta.tck.persistence.core.persistenceUnitUtil;
 
 import java.lang.System.Logger;
+import java.math.BigInteger;
 
+import ee.jakarta.tck.persistence.core.versioning.Member;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -30,6 +32,8 @@ public class Client extends PMClientBase {
 
 	private static final Logger logger = (Logger) System.getLogger(Client.class.getName());
 
+	private final Employee empRef[] = new Employee[2];
+
 	public Client() {
 	}
 
@@ -37,7 +41,7 @@ public class Client extends PMClientBase {
 
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
 		String pkgName = pkgNameWithoutSuffix + ".";
-		String[] classes = { pkgName + "Employee" };
+		String[] classes = { pkgName + "Employee", "ee.jakarta.tck.persistence.core.versioning.Member" };
 		return createDeploymentJar("jpa_core_persistenceUtilUtil.jar", pkgNameWithoutSuffix, classes);
 
 	}
@@ -49,6 +53,7 @@ public class Client extends PMClientBase {
 			super.setup();
 			createDeployment();
 			removeTestData();
+			createTestData();
 		} catch (Exception e) {
 			logger.log(Logger.Level.ERROR, "Exception: ", e);
 			throw new Exception("Setup failed:", e);
@@ -57,9 +62,9 @@ public class Client extends PMClientBase {
 
 	/*
 	 * @testName: getPersistenceUtilUtilTest
-	 * 
+	 *
 	 * @assertion_ids: PERSISTENCE:JAVADOC:384;
-	 * 
+	 *
 	 * @test_Strategy:
 	 *
 	 */
@@ -80,9 +85,9 @@ public class Client extends PMClientBase {
 
 	/*
 	 * @testName: getIdentifierTest
-	 * 
+	 *
 	 * @assertion_ids: PERSISTENCE:JAVADOC:385;
-	 * 
+	 *
 	 * @test_Strategy: Call PersistenceUnitUtil.getIdentifierTest on an entity and
 	 * verify the correct id is returned
 	 */
@@ -128,9 +133,9 @@ public class Client extends PMClientBase {
 
 	/*
 	 * @testName: getIdentifierIllegalArgumentExceptionTest
-	 * 
+	 *
 	 * @assertion_ids: PERSISTENCE:JAVADOC:548;
-	 * 
+	 *
 	 * @test_Strategy: Call PersistenceUnitUtil.getIdentifierTest of a non-entity
 	 * and verify IllegalArgumentException is thrown
 	 */
@@ -152,6 +157,89 @@ public class Client extends PMClientBase {
 		}
 	}
 
+	@Test
+	public void getVersionTest() throws Exception {
+		boolean pass = false;
+
+		Member member = new Member(1, "Member 1", true, BigInteger.valueOf(1000L));
+		try {
+			getEntityTransaction().begin();
+			getEntityManager().persist(member);
+
+			PersistenceUnitUtil puu = getEntityManager().getEntityManagerFactory().getPersistenceUnitUtil();
+			getEntityTransaction().commit();
+			Integer version = (Integer) puu.getVersion(member);
+			if (version != null && version.equals(member.getVersion())) {
+				pass = true;
+			}
+		} catch (Exception e) {
+			logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+			pass = false;
+		}
+		if (!pass) {
+			throw new Exception("getVersionTest failed");
+		}
+	}
+
+	@Test
+	public void loadIsLoadTest() throws Exception {
+		boolean pass = false;
+
+		try {
+			Employee employee = getEntityManager().find(Employee.class, empRef[0].getId());
+			PersistenceUnitUtil puu = getEntityManager().getEntityManagerFactory().getPersistenceUnitUtil();
+			puu.load(employee, "salary");
+			if (puu.isLoaded(employee, "salary")) {
+				pass = true;
+			}
+		} catch (Exception e) {
+			logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+			pass = false;
+		}
+		if (!pass) {
+			throw new Exception("loadIsLoadTest failed");
+		}
+	}
+
+	@Test
+	public void isInstanceTest() throws Exception {
+		boolean pass = false;
+
+		try {
+			Employee foundEmployee = getEntityManager().find(Employee.class, empRef[0].getId());
+			PersistenceUnitUtil puu = getEntityManager().getEntityManagerFactory().getPersistenceUnitUtil();
+			if (puu.isInstance(foundEmployee, Employee.class)) {
+				pass = true;
+			}
+		} catch (Exception e) {
+			logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+			pass = false;
+		}
+		if (!pass) {
+			throw new Exception("isInstanceTest failed");
+		}
+	}
+
+	@Test
+	public void getClassTest() throws Exception {
+		boolean pass = false;
+
+		try {
+			Employee foundEmployee = getEntityManager().find(Employee.class, empRef[0].getId());
+			PersistenceUnitUtil puu = getEntityManager().getEntityManagerFactory().getPersistenceUnitUtil();
+			Class<?> clazz = puu.getClass(foundEmployee);
+			if (clazz == Employee.class) {
+				pass = true;
+			}
+		} catch (Exception e) {
+			logger.log(Logger.Level.ERROR, "Unexpected exception occurred", e);
+			pass = false;
+		}
+		if (!pass) {
+			throw new Exception("getClassTest failed");
+		}
+	}
+
 	@AfterEach
 	public void cleanup() throws Exception {
 		try {
@@ -161,6 +249,38 @@ public class Client extends PMClientBase {
 			super.cleanup();
 		} finally {
 			removeTestJarFromCP();
+		}
+	}
+
+	private void createTestData() throws Exception {
+		logger.log(Logger.Level.TRACE, "createTestData");
+
+		try {
+			getEntityTransaction().begin();
+			// logger.log(Logger.Level.TRACE,"Create 20 employees");
+			empRef[0] = new Employee(100, "Alan", "Frechette", getSQLDate("2000-02-14"), (float) 35000.0);
+
+			// logger.log(Logger.Level.TRACE,"Start to persist employees ");
+			for (Employee e : empRef) {
+				if (e != null) {
+					getEntityManager().persist(e);
+					logger.log(Logger.Level.TRACE, "persisted employee " + e);
+				}
+			}
+
+			getEntityTransaction().commit();
+			logger.log(Logger.Level.TRACE, "Created TestData");
+
+		} catch (Exception re) {
+			logger.log(Logger.Level.ERROR, "Unexpected Exception in createTestData:", re);
+		} finally {
+			try {
+				if (getEntityTransaction().isActive()) {
+					getEntityTransaction().rollback();
+				}
+			} catch (Exception re) {
+				logger.log(Logger.Level.ERROR, "Unexpected Exception in createTestData while rolling back TX:", re);
+			}
 		}
 	}
 

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
@@ -41,7 +41,7 @@ public class Client extends PMClientBase {
 
 		String pkgNameWithoutSuffix = Client.class.getPackageName();
 		String pkgName = pkgNameWithoutSuffix + ".";
-		String[] classes = { pkgName + "Employee", "ee.jakarta.tck.persistence.core.versioning.Member" };
+		String[] classes = { pkgName + "Employee", Member.class.getName() };
 		return createDeploymentJar("jpa_core_persistenceUtilUtil.jar", pkgNameWithoutSuffix, classes);
 
 	}

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Employee.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Employee.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,12 +14,14 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package ee.jakarta.tck.persistence.core.persistenceUtilUtil;
+package ee.jakarta.tck.persistence.core.persistenceUnitUtil;
 
 import java.sql.Date;
 
+import jakarta.persistence.Basic;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
@@ -89,6 +91,7 @@ public class Employee implements java.io.Serializable {
 	}
 
 	@Column(name = "SALARY")
+	@Basic(fetch = FetchType.LAZY)
 	public float getSalary() {
 		return salary;
 	}


### PR DESCRIPTION
Another set of tests for new Jakarta Persistence 3.2. In this case it's about EntityManager and PersistenceUnitUtil new features:
https://jakartaee.github.io/persistence/latest-nightly/nightly.html#jakarta-persistence-3-2

Tested areas:
- Added setCacheStoreMode(), and setCacheRetreiveMode() methods to EntityManager and Query
- Added find(), refresh(), lock() overloads to EntityManager taking newly introduced FindOptions, RefreshOptions, and LockOptions respectively
- Added setCacheStoreMode(), and setCacheRetreiveMode() methods to EntityManager and Query
- Added getReference overload to EntityManager
- Added runWithConnection() and callWithConnection() to EntityManager
- Added getVersion(), isLoaded(), load(), isInstance() and getClass() methods to PersistenceUnitUtil


CC @lukasj @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
