### PR TITLE
[tckrefactor] Jakarta Persistence 3.2 - JPQL new ID() and VERSION() functions

### DIFF
--- a/jpa/bin/pom.xml
+++ b/jpa/bin/pom.xml
@@ -477,7 +477,7 @@
             <id>eclipselink</id>
             <properties>
                 <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-                <eclipselink.asm.version>9.6.0</eclipselink.asm.version>
+                <eclipselink.asm.version>9.7.0</eclipselink.asm.version>
                 <eclipselink.version>5.0.0-B01</eclipselink.version>
             </properties>
             <dependencies>

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/Client.java
@@ -168,8 +168,29 @@ public class Client extends PMClientBase {
 	@Test
 	public void getVersionTest() throws Exception {
 		boolean pass = false;
+		final int ID = 1;
+		Member member = new Member(ID, "Member 1", true, BigInteger.valueOf(1000L));
 
-		Member member = new Member(1, "Member 1", true, BigInteger.valueOf(1000L));
+		//Try cleanup first
+		try {
+			getEntityTransaction().begin();
+			Member member1 = getEntityManager().find(Member.class, ID);
+			if (member1 != null) {
+				getEntityManager().remove(member1);
+				getEntityTransaction().commit();
+			}
+		} catch (Exception e) {
+			logger.log(Logger.Level.ERROR, "Exception encountered while removing entity:", e);
+		} finally {
+			try {
+				if (getEntityTransaction().isActive()) {
+					getEntityTransaction().rollback();
+				}
+			} catch (Exception re) {
+				logger.log(Logger.Level.ERROR, "Unexpected Exception in removeTestData:", re);
+			}
+		}
+		//Prepare test data and test created version after commit
 		try {
 			getEntityTransaction().begin();
 			getEntityManager().persist(member);


### PR DESCRIPTION
Another set of tests for new Jakarta Persistence 3.2. In this case it's about JPQL ID() and VERSION() functions:
https://jakartaee.github.io/persistence/latest-nightly/nightly.html#jakarta-persistence-3-2

Tested areas:
- Test Query with ID() in SELECT and WHERE parts
- Test Query with VERSION() in SELECT and WHERE parts

plus there are
- Fix in `ee.jakarta.tck.persistence.core.persistenceUnitUtil.Client#getVersionTest` to avoid `primary key constraint` issue
- `org.eclipse.persistence.asm` dependency upgrade into 9.7.0

Note: New test can pass against latest EclipseLink snapshot (5.0.0-SNAPSHOT) now.

CC @lukasj @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
