### PR TITLE
add test excludes for accepted TCK challenge persistence/issues/579 Multiple fetch joins for same attribute

### DIFF
--- a/install/jakartaee/bin/ts.jtx
+++ b/install/jakartaee/bin/ts.jtx
@@ -78,6 +78,14 @@ com/sun/ts/tests/jpa/core/query/apitests/Client.java#queryAPITest29_from_pmservl
 com/sun/ts/tests/jpa/core/query/apitests/Client.java#queryAPITest29_from_puservlet
 com/sun/ts/tests/jpa/core/query/apitests/Client.java#queryAPITest29_from_stateless3
 
+# https://github.com/jakartaee/persistence/issues/591 Multiple fetch joins for same attribute
+com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java#fetchTest_from_appmanagedNoTx
+com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java#fetchTest_from_appmanaged
+com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java#fetchTest_from_pmservlet
+com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java#fetchTest_from_puservlet
+com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java#fetchTest_from_stateful3
+com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java#fetchTest_from_stateless3
+
 ################
 # Security API
 ################

--- a/install/jpa/bin/ts.jtx
+++ b/install/jpa/bin/ts.jtx
@@ -39,3 +39,5 @@ com/sun/ts/tests/jpa/core/query/apitests/Client.java#queryAPITest27_from_standal
 com/sun/ts/tests/jpa/core/query/apitests/Client.java#queryAPITest29_from_standalone
 com/sun/ts/tests/jpa/se/entityManager/Client.java#typedQueryMethodsAfterClose16Test_from_standalone
 
+# https://github.com/jakartaee/persistence/issues/591 Multiple fetch joins for same attribute
+com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java#fetchTest_from_standalone

--- a/release/tools/jpa.xml
+++ b/release/tools/jpa.xml
@@ -22,7 +22,7 @@
     <import file="../../bin/xml/ts.common.props.xml"/>
 
     <property name="deliverable.version" value="3.1"/>
-    <property name="deliverable.tck.version" value="3.1.3"/>
+    <property name="deliverable.tck.version" value="3.1.4"/>
 
     <target name="init">
         <mkdir dir="${deliverable.bundle.dir}/bin"/>


### PR DESCRIPTION


**Fixes Issue**
https://github.com/jakartaee/persistence/issues/591

**Describe the change**
Excludes com/sun/ts/tests/jpa/core/criteriaapi/metamodelquery/Client.java test

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
