### PR TITLE
Fix EJB 2.x Refactor

### DIFF
--- a/common/src/main/java/com/sun/ts/tests/common/testlogic/ejb/bb/argsemantics/TestLogic.java
+++ b/common/src/main/java/com/sun/ts/tests/common/testlogic/ejb/bb/argsemantics/TestLogic.java
@@ -1,0 +1,186 @@
+/*
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.common.testlogic.ejb.bb.argsemantics;
+
+import java.util.Properties;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.common.ejb.calleebeans.SimpleArgument;
+import com.sun.ts.tests.common.ejb.calleebeans.StatefulCallee;
+import com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeHome;
+import com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeLocal;
+import com.sun.ts.tests.common.ejb.calleebeans.StatefulCalleeLocalHome;
+
+public class TestLogic {
+
+  /*
+   * Names used for Callee beans lookups.
+   */
+  public static final String prefix = "java:comp/env/";
+
+  public static final String statefulRemoteLookup = prefix
+      + "ejb/StatefulCalleeRemote";
+
+  public static final String statefulLocalLookup = prefix
+      + "ejb/StatefulCalleeLocal";
+
+  public static final String statefulBiRemoteLookup = prefix
+      + "ejb/StatefulCalleeBothRemote";
+
+  public static final String statefulBiLocalLookup = prefix
+      + "ejb/StatefulCalleeBothLocal";
+
+  /*
+   * Expected values for our custom argument.
+   */
+  public static final int initialValue = 12;
+
+  public static final int modifiedValue = 24;
+
+  public static final int modifiedValue2 = 48;
+
+  private static StatefulCallee ssfCalleeBean = null;
+
+  private static StatefulCalleeLocal ssfCalleeLocalBean = null;
+
+  public static boolean testStatefulRemote(TSNamingContext nctx,
+      Properties props) {
+
+    return testStatefulRemote(statefulRemoteLookup, nctx, props);
+  }
+
+  public static boolean testStatefulLocal(TSNamingContext nctx,
+      Properties props) {
+
+    return testStatefulLocal(statefulLocalLookup, nctx, props);
+  }
+
+  public static boolean testStatefulBoth(TSNamingContext nctx,
+      Properties props) {
+
+    boolean pass;
+
+    pass = testStatefulRemote(statefulBiRemoteLookup, nctx, props);
+    pass &= testStatefulLocal(statefulBiLocalLookup, nctx, props);
+
+    return pass;
+  }
+
+  protected static boolean testStatefulRemote(String lookupName,
+      TSNamingContext nctx, Properties props) {
+
+    StatefulCalleeHome home;
+    ssfCalleeBean = null;
+    SimpleArgument arg;
+    boolean pass;
+
+    try {
+      arg = new SimpleArgument(initialValue);
+      TestUtil.logTrace("[TestLogic] Initial value is " + arg.getValue());
+
+      TestUtil.logTrace("[TestLogic] Looking up Callee " + lookupName + " ...");
+      home = (StatefulCalleeHome) nctx.lookup(lookupName,
+          StatefulCalleeHome.class);
+
+      ssfCalleeBean = home.create(props, arg);
+      TestUtil.logTrace("[TestLogic] Value after create is " + arg.getValue());
+
+      ssfCalleeBean.call(props, arg);
+      TestUtil.logTrace(
+          "[TestLogic] Value after business " + "method is " + arg.getValue());
+
+      pass = (arg.getValue() == initialValue);
+      if (!pass) {
+        TestUtil.logErr(
+            "[TestLogic] Argument has been " + "modified to " + arg.getValue());
+      }
+    } catch (Exception e) {
+      pass = false;
+      TestUtil.logErr("[TestLogic] Unexpected exception", e);
+    }
+
+    return pass;
+  }
+
+  protected static boolean testStatefulLocal(String lookupName,
+      TSNamingContext nctx, Properties props) {
+
+    StatefulCalleeLocalHome home;
+    ssfCalleeLocalBean = null;
+    SimpleArgument arg;
+    String msg;
+    boolean pass;
+
+    try {
+      arg = new SimpleArgument(initialValue);
+      TestUtil.logTrace("[TestLogic] Initial value is " + arg.getValue());
+
+      TestUtil.logTrace("[TestLogic] Looking up Callee " + lookupName + " ...");
+      home = (StatefulCalleeLocalHome) nctx.lookup(lookupName);
+
+      ssfCalleeLocalBean = home.create(props, arg);
+      TestUtil.logTrace("[TestLogic] Value after create is " + arg.getValue());
+      pass = (arg.getValue() == modifiedValue);
+      if (!pass) {
+        msg = "Expected Argument to be set to " + modifiedValue;
+        TestUtil.logErr("[TestLogic] " + msg);
+        throw new Exception(msg);
+      }
+
+      ssfCalleeLocalBean.call(props, arg);
+      TestUtil.logTrace(
+          "[TestLogic] Value after business " + "method is " + arg.getValue());
+
+      pass = (arg.getValue() == modifiedValue2);
+      if (!pass) {
+        TestUtil.logErr("[TestLogic] Expected argument to be " + "set to "
+            + modifiedValue2);
+      }
+    } catch (Exception e) {
+      pass = false;
+      TestUtil.logErr("[TestLogic] Unexpected exception", e);
+    }
+
+    return pass;
+  }
+
+  public static void cleanUpStatefulBean() {
+    TestUtil.logTrace("cleanUpStatefulBean");
+    try {
+      if (ssfCalleeBean != null) {
+        TestUtil.logTrace("cleanUp Session Stateful Remote Callee Bean");
+        ssfCalleeBean.remove();
+        ssfCalleeBean = null;
+      }
+
+      if (ssfCalleeLocalBean != null) {
+        TestUtil.logTrace("cleanUp Session Stateful Local Callee Bean");
+        ssfCalleeLocalBean.remove();
+        ssfCalleeLocalBean = null;
+      }
+    } catch (Exception e) {
+      TestUtil.logErr(
+          "Exception caught trying to remove Stateful Session beans", e);
+    }
+  }
+
+}

--- a/common/src/main/java/com/sun/ts/tests/common/vehicle/ejb/EJBVehicle.java
+++ b/common/src/main/java/com/sun/ts/tests/common/vehicle/ejb/EJBVehicle.java
@@ -27,6 +27,8 @@ import com.sun.ts.lib.harness.EETest;
 import com.sun.ts.lib.harness.RemoteStatus;
 import com.sun.ts.lib.util.TestUtil;
 
+import jakarta.ejb.EJBException;
+
 public class EJBVehicle {
   private EETest testObj;
 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesens/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejblink.casesens;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class CaseBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,7 +32,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbQ_ejblink_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesensT/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesensT/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejblink.casesensT;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class CaseBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesensT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/casesensT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,7 +32,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbT_ejblink_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBean2EJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejblink.scope;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class ReferencedBean2EJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejblink.scope;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class ReferencedBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,7 +35,7 @@
                                 com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scope/ReferencedBeanHome.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depMdbQ_ejblink_scope_jar1_ejb.xml"
@@ -44,7 +44,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbQ_ejblink_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBean2EJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejblink.scopeT;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class ReferencedBean2EJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejblink.scopeT;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class ReferencedBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,7 +35,7 @@
                                 com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/scopeT/ReferencedBeanHome.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depMdbT_ejblink_scope_jar1_ejb.xml"
@@ -44,7 +44,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbT_ejblink_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/single/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/single/MsgBean.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.ejblink.single;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
   <target name="compile">
       <ts.javac includes="${pkg.dir}/**/*.java,
                           com/sun/ts/tests/common/ejb/**/*.java,
-                          com/sun/ts/tests/assembly/util/refbean/**/*.java,
+                          com/sun/ts/tests/ejb/ee/deploy/util/refbean/**/*.java,
                           com/sun/ts/tests/jms/common*/**/*.java"/>
   </target>
 
@@ -34,19 +34,19 @@
       <ts.ejbjar descriptor="${my.app}_jar1_ejb.xml" archivename="${my.app}_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/single/TestCode.class,
-                           com/sun/ts/tests/assembly/util/refbean/*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"
-                excludes="com/sun/ts/tests/assembly/util/refbean/*ExternalEJB.class"/>
+                excludes="com/sun/ts/tests/ejb/ee/deploy/util/refbean/*ExternalEJB.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="${my.app}_jar2_ejb.xml" archivename="${my.app}_jar2"
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/single/MsgBean.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/refbean/*External*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*External*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"/>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/single/ejb_depMdbQ_ejblink_single_jar1_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/single/ejb_depMdbQ_ejblink_single_jar1_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>StatelessInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>StatefulInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -51,29 +51,29 @@
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
         <ejb-link>StatelessInternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
         <ejb-link>StatefulInternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
         <ejb-link>StatelessExternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
         <ejb-link>StatefulExternal</ejb-link>
       </ejb-ref>
       <resource-ref>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/single/ejb_depMdbQ_ejblink_single_jar2_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/single/ejb_depMdbQ_ejblink_single_jar2_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>StatefulExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>StatelessExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/singleT/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/singleT/MsgBean.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.ejblink.singleT;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/singleT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/singleT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018,2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
   <target name="compile">
       <ts.javac includes="${pkg.dir}/**/*.java,
                           com/sun/ts/tests/common/ejb/**/*.java,
-                          com/sun/ts/tests/assembly/util/refbean/**/*.java,
+                          com/sun/ts/tests/ejb/ee/deploy/util/refbean/**/*.java,
                           com/sun/ts/tests/jms/common*/**/*.java"/>
   </target>
 
@@ -35,18 +35,18 @@
                  archivename="${my.app}_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/single/TestCode.class,
-                           com/sun/ts/tests/assembly/util/refbean/*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"
-                excludes="com/sun/ts/tests/assembly/util/refbean/*ExternalEJB.class"/>
+                excludes="com/sun/ts/tests/ejb/ee/deploy/util/refbean/*ExternalEJB.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="${my.app}_jar2_ejb.xml" archivename="${my.app}_jar2"
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/singleT/MsgBean.class">
         <fileset dir="${class.dir}" includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/refbean/*External*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*External*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"/>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/singleT/ejb_depMdbT_ejblink_single_jar1_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/singleT/ejb_depMdbT_ejblink_single_jar1_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>StatelessInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>StatefulInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -51,29 +51,29 @@
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
         <ejb-link>StatelessInternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
         <ejb-link>StatefulInternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
         <ejb-link>StatelessExternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
         <ejb-link>StatefulExternal</ejb-link>
       </ejb-ref>
       <resource-ref>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/singleT/ejb_depMdbT_ejblink_single_jar2_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejblink/singleT/ejb_depMdbT_ejblink_single_jar2_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>StatefulExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>StatelessExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesens/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejbref.casesens;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class CaseBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,7 +32,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbQ_ejbref_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesensT/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesensT/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejbref.casesensT;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class CaseBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesensT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/casesensT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -32,7 +32,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbT_ejbref_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scope/ReferencedBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scope/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejbref.scope;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class ReferencedBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depMdbQ_ejbref_scope_jar1_ejb.xml"
@@ -41,7 +41,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbQ_ejbref_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scopeT/ReferencedBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scopeT/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.mdb.ejbref.scopeT;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class ReferencedBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scopeT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/scopeT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,7 +33,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depMdbT_ejbref_scope_jar1_ejb.xml"
@@ -41,7 +41,7 @@
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateless.ejb},
                            ${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbT_ejbref_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/single/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/single/MsgBean.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.ejbref.single;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018,2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
   <target name="compile">
       <ts.javac includes="${pkg.dir}/**/*.java,
                           com/sun/ts/tests/common/ejb/**/*.java,
-                          com/sun/ts/tests/assembly/util/refbean/**/*.java,
+                          com/sun/ts/tests/ejb/ee/deploy/util/refbean/**/*.java,
                           com/sun/ts/tests/jms/common*/**/*.java"/>
   </target>
 
@@ -35,12 +35,12 @@
                  archivename="${my.app}_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/single/TestCode.class,
-                           com/sun/ts/tests/assembly/util/refbean/*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"
-                excludes="com/sun/ts/tests/assembly/util/refbean/*ExternalEJB.class"/>
+                excludes="com/sun/ts/tests/ejb/ee/deploy/util/refbean/*ExternalEJB.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="${my.app}_jar2_ejb.xml"
@@ -48,7 +48,7 @@
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/single/MsgBean.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/refbean/*External*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*External*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"/>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/single/ejb_depMdbQ_ejbref_single_jar1_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/single/ejb_depMdbQ_ejbref_single_jar1_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>ejb_ee_deploy_mdb_ejbref_single_StatelessInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -40,26 +40,26 @@
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
       </ejb-ref>
       <resource-ref>
         <description>description</description>
@@ -75,9 +75,9 @@
     </message-driven>
     <session>
       <ejb-name>ejb_ee_deploy_mdb_ejbref_single_StatefulInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/single/ejb_depMdbQ_ejbref_single_jar2_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/single/ejb_depMdbQ_ejbref_single_jar2_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>ejb_ee_deploy_mdb_ejbref_single_StatefulExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>ejb_ee_deploy_mdb_ejbref_single_StatelessExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/singleT/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/singleT/MsgBean.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.ejbref.singleT;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/singleT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/singleT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018,2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
   <target name="compile">
       <ts.javac includes="${pkg.dir}/**/*.java,
                           com/sun/ts/tests/common/ejb/**/*.java,
-                          com/sun/ts/tests/assembly/util/refbean/**/*.java,
+                          com/sun/ts/tests/ejb/ee/deploy/util/refbean/**/*.java,
                           com/sun/ts/tests/jms/common*/**/*.java"/>
   </target>
 
@@ -34,19 +34,19 @@
       <ts.ejbjar descriptor="${my.app}_jar1_ejb.xml" archivename="${my.app}_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/single/TestCode.class,
-                           com/sun/ts/tests/assembly/util/refbean/*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"
-                excludes="com/sun/ts/tests/assembly/util/refbean/*ExternalEJB.class"/>
+                excludes="com/sun/ts/tests/ejb/ee/deploy/util/refbean/*ExternalEJB.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="${my.app}_jar2_ejb.xml" archivename="${my.app}_jar2"
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/singleT/MsgBean.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/refbean/*External*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*External*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"/>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/singleT/ejb_depMdbT_ejbref_single_jar1_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/singleT/ejb_depMdbT_ejbref_single_jar1_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>ejb_ee_deploy_mdb_ejbref_singleT_StatelessInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -40,26 +40,26 @@
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
       </ejb-ref>
       <resource-ref>
         <description>description</description>
@@ -75,9 +75,9 @@
     </message-driven>
     <session>
       <ejb-name>ejb_ee_deploy_mdb_ejbref_singleT_StatefulInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/singleT/ejb_depMdbT_ejbref_single_jar2_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/ejbref/singleT/ejb_depMdbT_ejbref_single_jar2_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>ejb_ee_deploy_mdb_ejbref_singleT_StatefulExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>ejb_ee_deploy_mdb_ejbref_singleT_StatelessExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/casesens/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/casesens/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.enventry.casesens;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.casesens.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.casesens.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,7 +31,7 @@
                  archivename="ejb_depMdbQ_enventry_casesens">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/casesens/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/casesens/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbQ_enventry_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/casesensT/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/casesensT/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.enventry.casesensT;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.casesens.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.casesens.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/casesensT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/casesensT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,7 +31,7 @@
                  archivename="ejb_depMdbT_enventry_casesens">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/casesens/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/casesens/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbT_enventry_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/scope/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/scope/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.enventry.scope;
 import java.util.Properties;
 
 import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.assembly.util.shared.enventry.scope.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.scope.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,21 +31,21 @@
                  archivename="ejb_depMdbQ_enventry_scope_jar3">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depMdbQ_enventry_scope_jar1_ejb.xml"
                  archivename="ejb_depMdbQ_enventry_scope_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depMdbQ_enventry_scope_jar2_ejb.xml"
                  archivename="ejb_depMdbQ_enventry_scope_jar2">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbQ_enventry_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/scopeT/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/scopeT/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.enventry.scopeT;
 import java.util.Properties;
 
 import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.assembly.util.shared.enventry.scope.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.scope.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/scopeT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/scopeT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,21 +31,21 @@
                  archivename="ejb_depMdbT_enventry_scope_jar3">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depMdbT_enventry_scope_jar1_ejb.xml"
                  archivename="ejb_depMdbT_enventry_scope_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depMdbT_enventry_scope_jar2_ejb.xml"
                  archivename="ejb_depMdbT_enventry_scope_jar2">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbT_enventry_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/single/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/single/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.enventry.single;
 import java.util.Properties;
 
 import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,7 +31,7 @@
                  archivename="ejb_depMdbQ_enventry_single">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/single/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/single/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbQ_enventry_single_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/singleT/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/singleT/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.enventry.singleT;
 import java.util.Properties;
 
 import com.sun.ts.lib.util.TestUtil;
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/singleT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/enventry/singleT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,7 +31,7 @@
                  archivename="ejb_depMdbT_enventry_single">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/single/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/single/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depMdbT_enventry_single_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/resref/single/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/resref/single/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.resref.single;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.resref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/resref/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/resref/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,8 +31,8 @@
                  archivename="ejb_depMdbQ_resref_single">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/resref/single/ByteArrayDataSource.class,
-                           com/sun/ts/tests/assembly/util/shared/resref/single/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/ByteArrayDataSource.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.war descriptor="ejb_depMdbQ_resref_single_jsp_web.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/resref/singleT/MsgBean.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/resref/singleT/MsgBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.mdb.resref.singleT;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.resref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.MDBWrapper;
 
 public class MsgBean extends MDBWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/resref/singleT/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/mdb/resref/singleT/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -31,8 +31,8 @@
                  archivename="ejb_depMdbT_resref_single">
         <fileset dir="${class.dir}" 
                  includes="${ts.wrappers.classes.mdb.ejb},
-                           com/sun/ts/tests/assembly/util/shared/resref/single/ByteArrayDataSource.class,
-                           com/sun/ts/tests/assembly/util/shared/resref/single/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/ByteArrayDataSource.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.war descriptor="ejb_depMdbT_resref_single_jsp.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.ejblink.casesens;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class CaseBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@
                  archivename="ejb_depSsf_ejblink_casesens">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.statefull.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class,
                            com/sun/ts/tests/common/ejb/wrappers/StatefulWrapper.class"/>
       </ts.ejbjar>
 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBean2EJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.ejblink.scope;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class ReferencedBean2EJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.ejblink.scope;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class ReferencedBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,7 +30,7 @@
                                 com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/TestBean*.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depSsf_ejblink_scope_jar1_ejb.xml"
@@ -38,7 +38,7 @@
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/scope/ReferencedBean2EJB.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsf_ejblink_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/TestBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/TestBeanEJB.java
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.ejblink.single;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class TestBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018,2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
   <target name="compile">
       <ts.javac includes="${pkg.dir}/**/*.java,
                           com/sun/ts/tests/common/ejb/**/*.java,
-                          com/sun/ts/tests/assembly/util/refbean/**/*.java,
+                          com/sun/ts/tests/ejb/ee/deploy/util/refbean/**/*.java,
                           com/sun/ts/tests/jms/common*/**/*.java"/>
   </target>
 
@@ -34,19 +34,19 @@
       <ts.ejbjar descriptor="${my.app}_jar1_ejb.xml" archivename="${my.app}_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/single/TestCode.class,
-                           com/sun/ts/tests/assembly/util/refbean/*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"
-                excludes="com/sun/ts/tests/assembly/util/refbean/*ExternalEJB.class"/>
+                excludes="com/sun/ts/tests/ejb/ee/deploy/util/refbean/*ExternalEJB.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="${my.app}_jar2_ejb.xml" archivename="${my.app}_jar2"
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/TestBean*.class">
         <fileset dir="${class.dir}" 
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/refbean/*External*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*External*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"/>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/ejb_depSsf_ejblink_single_jar1_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/ejb_depSsf_ejblink_single_jar1_ejb.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>StatefulInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>StatelessInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -52,29 +52,29 @@
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
         <ejb-link>StatelessInternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
         <ejb-link>StatefulInternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
         <ejb-link>StatelessExternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
         <ejb-link>StatefulExternal</ejb-link>
       </ejb-ref>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/ejb_depSsf_ejblink_single_jar2_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejblink/single/ejb_depSsf_ejblink_single_jar2_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>StatefulExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>StatelessExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.ejbref.casesens;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class CaseBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@
                  archivename="ejb_depSsf_ejbref_casesens">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsf_ejbref_casesens_client.xml" 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencedBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.ejbref.scope;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class ReferencedBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@
                  archivename="ejb_depSsf_ejbref_scope_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depSsf_ejbref_scope_jar2_ejb.xml" 
@@ -34,7 +34,7 @@
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/scope/ReferencedBeanEJB.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsf_ejbref_scope_client.xml" 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/TestBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/TestBeanEJB.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.session.stateful.ejbref.single;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class TestBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018,2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
   <target name="compile">
       <ts.javac includes="${pkg.dir}/**/*.java,
                           com/sun/ts/tests/common/ejb/**/*.java,
-                          com/sun/ts/tests/assembly/util/refbean/**/*.java,
+                          com/sun/ts/tests/ejb/ee/deploy/util/refbean/**/*.java,
                           com/sun/ts/tests/jms/common*/**/*.java"/>
   </target>
 
@@ -34,19 +34,19 @@
       <ts.ejbjar descriptor="${my.app}_jar1_ejb.xml" archivename="${my.app}_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/single/TestCode.class,
-                           com/sun/ts/tests/assembly/util/refbean/*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"
-                excludes="com/sun/ts/tests/assembly/util/refbean/*ExternalEJB.class"/>
+                excludes="com/sun/ts/tests/ejb/ee/deploy/util/refbean/*ExternalEJB.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="${my.app}_jar2_ejb.xml" archivename="${my.app}_jar2" 
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/TestBean*.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/refbean/*External*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*External*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"/>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/ejb_depSsf_ejbref_single_jar1_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/ejb_depSsf_ejbref_single_jar1_ejb.xml
@@ -30,26 +30,26 @@
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
       </ejb-ref>
       <security-identity>
         <use-caller-identity/>
@@ -57,9 +57,9 @@
     </session>
     <session>
       <ejb-name>ejb_ee_deploy_session_stateful_ejbref_single_StatefulInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -68,9 +68,9 @@
     </session>
     <session>
       <ejb-name>ejb_ee_deploy_session_stateful_ejbref_single_StatelessInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/ejb_depSsf_ejbref_single_jar2_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/ejbref/single/ejb_depSsf_ejbref_single_jar2_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>ejb_ee_deploy_session_stateful_ejbref_single_StatefulExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>ejb_ee_deploy_session_stateful_ejbref_single_StatelessExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.casesens;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.casesens.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.casesens.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class CaseBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@
                  archivename="ejb_depSsf_enventry_casesens">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/casesens/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/casesens/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsf_enventry_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/scope/BeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/scope/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.scope;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.scope.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.scope.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class BeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,21 +26,21 @@
                  archivename="ejb_depSsf_enventry_scope_jar2">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depSsf_enventry_scope_jar1_ejb.xml" 
                  archivename="ejb_depSsf_enventry_scope_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depSsf_enventry_scope_jar3_ejb.xml" 
                  archivename="ejb_depSsf_enventry_scope_jar3">
         <fileset dir="${class.dir}"
                   includes="${ts.wrappers.classes.stateful.ejb},
-                            com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                            com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsf_enventry_scope_client.xml" 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/AllBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/AllBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class AllBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/BooleanBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/BooleanBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class BooleanBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ByteBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ByteBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class ByteBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/CharBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/CharBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class CharBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/DoubleBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/DoubleBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class DoubleBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/FloatBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/FloatBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class FloatBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/IntegerBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/IntegerBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class IntegerBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/LongBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/LongBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class LongBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ShortBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/ShortBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class ShortBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/StringBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/StringBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class StringBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/enventry/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@
                  archivename="ejb_depSsf_enventry_single">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/enventry/single/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/single/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsf_enventry_single_client.xml" 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/casesens/TestBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/casesens/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.session.stateful.resref.casesens;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.resref.casesens.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.casesens.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class TestBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@
                  archivename="ejb_depSsf_resref_casesens">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/resref/casesens/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/casesens/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsf_resref_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/QueueBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/QueueBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.resref.scope;
 
-import com.sun.ts.tests.assembly.util.shared.resref.scope.QueueCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.scope.QueueCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class QueueBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/TopicBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/TopicBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.resref.scope;
 
-import com.sun.ts.tests.assembly.util.shared.resref.scope.TopicCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.scope.TopicCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class TopicBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,8 +26,8 @@
                  archivename="ejb_depSsf_resref_scope">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/resref/scope/TopicCode.class,
-                           com/sun/ts/tests/assembly/util/shared/resref/scope/QueueCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/TopicCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/QueueCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsf_resref_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/TestBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateful.resref.single;
 
-import com.sun.ts.tests.assembly.util.shared.resref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
 
 public class TestBeanEJB extends StatefulWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateful/resref/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,8 +26,8 @@
                  archivename="ejb_depSsf_resref_single">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.stateful.ejb},
-                           com/sun/ts/tests/assembly/util/shared/resref/single/ByteArrayDataSource.class,
-                           com/sun/ts/tests/assembly/util/shared/resref/single/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/ByteArrayDataSource.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.war descriptor="ejb_depSsf_resref_single_jsp_web.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.ejblink.casesens;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 import jakarta.ejb.EJBException;

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@
                  archivename="ejb_depSsl_ejblink_casesens">
         <fileset dir="${class.dir}"
                  includes="com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsl_ejblink_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean2EJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean2EJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.ejblink.scope;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 import jakarta.ejb.EJBException;

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.ejblink.scope;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 import jakarta.ejb.EJBException;

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,7 +27,7 @@
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/ReferencedBean2EJB.class">
         <fileset dir="${class.dir}"
                  includes="com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depSsl_ejblink_scope_jar2_ejb.xml"
@@ -38,7 +38,7 @@
                                 com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/scope/TestBean*.class">
         <fileset dir="${class.dir}"
                  includes="com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsl_ejblink_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/TestBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/TestBeanEJB.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.session.stateless.ejblink.single;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class TestBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018,2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
   <target name="compile">
       <ts.javac includes="${pkg.dir}/**/*.java,
                           com/sun/ts/tests/common/ejb/**/*.java,
-                          com/sun/ts/tests/assembly/util/refbean/**/*.java,
+                          com/sun/ts/tests/ejb/ee/deploy/util/refbean/**/*.java,
                           com/sun/ts/tests/jms/common*/**/*.java"/>
   </target>
 
@@ -35,19 +35,19 @@
       <ts.ejbjar descriptor="${my.app}_jar1_ejb.xml" archivename="${my.app}_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/single/TestCode.class,
-                           com/sun/ts/tests/assembly/util/refbean/*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"
-                excludes="com/sun/ts/tests/assembly/util/refbean/*ExternalEJB.class"/>
+                excludes="com/sun/ts/tests/ejb/ee/deploy/util/refbean/*ExternalEJB.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="${my.app}_jar2_ejb.xml" archivename="${my.app}_jar2"
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/TestBean*.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/refbean/*External*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*External*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"/>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/ejb_depSsl_ejblink_single_jar1_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/ejb_depSsl_ejblink_single_jar1_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>StatelessInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>StatefulInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -52,29 +52,29 @@
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
         <ejb-link>StatelessInternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
         <ejb-link>StatefulInternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
         <ejb-link>StatelessExternal</ejb-link>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
         <ejb-link>StatefulExternal</ejb-link>
       </ejb-ref>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/ejb_depSsl_ejblink_single_jar2_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejblink/single/ejb_depSsl_ejblink_single_jar2_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>StatefulExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>StatelessExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.ejbref.casesens;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 import jakarta.ejb.EJBException;

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,7 +26,7 @@
                  archivename="ejb_depSsl_ejbref_casesens">
         <fileset dir="${class.dir}"
                  includes="com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsl_ejbref_casesens_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencedBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencedBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -19,7 +19,7 @@
  */
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.ejbref.scope;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common.ReferencedBeanCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 import jakarta.ejb.EJBException;

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,14 +27,14 @@
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/scope/ReferencedBeanEJB.class">
         <fileset dir="${class.dir}"
                  includes="com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depSsl_ejbref_scope_jar1_ejb.xml"
                  archivename="ejb_depSsl_ejbref_scope_jar1">
         <fileset dir="${class.dir}"
                  includes="com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                           com/sun/ts/tests/assembly/util/shared/ejbref/common/ReferencedBeanCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsl_ejbref_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/TestBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/TestBeanEJB.java
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.session.stateless.ejbref.single;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.ejbref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class TestBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018,2024 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
   <target name="compile">
       <ts.javac includes="${pkg.dir}/**/*.java,
                           com/sun/ts/tests/common/ejb/**/*.java,
-                          com/sun/ts/tests/assembly/util/refbean/**/*.java,
+                          com/sun/ts/tests/ejb/ee/deploy/util/refbean/**/*.java,
                           com/sun/ts/tests/jms/common*/**/*.java"/>
   </target>
 
@@ -34,19 +34,19 @@
       <ts.ejbjar descriptor="${my.app}_jar1_ejb.xml" archivename="${my.app}_jar1">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/shared/ejbref/single/TestCode.class,
-                           com/sun/ts/tests/assembly/util/refbean/*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"
-                excludes="com/sun/ts/tests/assembly/util/refbean/*ExternalEJB.class"/>
+                excludes="com/sun/ts/tests/ejb/ee/deploy/util/refbean/*ExternalEJB.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="${my.app}_jar2_ejb.xml" archivename="${my.app}_jar2"
                  excludedfiles="com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/TestBean*.class">
         <fileset dir="${class.dir}"
                  includes="${ts.wrappers.classes.all.ejb},
-                           com/sun/ts/tests/assembly/util/refbean/*External*.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/refbean/*External*.class,
                            com/sun/ts/tests/common/ejb/wrappers/*.class,
                            com/sun/ts/tests/jms/common/JmsUtil.class,
                            com/sun/ts/tests/jms/commonee/ParentMsgBean.class"/>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/ejb_depSsl_ejbref_single_jar1_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/ejb_depSsl_ejbref_single_jar1_ejb.xml
@@ -30,26 +30,26 @@
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_SameJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatelessBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
       </ejb-ref>
       <ejb-ref>
         <ejb-ref-name>ejb/StatefulBean_ExternalJAR</ejb-ref-name>
         <ejb-ref-type>Session</ejb-ref-type>
-        <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-        <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
+        <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+        <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
       </ejb-ref>
       <security-identity>
         <use-caller-identity/>
@@ -57,9 +57,9 @@
     </session>
     <session>
       <ejb-name>ejb_ee_deploy_session_stateless_ejbref_single_StatefulInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -68,9 +68,9 @@
     </session>
     <session>
       <ejb-name>ejb_ee_deploy_session_stateless_ejbref_single_StatelessInternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessInternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessInternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessInternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/ejb_depSsl_ejbref_single_jar2_ejb.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/ejbref/single/ejb_depSsl_ejbref_single_jar2_ejb.xml
@@ -22,9 +22,9 @@
   <enterprise-beans>
     <session>
       <ejb-name>ejb_ee_deploy_session_stateless_ejbref_single_StatefulExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatefulExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatefulExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatefulExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalEJB</ejb-class>
       <session-type>Stateful</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>
@@ -33,9 +33,9 @@
     </session>
     <session>
       <ejb-name>ejb_ee_deploy_session_stateless_ejbref_single_StatelessExternal</ejb-name>
-      <home>com.sun.ts.tests.assembly.util.refbean.StatelessExternalHome</home>
-      <remote>com.sun.ts.tests.assembly.util.refbean.StatelessExternal</remote>
-      <ejb-class>com.sun.ts.tests.assembly.util.refbean.StatelessExternalEJB</ejb-class>
+      <home>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome</home>
+      <remote>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal</remote>
+      <ejb-class>com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalEJB</ejb-class>
       <session-type>Stateless</session-type>
       <transaction-type>Container</transaction-type>
       <security-identity>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/casesens/CaseBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/casesens/CaseBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.casesens;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.casesens.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.casesens.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class CaseBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
       <ts.ejbjar descriptor="ejb_depSsl_enventry_casesens_ejb.xml"
                  archivename="ejb_depSsl_enventry_casesens">
         <fileset dir="${class.dir}"
-                 includes="com/sun/ts/tests/assembly/util/shared/enventry/casesens/TestCode.class,
+                 includes="com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/casesens/TestCode.class,
                            com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class"/>
       </ts.ejbjar>
 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/scope/BeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/scope/BeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.scope;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.scope.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.scope.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class BeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -26,21 +26,21 @@
                  archivename="ejb_depSsl_enventry_scope_jar2">
         <fileset dir="${class.dir}"
                   includes="com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                            com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                            com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depSsl_enventry_scope_jar1_ejb.xml"
                  archivename="ejb_depSsl_enventry_scope_jar1">
         <fileset dir="${class.dir}"
                  includes="com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.ejbjar descriptor="ejb_depSsl_enventry_scope_jar3_ejb.xml"
                  archivename="ejb_depSsl_enventry_scope_jar3">
         <fileset dir="${class.dir}"
                  includes="com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                           com/sun/ts/tests/assembly/util/shared/enventry/scope/TestCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsl_enventry_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/AllBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/AllBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class AllBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/BooleanBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/BooleanBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class BooleanBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ByteBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ByteBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class ByteBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/CharBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/CharBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class CharBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/DoubleBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/DoubleBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class DoubleBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/FloatBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/FloatBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class FloatBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/IntegerBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/IntegerBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class IntegerBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/LongBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/LongBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class LongBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ShortBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/ShortBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class ShortBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/StringBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/StringBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.enventry.single;
 
-import com.sun.ts.tests.assembly.util.shared.enventry.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class StringBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/enventry/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
       <ts.ejbjar descriptor="ejb_depSsl_enventry_single_ejb.xml"
                  archivename="ejb_depSsl_enventry_single">
         <fileset dir="${class.dir}"
-                 includes="com/sun/ts/tests/assembly/util/shared/enventry/single/TestCode.class,
+                 includes="com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/single/TestCode.class,
                            com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class"/>
       </ts.ejbjar>
 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/casesens/TestBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/casesens/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@ package com.sun.ts.tests.ejb.ee.deploy.session.stateless.resref.casesens;
 
 import java.util.Properties;
 
-import com.sun.ts.tests.assembly.util.shared.resref.casesens.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.casesens.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class TestBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/casesens/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,7 +25,7 @@
       <ts.ejbjar descriptor="ejb_depSsl_resref_casesens_ejb.xml"
                  archivename="ejb_depSsl_resref_casesens">
         <fileset dir="${class.dir}"
-                 includes="com/sun/ts/tests/assembly/util/shared/resref/casesens/TestCode.class,
+                 includes="com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/casesens/TestCode.class,
                            com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class"/>
       </ts.ejbjar>
 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/QueueBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/QueueBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.resref.scope;
 
-import com.sun.ts.tests.assembly.util.shared.resref.scope.QueueCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.scope.QueueCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class QueueBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/TopicBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/TopicBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.resref.scope;
 
-import com.sun.ts.tests.assembly.util.shared.resref.scope.TopicCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.scope.TopicCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class TopicBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/scope/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -25,9 +25,9 @@
       <ts.ejbjar descriptor="ejb_depSsl_resref_scope_ejb.xml"
                  archivename="ejb_depSsl_resref_scope">
         <fileset dir="${class.dir}"
-                 includes="com/sun/ts/tests/assembly/util/shared/resref/scope/TopicCode.class,
+                 includes="com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/TopicCode.class,
                            com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class,
-                           com/sun/ts/tests/assembly/util/shared/resref/scope/QueueCode.class"/>
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/QueueCode.class"/>
       </ts.ejbjar>
 
       <ts.clientjar descriptor="ejb_depSsl_resref_scope_client.xml"

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/single/TestBeanEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/single/TestBeanEJB.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,7 +20,7 @@
 
 package com.sun.ts.tests.ejb.ee.deploy.session.stateless.resref.single;
 
-import com.sun.ts.tests.assembly.util.shared.resref.single.TestCode;
+import com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.single.TestCode;
 import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
 
 public class TestBeanEJB extends StatelessWrapper {

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/session/stateless/resref/single/build.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -30,8 +30,8 @@
       <ts.ejbjar descriptor="ejb_depSsl_resref_single_ejb.xml"
                  archivename="ejb_depSsl_resref_single">
         <fileset dir="${class.dir}"
-                 includes="com/sun/ts/tests/assembly/util/shared/resref/single/ByteArrayDataSource.class,
-                           com/sun/ts/tests/assembly/util/shared/resref/single/TestCode.class,
+                 includes="com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/ByteArrayDataSource.class,
+                           com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/TestCode.class,
                            com/sun/ts/tests/common/ejb/wrappers/StatelessWrapper.class"/>
       </ts.ejbjar>
 

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project basedir="." default="usage" name="ejb_ee_deploy_util">
+  <import file="../../../../../../../../../bin/xml/ts.nonleafimport.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulExternal.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulExternal.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import java.rmi.RemoteException;
+
+import jakarta.ejb.EJBObject;
+
+public interface StatefulExternal extends EJBObject {
+  public boolean isTestStatefulExternal() throws RemoteException;
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulExternalEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulExternalEJB.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
+
+public class StatefulExternalEJB extends StatefulWrapper {
+
+  /**
+   * Method used to identify this bean (only available for this bean).
+   */
+  public boolean isTestStatefulExternal() {
+    TestUtil.logTrace("StatefulExternal: isTestStatefulExternal()");
+    return true;
+  }
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulExternalHome.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulExternalHome.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import java.rmi.RemoteException;
+import java.util.Properties;
+
+import jakarta.ejb.CreateException;
+import jakarta.ejb.EJBHome;
+
+public interface StatefulExternalHome extends EJBHome {
+
+  public StatefulExternal create(Properties p)
+      throws RemoteException, CreateException;
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulInternal.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulInternal.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import java.rmi.RemoteException;
+
+import jakarta.ejb.EJBObject;
+
+public interface StatefulInternal extends EJBObject {
+  public boolean isTestStatefulInternal() throws RemoteException;
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulInternalEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulInternalEJB.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.common.ejb.wrappers.StatefulWrapper;
+
+public class StatefulInternalEJB extends StatefulWrapper {
+
+  /**
+   * Method used to identify this bean (only available for this bean).
+   */
+  public boolean isTestStatefulInternal() {
+    TestUtil.logTrace("StatefulInternal: isTestStatefulInternal()");
+    return true;
+  }
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulInternalHome.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatefulInternalHome.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import java.rmi.RemoteException;
+import java.util.Properties;
+
+import jakarta.ejb.CreateException;
+import jakarta.ejb.EJBHome;
+
+public interface StatefulInternalHome extends EJBHome {
+
+  public StatefulInternal create(Properties p)
+      throws RemoteException, CreateException;
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessExternal.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessExternal.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import java.rmi.RemoteException;
+import java.util.Properties;
+
+import jakarta.ejb.EJBObject;
+
+public interface StatelessExternal extends EJBObject {
+
+  public void initLogging(Properties p) throws RemoteException;
+
+  public boolean isTestStatelessExternal() throws RemoteException;
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessExternalEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessExternalEJB.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
+
+public class StatelessExternalEJB extends StatelessWrapper {
+
+  /**
+   * Method used to identify this bean (only available for this bean).
+   */
+  public boolean isTestStatelessExternal() {
+    TestUtil.logTrace("StatelessExternal: isTestStatelessExternal()");
+    return true;
+  }
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessExternalHome.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessExternalHome.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import java.rmi.RemoteException;
+
+import jakarta.ejb.CreateException;
+import jakarta.ejb.EJBHome;
+
+public interface StatelessExternalHome extends EJBHome {
+
+  public StatelessExternal create() throws RemoteException, CreateException;
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessInternal.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessInternal.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import java.rmi.RemoteException;
+import java.util.Properties;
+
+import jakarta.ejb.EJBObject;
+
+public interface StatelessInternal extends EJBObject {
+
+  public void initLogging(Properties p) throws RemoteException;
+
+  public boolean isTestStatelessInternal() throws RemoteException;
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessInternalEJB.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessInternalEJB.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper;
+
+public class StatelessInternalEJB extends StatelessWrapper {
+
+  /**
+   * Method used to identify this bean (only available for this bean).
+   */
+  public boolean isTestStatelessInternal() {
+    TestUtil.logTrace("StatelessInternal: isStatelessInternal()");
+    return true;
+  }
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessInternalHome.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/StatelessInternalHome.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.refbean;
+
+import java.rmi.RemoteException;
+
+import jakarta.ejb.CreateException;
+import jakarta.ejb.EJBHome;
+
+public interface StatelessInternalHome extends EJBHome {
+
+  public StatelessInternal create() throws RemoteException, CreateException;
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/refbean/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_refbean" basedir="." default="usage">
+  <import file="../../../../../../../../../../bin/xml/ts.import.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project basedir="." default="usage" name="ejb_ee_deploy_util_shared">
+  <import file="../../../../../../../../../../bin/xml/ts.nonleafimport.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project basedir="." default="usage" name="ejb_ee_deploy_util_shared_ejbref">
+  <import file="../../../../../../../../../../../bin/xml/ts.nonleafimport.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/ReferencedBeanCode.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)ReferencedBeanCode.java	1.8 03/05/16
+ */
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.common;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+import jakarta.ejb.EJBException;
+
+public class ReferencedBeanCode {
+  public static final String envEntryName = "java:comp/env/myName";
+
+  /**
+   * Method used to identify this bean. Return the value of bean env entry
+   * called 'myName'.
+   */
+  public static String whoAreYou(TSNamingContext nctx) throws EJBException {
+
+    String name;
+
+    try {
+      TestUtil.logTrace("CaseBean: whoAreYou()");
+      name = (String) nctx.lookup(envEntryName);
+      TestUtil.logTrace("CaseBean: my name is '" + name + "'");
+    } catch (Exception e) {
+      TestUtil.logErr("CaseBean: Caught exception: " + e, e);
+      throw new EJBException(e.getMessage());
+    }
+
+    return name;
+  }
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/common/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_shared_ejbref_common" basedir="." default="usage">
+  <import file="../../../../../../../../../../../../bin/xml/ts.import.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/TestCode.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)TestCode.java	1.11 03/05/16
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.ejbref.single;
+
+import java.util.Properties;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternal;
+import com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulExternalHome;
+import com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternal;
+import com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatefulInternalHome;
+import com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternal;
+import com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessExternalHome;
+import com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternal;
+import com.sun.ts.tests.ejb.ee.deploy.util.refbean.StatelessInternalHome;
+
+public class TestCode {
+
+  protected static final String prefix = "java:comp/env/ejb/";
+
+  protected static final String statelessInternalName = prefix
+      + "StatelessBean_SameJAR";
+
+  protected static final String statelessExternalName = prefix
+      + "StatelessBean_ExternalJAR";
+
+  protected static final String statefulInternalName = prefix
+      + "StatefulBean_SameJAR";
+
+  protected static final String statefulExternalName = prefix
+      + "StatefulBean_ExternalJAR";
+
+  private static StatefulExternal ssfExternalBeanRef1 = null;
+
+  private static StatefulInternal ssfInternalBeanRef1 = null;
+
+  public static boolean testStatelessInternal(TSNamingContext nctx,
+      Properties props) {
+
+    StatelessInternalHome home = null;
+    StatelessInternal bean = null;
+    boolean pass;
+
+    try {
+      home = (StatelessInternalHome) nctx.lookup(statelessInternalName,
+          StatelessInternalHome.class);
+      bean = home.create();
+      bean.initLogging(props);
+
+      pass = bean.isTestStatelessInternal();
+    } catch (Exception e) {
+      TestUtil.logErr("TestBean: Caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  public static boolean testStatelessExternal(TSNamingContext nctx,
+      Properties props) {
+
+    StatelessExternalHome home = null;
+    StatelessExternal bean = null;
+    boolean pass;
+
+    try {
+      home = (StatelessExternalHome) nctx.lookup(statelessExternalName,
+          StatelessExternalHome.class);
+      bean = home.create();
+      bean.initLogging(props);
+      pass = bean.isTestStatelessExternal();
+
+      pass = true;
+    } catch (Exception e) {
+      TestUtil.logErr(
+          "TestBean: Exception in " + "testStatelessExternal(): " + e, e);
+      pass = false;
+    }
+    return pass;
+  }
+
+  public static boolean testStatefulInternal(TSNamingContext nctx,
+      Properties props) {
+
+    StatefulInternalHome home = null;
+    boolean pass;
+
+    try {
+      home = (StatefulInternalHome) nctx.lookup(statefulInternalName,
+          StatefulInternalHome.class);
+      ssfInternalBeanRef1 = home.create(props);
+      pass = ssfInternalBeanRef1.isTestStatefulInternal();
+
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  public static boolean testStatefulExternal(TSNamingContext nctx,
+      Properties props) {
+
+    StatefulExternalHome home = null;
+    boolean pass;
+
+    try {
+      home = (StatefulExternalHome) nctx.lookup(statefulExternalName,
+          StatefulExternalHome.class);
+      ssfExternalBeanRef1 = home.create(props);
+      pass = ssfExternalBeanRef1.isTestStatefulExternal();
+    } catch (Exception e) {
+      TestUtil.logErr("TestBean: Got exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  public static void cleanUpStatefulBean() {
+    TestUtil.logTrace("cleanUpStatefulBean");
+    try {
+      if (ssfInternalBeanRef1 != null) {
+        TestUtil.logTrace("cleanUp Session StatefulInternal Bean");
+        ssfInternalBeanRef1.remove();
+        ssfInternalBeanRef1 = null;
+      }
+      if (ssfExternalBeanRef1 != null) {
+        TestUtil.logTrace("cleanUp Session StatefulExternal Bean");
+        ssfExternalBeanRef1.remove();
+        ssfExternalBeanRef1 = null;
+      }
+    } catch (Exception e) {
+      TestUtil.logErr(
+          "Exception caught trying to remove Stateful Session beans", e);
+    }
+  }
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/ejbref/single/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_shared_ejbref_single" basedir="." default="usage">
+  <import file="../../../../../../../../../../../../bin/xml/ts.import.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project basedir="." default="usage" name="ejb_ee_deploy_util_shared_enventry">
+  <import file="../../../../../../../../../../../bin/xml/ts.nonleafimport.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/casesens/TestCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/casesens/TestCode.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)TestCode.java	1.8 03/05/16
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.casesens;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+public class TestCode {
+
+  /** Prefix for JNDI lookups */
+  public static final String prefix = "java:comp/env/";
+
+  /*
+   * Names we use to lookup the two env. entries - differ by case
+   */
+  public static final String entryName1 = prefix + "aloha";
+
+  public static final String entryName2 = prefix + "Aloha";
+
+  /*
+   * Values specified in DD for these env. entries (must be distinct)
+   */
+  public static final String ddValue1 = "Windsurf";
+
+  public static final String ddValue2 = "windsurf";
+
+  /**
+   * Check that two environment entries whose names differ only by case are
+   * associated with different runtime values (as specified in DD).
+   */
+  public static boolean testCaseSensitivity(TSNamingContext nctx) {
+    /* Runtime values */
+    String value1;
+    String value2;
+
+    boolean pass;
+
+    try {
+      TestUtil.logTrace("Looking up '" + entryName1 + "' ...");
+      value1 = (String) nctx.lookup(entryName1);
+      TestUtil.logTrace("Runtime value is '" + value1 + "'");
+
+      TestUtil.logTrace("Looking up '" + entryName2 + "' ...");
+      value2 = (String) nctx.lookup(entryName2);
+      TestUtil.logTrace("Runtime value is '" + value2 + "'");
+
+      pass = ddValue1.equals(value1) && ddValue2.equals(value2);
+      if (!pass) {
+        TestUtil.logErr(entryName1 + " value should be '" + ddValue1 + "' and "
+            + entryName2 + " value should " + "be '" + ddValue2 + "' !");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/casesens/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_shared_enventry_casesens" basedir="." default="usage">
+  <import file="../../../../../../../../../../../../bin/xml/ts.import.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/TestCode.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)TestCode.java	1.8 03/05/16
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.scope;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+public class TestCode {
+
+  /**
+   * Lookup a String env entry and compare its runtime value with a reference
+   * value.
+   *
+   * @param name
+   *          Name of the env entry to lookup.
+   * @param ref
+   *          Reference value for this env entry (the one in DD).
+   *
+   * @return true if runtime value and reference matches. False otherwise.
+   */
+  public static boolean checkEntry(TSNamingContext nctx, String name,
+      String ref) {
+
+    String runtimeVal;
+    boolean pass;
+
+    try {
+      TestUtil.logTrace("Looking up '" + name + "'");
+      runtimeVal = (String) nctx.lookup("java:comp/env/" + name);
+      TestUtil.logTrace("Runtime value is '" + runtimeVal + "'");
+
+      pass = runtimeVal.equals(ref);
+      if (!pass) {
+        TestUtil.logErr("Expected value was '" + ref + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/scope/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_shared_enventry_scope" basedir="." default="usage">
+  <import file="../../../../../../../../../../../../bin/xml/ts.import.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/single/TestCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/single/TestCode.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)TestCode.java	1.9 03/05/16
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.enventry.single;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+public class TestCode {
+  /** Prefix for JNDI lookups */
+  protected static final String prefix = "java:comp/env/";
+
+  /*
+   * Names of the env. entries.
+   */
+  protected static final String charEntryName = prefix + "myChar";
+
+  protected static final String stringEntryName = prefix + "myString";
+
+  protected static final String booleanEntryName = prefix + "myBoolean";
+
+  protected static final String byteEntryName = prefix + "myByte";
+
+  protected static final String shortEntryName = prefix + "myShort";
+
+  protected static final String integerEntryName = prefix + "myInteger";
+
+  protected static final String longEntryName = prefix + "myLong";
+
+  protected static final String floatEntryName = prefix + "myFloat";
+
+  protected static final String doubleEntryName = prefix + "myDouble";
+
+  /*
+   * Reference values for the environment entries.
+   */
+  protected static final Character charValue = new Character('J');
+
+  protected static final String stringValue = new String("In vino veritas");
+
+  protected static final Boolean boolValue = new Boolean("true");
+
+  protected static final Byte byteValue = new Byte("22");
+
+  protected static final Short shortValue = new Short("1789");
+
+  protected static final Integer intValue = new Integer("-1");
+
+  protected static final Long longValue = new Long("55000000");
+
+  protected static final Float floatValue = new Float("37.2");
+
+  protected static final Double doubleValue = new Double("5.5");
+
+  /**
+   * Check that runtime value for Character env entry.
+   */
+  public static boolean testCharacterEntry(TSNamingContext nctx) {
+    boolean pass;
+    Character value = null;
+
+    try {
+      TestUtil.logTrace("Looking up env entry '" + charEntryName + "'");
+      value = (Character) nctx.lookup(charEntryName);
+      TestUtil.logTrace("Runtime value is '" + value + "'");
+
+      pass = charValue.equals(value);
+      if (!pass) {
+        TestUtil.logErr("Value should be '" + charValue + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  /**
+   * Check that runtime value for String env entry.
+   */
+  public static boolean testStringEntry(TSNamingContext nctx) {
+    boolean pass;
+    String value = null;
+
+    try {
+      TestUtil.logTrace("Looking up env entry '" + stringEntryName + "'");
+      value = (String) nctx.lookup(stringEntryName);
+      TestUtil.logTrace("Runtime value is '" + value + "'");
+
+      pass = stringValue.equals(value);
+      if (!pass) {
+        TestUtil.logErr("Value should be '" + stringValue + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  /**
+   * Check that runtime value for Boolean env entry.
+   */
+  public static boolean testBooleanEntry(TSNamingContext nctx) {
+    boolean pass;
+    Boolean value;
+
+    try {
+      TestUtil.logTrace("Looking up env entry '" + booleanEntryName + "'");
+      value = (Boolean) nctx.lookup(booleanEntryName);
+      TestUtil.logTrace("Runtime value is '" + value + "'");
+
+      pass = boolValue.equals(value);
+      if (!pass) {
+        TestUtil.logErr("Value should be '" + boolValue + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  /**
+   * Check that runtime value for Byte env entry.
+   */
+  public static boolean testByteEntry(TSNamingContext nctx) {
+    boolean pass;
+    Byte value;
+
+    try {
+      TestUtil.logTrace("Looking up env entry '" + byteEntryName + "'");
+      value = (Byte) nctx.lookup(byteEntryName);
+      TestUtil.logTrace("Runtime value is '" + value + "'");
+
+      pass = byteValue.equals(value);
+      if (!pass) {
+        TestUtil.logErr("Value should be '" + byteValue + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  /**
+   * Check that runtime value for Short env entry.
+   */
+  public static boolean testShortEntry(TSNamingContext nctx) {
+    boolean pass;
+    Short value;
+
+    try {
+      TestUtil.logTrace("Looking up env entry '" + shortEntryName + "'");
+      value = (Short) nctx.lookup(shortEntryName);
+      TestUtil.logTrace("Runtime value is '" + value + "'");
+
+      pass = shortValue.equals(value);
+      if (!pass) {
+        TestUtil.logErr("Value should be '" + shortValue + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  /**
+   * Check that runtime value for Integer env entry.
+   */
+  public static boolean testIntegerEntry(TSNamingContext nctx) {
+    boolean pass;
+    Integer value;
+
+    try {
+      TestUtil.logTrace("Looking up env entry '" + integerEntryName + "'");
+      value = (Integer) nctx.lookup(integerEntryName);
+      TestUtil.logTrace("Runtime value is '" + value + "'");
+
+      pass = intValue.equals(value);
+      if (!pass) {
+        TestUtil.logErr("Value should be '" + intValue + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  /**
+   * Check that runtime value for Long env entry.
+   */
+  public static boolean testLongEntry(TSNamingContext nctx) {
+    boolean pass;
+    Long value;
+
+    try {
+      TestUtil.logTrace("Looking up env entry '" + longEntryName + "'");
+      value = (Long) nctx.lookup(longEntryName);
+      TestUtil.logTrace("Runtime value is '" + value + "'");
+
+      pass = longValue.equals(value);
+      if (!pass) {
+        TestUtil.logErr("Value should be '" + longValue + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  /**
+   * Check that runtime value for Float env entry.
+   */
+  public static boolean testFloatEntry(TSNamingContext nctx) {
+    boolean pass;
+    Float value;
+
+    try {
+      TestUtil.logTrace("Looking up env entry '" + floatEntryName + "'");
+      value = (Float) nctx.lookup(floatEntryName);
+      TestUtil.logTrace("Runtime value is '" + value + "'");
+
+      pass = floatValue.equals(value);
+      if (!pass) {
+        TestUtil.logErr("Value should be '" + floatValue + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+  /**
+   * Check that runtime value for Double env entry.
+   */
+  public static boolean testDoubleEntry(TSNamingContext nctx) {
+    boolean pass;
+    Double value;
+
+    try {
+      TestUtil.logTrace("Looking up env entry '" + doubleEntryName + "'");
+      value = (Double) nctx.lookup(doubleEntryName);
+      TestUtil.logTrace("Runtime value is '" + value + "'");
+
+      pass = doubleValue.equals(value);
+      if (!pass) {
+        TestUtil.logErr("Value should be '" + doubleValue + "'");
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e, e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/enventry/single/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_shared_enventry_single" basedir="." default="usage">
+  <import file="../../../../../../../../../../../../bin/xml/ts.import.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project basedir="." default="usage" name="ejb_ee_deploy_util_shared_resref">
+  <import file="../../../../../../../../../../../bin/xml/ts.nonleafimport.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/casesens/TestCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/casesens/TestCode.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)TestCode.java	1.7 03/05/16
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.casesens;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+import jakarta.jms.QueueConnection;
+import jakarta.jms.QueueConnectionFactory;
+import jakarta.jms.TopicConnection;
+import jakarta.jms.TopicConnectionFactory;
+
+public class TestCode {
+
+  /** Prefix used for JNDI lookups */
+  private static final String prefix = "java:comp/env/";
+
+  /*
+   * JNDI lookup names for resource manager connection factories. They differ
+   * only by case.
+   */
+  protected static final String res1Lookup = prefix + "Aloha";
+
+  protected static final String res2Lookup = prefix + "aloha";
+
+  public static boolean testCaseSensitivity(TSNamingContext nctx) {
+    QueueConnectionFactory res1;
+    TopicConnectionFactory res2;
+    QueueConnection conn1;
+    TopicConnection conn2;
+    boolean pass;
+
+    try {
+      TestUtil.logTrace("[TestCode] Looking up " + res1Lookup);
+      res1 = (QueueConnectionFactory) nctx.lookup(res1Lookup);
+      TestUtil.logTrace("[TestCode] Create QueueConnection");
+      conn1 = res1.createQueueConnection();
+      conn1.close();
+
+      TestUtil.logTrace("[TestCode] Looking up " + res2Lookup);
+      res2 = (TopicConnectionFactory) nctx.lookup(res2Lookup);
+      TestUtil.logTrace("[TestCode] Create TopicConnection");
+      conn2 = res2.createTopicConnection();
+
+      pass = true;
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/casesens/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/casesens/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_shared_resref_casesens" basedir="." default="usage">
+  <import file="../../../../../../../../../../../../bin/xml/ts.import.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/QueueCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/QueueCode.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)QueueCode.java	1.6 03/05/16
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.scope;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+import jakarta.jms.QueueConnection;
+import jakarta.jms.QueueConnectionFactory;
+
+public class QueueCode {
+
+  /** Prefix used for JNDI lookups */
+  private static final String prefix = "java:comp/env/jms/";
+
+  /*
+   * JNDI lookup names for resource manager connection factories. They differ
+   * only by case.
+   */
+  protected static final String resLookup = prefix + "myFactory";
+
+  public static boolean checkYourQueue(TSNamingContext nctx) {
+    QueueConnectionFactory res;
+    QueueConnection conn;
+    boolean pass;
+
+    try {
+      TestUtil.logTrace("[QueueCode] Looking up " + resLookup);
+      res = (QueueConnectionFactory) nctx.lookup(resLookup);
+      TestUtil.logTrace("[QueueCode] Create QueueConnection");
+      conn = res.createQueueConnection();
+      conn.close();
+
+      pass = true;
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/TopicCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/TopicCode.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)TopicCode.java	1.6 03/05/16
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.scope;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+import jakarta.jms.TopicConnection;
+import jakarta.jms.TopicConnectionFactory;
+
+public class TopicCode {
+
+  /** Prefix used for JNDI lookups */
+  private static final String prefix = "java:comp/env/jms/";
+
+  /*
+   * JNDI lookup names for resource manager connection factories. They differ
+   * only by case.
+   */
+  protected static final String resLookup = prefix + "myFactory";
+
+  public static boolean checkYourTopic(TSNamingContext nctx) {
+    TopicConnectionFactory res;
+    TopicConnection conn;
+    boolean pass;
+
+    try {
+      TestUtil.logTrace("[TopicCode] Looking up " + resLookup);
+      res = (TopicConnectionFactory) nctx.lookup(resLookup);
+      TestUtil.logTrace("[TopicCode] Create TopicConnection");
+      conn = res.createTopicConnection();
+      conn.close();
+
+      pass = true;
+    } catch (Exception e) {
+      TestUtil.logErr("Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+      pass = false;
+    }
+
+    return pass;
+  }
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/scope/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_shared_resref_scope" basedir="." default="usage">
+  <import file="../../../../../../../../../../../../bin/xml/ts.import.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/ByteArrayDataSource.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/ByteArrayDataSource.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)ByteArrayDataSource.java	1.10 03/05/16
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.single;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
+
+import com.sun.ts.lib.util.TestUtil;
+
+import jakarta.activation.DataSource;
+
+class ByteArrayDataSource implements DataSource {
+  private byte[] data;
+
+  private String type;
+
+  ByteArrayDataSource(InputStream is, String type) {
+    this.type = type;
+    try {
+      ByteArrayOutputStream os = new ByteArrayOutputStream();
+      int ch;
+
+      while ((ch = is.read()) != -1)
+        os.write(ch);
+
+      data = os.toByteArray();
+    } catch (IOException ioex) {
+      TestUtil.printStackTrace(ioex);
+    }
+  }
+
+  ByteArrayDataSource(byte[] data, String type) {
+    this.data = data;
+    this.type = type;
+  }
+
+  ByteArrayDataSource(String data, String type) {
+    try {
+      this.data = data.getBytes("iso-8859-1");
+    } catch (UnsupportedEncodingException uex) {
+      TestUtil.printStackTrace(uex);
+    }
+    this.type = type;
+  }
+
+  public InputStream getInputStream() throws IOException {
+    if (data == null)
+      throw new IOException("no data");
+    return new ByteArrayInputStream(data);
+  }
+
+  public OutputStream getOutputStream() throws IOException {
+    throw new IOException("cannot do this");
+  }
+
+  public String getContentType() {
+    return type;
+  }
+
+  public String getName() {
+    return "dummy";
+  }
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/TestCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/TestCode.java
@@ -1,0 +1,287 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)TestCode.java	1.10 03/05/16
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.single;
+
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLConnection;
+import java.sql.Connection;
+import java.util.Date;
+import java.util.Properties;
+
+import javax.sql.DataSource;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+import jakarta.activation.DataHandler;
+import jakarta.jms.QueueConnectionFactory;
+import jakarta.jms.TopicConnectionFactory;
+import jakarta.mail.Message;
+import jakarta.mail.MessagingException;
+import jakarta.mail.Session;
+import jakarta.mail.Transport;
+import jakarta.mail.internet.InternetAddress;
+import jakarta.mail.internet.MimeMessage;
+
+public class TestCode {
+
+  /** Prefix used for JNDI lookups */
+  private static final String prefix = "java:comp/env/";
+
+  /*
+   * JNDI lookup names for resource manager connection factories.
+   */
+  protected static final String dbLookup = prefix + "jdbc/DB1";
+
+  protected static final String mailLookup = prefix + "mail/MailSession";
+
+  protected static final String urlLookup = prefix + "url/URL";
+
+  protected static final String queueLookup = prefix
+      + "jms/myQueueConnectionFactory";
+
+  protected static final String topicLookup = prefix
+      + "jms/myTopicConnectionFactory";
+
+  /*
+   * Hard coded values used to send mail.
+   */
+  protected static final String mailer = "JavaMailer";
+
+  protected static final String subject = "Test message";
+
+  protected static final String htmlContents = "This is a test message";
+
+  public static boolean testDatasource(TSNamingContext nctx) {
+    DataSource ds;
+    Connection connection;
+
+    try {
+      TestUtil.logTrace("[TestCode] looking up " + dbLookup);
+      ds = (DataSource) nctx.lookup(dbLookup);
+      TestUtil.logTrace("[TestCode] get a new DB connection...");
+      connection = ds.getConnection();
+      connection.close();
+    } catch (Exception e) {
+      TestUtil.logErr("RestTest: Caught exception: " + e, e);
+      return false;
+    }
+
+    return true;
+  }
+
+  public static boolean testSession(TSNamingContext nctx) {
+    String recipient;
+    Session session;
+
+    if (null == (recipient = getRecipient())) {
+      TestUtil.logErr("RestTest: Aborting testSession() [setup]");
+      return false;
+    }
+
+    try {
+      TestUtil.logTrace("[TestCode] looking up " + mailLookup);
+      session = (Session) nctx.lookup(mailLookup);
+      TestUtil.logTrace("[TestCode] sendind mail to " + recipient);
+      Transport.send(compose(session, recipient));
+    } catch (Exception e) {
+      TestUtil.logErr("RestTest: Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+
+      return false;
+    }
+
+    return true;
+  }
+
+  public static boolean testURL(TSNamingContext nctx) {
+    Properties props;
+    String resRef;
+    URL myUrl;
+    URLConnection urlConnection;
+
+    try {
+      TestUtil.logTrace("[TestCode] looking up " + urlLookup);
+      myUrl = (java.net.URL) nctx.lookup(urlLookup);
+      TestUtil.logTrace("[TestCode] get a new URL connection...");
+      urlConnection = myUrl.openConnection();
+
+      props = TestUtil.getResponseProperties(urlConnection);
+      resRef = props.getProperty("resourceref");
+
+      if ((null == resRef) || (!resRef.equals("true"))) {
+        TestUtil.logErr("ResRef: Invalid connection!");
+        return false;
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("RestTest: Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+      return false;
+    }
+
+    return true;
+  }
+
+  public static boolean testQueue(TSNamingContext nctx) {
+    QueueConnectionFactory queueFact;
+
+    try {
+      TestUtil.logTrace("[TestCode] looking up " + queueLookup);
+      queueFact = (QueueConnectionFactory) nctx.lookup(queueLookup);
+    } catch (Exception e) {
+      TestUtil.logErr("RestTest: Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+      return false;
+    }
+
+    return true;
+  }
+
+  public static boolean testTopic(TSNamingContext nctx) {
+    TopicConnectionFactory topicFact;
+
+    try {
+      TestUtil.logTrace("[TestCode] looking up " + topicLookup);
+      topicFact = (TopicConnectionFactory) nctx.lookup(topicLookup);
+    } catch (Exception e) {
+      TestUtil.logErr("RestTest: Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+      return false;
+    }
+
+    return true;
+  }
+
+  public static boolean testAll(TSNamingContext nctx) {
+    boolean pass = true;
+
+    try {
+      pass &= testDatasource(nctx);
+      pass &= testSession(nctx);
+      pass &= testURL(nctx);
+      pass &= testQueue(nctx);
+      pass &= testTopic(nctx);
+    } catch (Exception e) {
+      TestUtil.logErr("ResRef: Caught exception in testAll: " + e);
+      TestUtil.printStackTrace(e);
+      return false;
+    }
+
+    return pass;
+  }
+
+  public static boolean testAllButDataSource(TSNamingContext nctx) {
+    boolean pass = true;
+
+    try {
+      pass &= testSession(nctx);
+      pass &= testURL(nctx);
+      pass &= testQueue(nctx);
+      pass &= testTopic(nctx);
+    } catch (Exception e) {
+      TestUtil.logErr("ResRef: Caught exception in testAllButDataSource: " + e);
+      TestUtil.printStackTrace(e);
+      return false;
+    }
+
+    return pass;
+  }
+
+  /*
+   * Helper methods.
+   */
+
+  /** Get mail recipient address */
+  protected static String getRecipient() {
+    String recipient;
+
+    try {
+      recipient = TestUtil.getProperty("mailuser1");
+
+      if ("" == recipient || null == recipient) {
+        TestUtil.logErr("[TestCode] 'mailuser1' property is "
+            + ((null == recipient) ? "null" : "empty"));
+        return null;
+      }
+
+      TestUtil.logTrace("[TestCode] Sending mail to:" + recipient);
+    } catch (Exception e) {
+      TestUtil.logErr("[TestCode] setupMail() failed: " + e, e);
+      return null;
+    }
+
+    return recipient;
+  }
+
+  /** Send a mail to 'recipient', using 'session' object. */
+  protected static Message compose(Session session, String recipient)
+      throws Exception {
+
+    Message msg;
+
+    try {
+      msg = new MimeMessage(session);
+      msg.setFrom();
+
+      msg.setRecipients(Message.RecipientType.TO,
+          InternetAddress.parse(recipient, false));
+
+      msg.setSubject(subject);
+      collect(subject, htmlContents, msg);
+      msg.setHeader("X-Mailer", mailer);
+      msg.setSentDate(new Date());
+
+    } catch (Exception e) {
+      TestUtil.logErr("[TestCode] Caught exception in compose(): " + e);
+      TestUtil.printStackTrace(e);
+      throw new Exception("compose() failed due to " + e);
+    }
+
+    return msg;
+  }
+
+  protected static void collect(String subject, String htmlContents,
+      Message msg) throws MessagingException, IOException {
+
+    String line;
+    StringBuffer sb = new StringBuffer();
+
+    sb.append("<HTML>\n");
+
+    sb.append("<HEAD>\n");
+    sb.append("<TITLE>\n");
+    sb.append(subject + "\n");
+    sb.append("</TITLE>\n");
+    sb.append("</HEAD>\n");
+
+    sb.append("<BODY>\n");
+    sb.append("<H1>" + subject + "</H1>" + "\n");
+    sb.append(htmlContents);
+    sb.append("</BODY>\n");
+
+    sb.append("</HTML>\n");
+
+    msg.setDataHandler(
+        new DataHandler(new ByteArrayDataSource(sb.toString(), "text/html")));
+  }
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/appclient/TestCode.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/appclient/TestCode.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+package com.sun.ts.tests.ejb.ee.deploy.util.shared.resref.single.appclient;
+
+import java.net.URL;
+import java.net.URLConnection;
+import java.sql.Connection;
+import java.util.Properties;
+
+import javax.sql.DataSource;
+
+import com.sun.ts.lib.util.TSNamingContext;
+import com.sun.ts.lib.util.TestUtil;
+
+import jakarta.jms.QueueConnectionFactory;
+import jakarta.jms.TopicConnectionFactory;
+
+public class TestCode {
+
+  /** Prefix used for JNDI lookups */
+  private static final String prefix = "java:comp/env/";
+
+  /*
+   * JNDI lookup names for resource manager connection factories.
+   */
+  protected static final String dbLookup = prefix + "jdbc/DB1";
+
+  protected static final String urlLookup = prefix + "url/URL";
+
+  protected static final String queueLookup = prefix
+      + "jms/myQueueConnectionFactory";
+
+  protected static final String topicLookup = prefix
+      + "jms/myTopicConnectionFactory";
+
+  public static boolean testDatasource(TSNamingContext nctx) {
+    DataSource ds;
+    Connection connection;
+
+    try {
+      TestUtil.logTrace("[TestCode] looking up " + dbLookup);
+      ds = (DataSource) nctx.lookup(dbLookup);
+      TestUtil.logTrace("[TestCode] get a new DB connection...");
+      connection = ds.getConnection();
+      connection.close();
+    } catch (Exception e) {
+      TestUtil.logErr("RestTest: Caught exception: " + e, e);
+      return false;
+    }
+
+    return true;
+  }
+
+  public static boolean testURL(TSNamingContext nctx) {
+    Properties props;
+    String resRef;
+    URL myUrl;
+    URLConnection urlConnection;
+
+    try {
+      TestUtil.logTrace("[TestCode] looking up " + urlLookup);
+      myUrl = (java.net.URL) nctx.lookup(urlLookup);
+      TestUtil.logTrace("[TestCode] get a new URL connection...");
+      urlConnection = myUrl.openConnection();
+
+      props = TestUtil.getResponseProperties(urlConnection);
+      resRef = props.getProperty("resourceref");
+
+      if ((null == resRef) || (!resRef.equals("true"))) {
+        TestUtil.logErr("ResRef: Invalid connection!");
+        return false;
+      }
+    } catch (Exception e) {
+      TestUtil.logErr("RestTest: Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+      return false;
+    }
+
+    return true;
+  }
+
+  public static boolean testQueue(TSNamingContext nctx) {
+    QueueConnectionFactory queueFact;
+
+    try {
+      TestUtil.logTrace("[TestCode] looking up " + queueLookup);
+      queueFact = (QueueConnectionFactory) nctx.lookup(queueLookup);
+    } catch (Exception e) {
+      TestUtil.logErr("RestTest: Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+      return false;
+    }
+
+    return true;
+  }
+
+  public static boolean testTopic(TSNamingContext nctx) {
+    TopicConnectionFactory topicFact;
+
+    try {
+      TestUtil.logTrace("[TestCode] looking up " + topicLookup);
+      topicFact = (TopicConnectionFactory) nctx.lookup(topicLookup);
+    } catch (Exception e) {
+      TestUtil.logErr("RestTest: Caught exception: " + e);
+      TestUtil.printStackTrace(e);
+      return false;
+    }
+
+    return true;
+  }
+
+}

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/appclient/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/appclient/build.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_shared_resref_single_appclient" basedir="." default="usage">
+  <import file="../../../../../../../../../../../../../bin/xml/ts.import.xml" />
+  <property name="pkg.dir" value="com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/appclient"/>  
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/build.xml
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/deploy/util/shared/resref/single/build.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="ejb_ee_deploy_util_shared_resref_single" basedir="." default="usage">
+  <import file="../../../../../../../../../../../../bin/xml/ts.import.xml" />
+</project>

--- a/ejb/src/main/java/com/sun/ts/tests/ejb/ee/sec/mdb/MDBClient.java
+++ b/ejb/src/main/java/com/sun/ts/tests/ejb/ee/sec/mdb/MDBClient.java
@@ -64,7 +64,7 @@ public class MDBClient extends Client {
       bmtQ = (Queue) context.lookup("java:comp/env/jms/EJB_SEC_MDB_QUEUE_BMT");
 
     } catch (Exception e) {
-      throw new Fault("Setup Failed!", e);
+      throw new Exception("Setup Failed!", e);
     }
   }
   /* Run tests */


### PR DESCRIPTION
This supercedes Scott's change under https://github.com/jakartaee/platform-tck/pull/1304

There was code in the assembly suite that was also being used in the ejb suite. This is a problem because I had modernized the assembly suite to use EJB 3.x, but we explicitly want the ejb suite to remain at the EJB 2.x level. The same classes can't really work for both levels like was inadvertently being tried here.

I removed the dependency from the ejb suite, which involved bringing over 2.x compatible versions of all of the needed classes into the ejb suite.

All of this code has been compiled and built from scratch to the best of my ability, so it should be good to go. You can see that I even found an extraneous compilation problem in sec/mdb/MDBClient that I otherwise wouldn't have touched for this piece of work.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
