### PR TITLE
Fixed usage of the exec-maven-plugin to use same JDK as was used to run Maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -747,7 +747,13 @@
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>exec-maven-plugin</artifactId>
-                    <version>1.6.0</version>
+                    <version>3.2.0</version>
+                    <configuration>
+                        <environmentVariables>
+                            <AS_JAVA>${java.home}</AS_JAVA>
+                            <JAVA_HOME>${java.home}</JAVA_HOME>
+                        </environmentVariables>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>


### PR DESCRIPTION
* Noticed when reviewing https://github.com/jakartaee/platform-tck/pull/1291
* If you use Ant exec somewhere - that is the same situation.
* Critical especially when you use `.mavenrc` to configure Maven but your local system uses older java.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
