### PR TITLE
JSTL Tests: Fix compilation error, Update versions

### DIFF
--- a/glassfish-runner/jstl-tck/pom.xml
+++ b/glassfish-runner/jstl-tck/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
-        <version>10.0.0-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jstl-tck</artifactId>
-    <version>10.0.0-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -45,7 +45,7 @@
         <jstl.db.url>jdbc:derby://${jstl.db.server}:${jstl.db.port}/${jstl.db.name};create=true</jstl.db.url>
         <jstl.db.user>cts1</jstl.db.user>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
-        <tck.artifactId>jstl-tck</tck.artifactId>
+        <tck.artifactId>jakarta-tags-tck</tck.artifactId>
         <tck.version>4.0.0</tck.version>
     </properties>
 
@@ -57,8 +57,8 @@
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>
-            <artifactId>jstl-tck</artifactId>
-            <version>11.0.0-SNAPSHOT</version>
+            <artifactId>${tck.artifactId}</artifactId>
+            <version>${tck.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>
@@ -422,7 +422,7 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.servlet.jsp-api.jar</additionalClasspathElement>
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.servlet.jsp.jstl-api.jar</additionalClasspathElement>
                             </additionalClasspathElements>
-                            <dependenciesToScan>jakartatck:jstl-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>

--- a/jstl/pom.xml
+++ b/jstl/pom.xml
@@ -26,7 +26,8 @@
         <version>11.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>jstl-tck</artifactId>
+    <artifactId>jakarta-tags-tck</artifactId>
+    <version>4.0.0</version>
     <packaging>jar</packaging>
 
     <name>JSTL</name>
@@ -37,14 +38,27 @@
         <jakarta.servlet.api.version>6.1.0-M2</jakarta.servlet.api.version>
         <jakarta.servlet.jsp-api.version>4.0.0-M2</jakarta.servlet.jsp-api.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
-        <maven.compiler.source>17</maven.compiler.source>
-        <maven.compiler.target>17</maven.compiler.target>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
+            <version>11.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>runtime</artifactId>
+            <version>11.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>libutil</artifactId>
+            <version>11.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>javatest</groupId>
+            <artifactId>javatest</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet.jsp</groupId>
@@ -59,10 +73,12 @@
         <dependency>
             <groupId>jakarta.servlet.jsp.jstl</groupId>
             <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+            <version>3.0.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
+            <version>2.0.1</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
@@ -81,54 +97,16 @@
         </dependency>
     </dependencies>
 
-    <profiles>
-        <profile>
-            <id>tck-build</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>2.3.2</version>
-                    </plugin>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <version>3.0.0-M5</version>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-jar-plugin</artifactId>
-                        <version>3.2.0</version>
-                        <configuration>
-                            <resources>
-                                <resource>
-                                    <directory>src/main/java</directory>
-                                    <includes>
-                                        <include>**/*.xml</include>
-                                    </includes>
-                                </resource>
-                            </resources>
-                        </configuration>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>attach-sources</id>
-                                <goals>
-                                    <goal>jar</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
     <build>
+        <finalName>${bundle-name}-${project.version}</finalName>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <includes>
+                    <include>com/</include>
+                </includes>
+            </resource>
+        </resources>
         <plugins>
             <!-- do not publish this artifact to Maven repositories -->
             <plugin>
@@ -137,6 +115,45 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <doclint>none</doclint>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>EFTL</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <bundle-name>jakarta-tags-tck</bundle-name>
+                <license>EFTL</license>
+            </properties>
+        </profile>
+        <profile>
+            <id>EPL</id>
+            <properties>
+                <bundle-name>tags-tck</bundle-name>
+                <license>EPL</license>
+            </properties>
+        </profile>
+    </profiles>
+
 </project>

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/common/tags/ExceptionCheckTag.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/common/tags/ExceptionCheckTag.java
@@ -171,7 +171,7 @@ public class ExceptionCheckTag extends TagSupport implements TryCatchFinally {
         sb.append("</strong> was thrown!");
 
         if (t instanceof JspException && _checkRootCause) {
-          Throwable rt = ((JspException) t).getRootCause();
+          Throwable rt = ((JspException) t).getCause();
           if (rt != null) {
             if (_rootException == null) {
               sb.append("<br>\nThe root cause of Exception defined");


### PR DESCRIPTION
**Describe the change**
- Correct the TCK version, modules version, update jstl artifact name
- Replace JspException.getRootCause with JspException.getCause() to fix compilation errors

Related PR : https://github.com/jakartaee/platform-tck/pull/1203/
