### PR TITLE
[tckrefactor] Jakarta Persistence 3.2 - CriteriaQuery test fix

### DIFF
--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client9.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client9.java
@@ -67,6 +67,8 @@ public class Client9 extends UtilCriteriaEntityData {
 
         CriteriaQuery<CriteriaEntity> cQuery = cb.createQuery(CriteriaEntity.class);
         if (cQuery != null) {
+            Root<CriteriaEntity> root = cQuery.from(CriteriaEntity.class);
+            cQuery.select(root);
             cQuery.where(cb.and(Collections.emptyList()));
             TypedQuery<CriteriaEntity> query = getEntityManager().createQuery(cQuery);
             List<CriteriaEntity> result = query.getResultList();
@@ -103,6 +105,8 @@ public class Client9 extends UtilCriteriaEntityData {
 
         CriteriaQuery<CriteriaEntity> cQuery = cb.createQuery(CriteriaEntity.class);
         if (cQuery != null) {
+            Root<CriteriaEntity> root = cQuery.from(CriteriaEntity.class);
+            cQuery.select(root);
             cQuery.where(cb.or(Collections.emptyList()));
             TypedQuery<CriteriaEntity> query = getEntityManager().createQuery(cQuery);
             List<CriteriaEntity> result = query.getResultList();


### PR DESCRIPTION
**Fixes Issue**
There was issue in new CriteriaBuilder tests. There wasn't `from()` and `select()` mentioned.

**Describe the change**
Add missing method calls.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
@lukasj 