### PR TITLE
Javaee Module : Fix the refactored tests to run with Glassfish 7.0.10+

### DIFF
--- a/glassfish-runner/javaee-module-tck/pom.xml
+++ b/glassfish-runner/javaee-module-tck/pom.xml
@@ -28,7 +28,11 @@
     <packaging>jar</packaging>
 
     <properties>
-        <glassfish.container.version>7.0.9</glassfish.container.version>
+        <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
+        <!-- <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version> -->
+        <!-- Use JDK21 to run with GF 8.0.0-M5 -->
+        <glassfish.container.version>8.0.0-M5</glassfish.container.version>
+        <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.artifactId>javaee-tck</tck.artifactId>
@@ -42,8 +46,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
-            <artifactId>javaee-tck</artifactId>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>${tck.artifactId}</artifactId>
             <version>${tck.version}</version>
         </dependency>
         <dependency>
@@ -173,7 +177,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <dependenciesToScan>jakartatck:javaee-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>

--- a/glassfish-runner/javaee-module-tck/src/test/resources/arquillian.xml
+++ b/glassfish-runner/javaee-module-tck/src/test/resources/arquillian.xml
@@ -10,7 +10,7 @@
   <group qualifier="glassfish-servers" default="true">
     <container qualifier="http" default="true">
         <configuration>
-            <property name="glassFishHome">target/glassfish7</property>
+            <property name="glassFishHome">target/glassfish8</property>
         </configuration>
     </container>
   </group>

--- a/javaee/pom.xml
+++ b/javaee/pom.xml
@@ -44,6 +44,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>servlet</artifactId>
+            <version>11.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>jakarta.inject</groupId>

--- a/servlet/src/main/java/com/sun/ts/tests/servlet/common/client/AbstractUrlClient.java
+++ b/servlet/src/main/java/com/sun/ts/tests/servlet/common/client/AbstractUrlClient.java
@@ -23,8 +23,6 @@ package com.sun.ts.tests.servlet.common.client;
 import com.sun.ts.tests.servlet.common.request.HttpRequest;
 import com.sun.ts.tests.servlet.common.request.WebTestCase;
 import com.sun.ts.tests.servlet.common.util.Data;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -38,8 +36,6 @@ import java.net.UnknownHostException;
  */
 
 public abstract class AbstractUrlClient extends BaseUrlClient {
-
-  protected final Logger logger = LoggerFactory.getLogger(getClass());
 
   protected static final String APITEST = "apitest";
 

--- a/servlet/src/main/java/com/sun/ts/tests/servlet/common/servlets/HttpTCKServlet.java
+++ b/servlet/src/main/java/com/sun/ts/tests/servlet/common/servlets/HttpTCKServlet.java
@@ -25,8 +25,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServlet;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import java.lang.System.Logger;
 
 /**
  * GenericTCKServlet.java
@@ -44,7 +43,7 @@ public abstract class HttpTCKServlet extends HttpServlet {
 
   private static final String TEXT_PLAIN = "text/plain";
 
-  protected Logger logger = LoggerFactory.getLogger(getClass());
+  protected static final Logger logger = System.getLogger(HttpTCKServlet.class.getName());
 
   /**
    * <code>TEST_HEADER</code> is the constant for the <code>testname</code>

--- a/servlet/src/main/java/com/sun/ts/tests/servlet/common/util/ServletTestUtil.java
+++ b/servlet/src/main/java/com/sun/ts/tests/servlet/common/util/ServletTestUtil.java
@@ -22,10 +22,6 @@ package com.sun.ts.tests.servlet.common.util;
 
 import jakarta.servlet.ServletOutputStream;
 import jakarta.servlet.http.Cookie;
-import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -37,14 +33,14 @@ import java.util.NoSuchElementException;
 import java.util.StringTokenizer;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import java.lang.System.Logger;
 
 /**
  * A set of useful utility methods to help perform test functions.
  */
 public class ServletTestUtil {
 
-  private static Logger LOGGER = LoggerFactory.getLogger(ServletTestUtil.class);
-
+  private static final Logger LOGGER = System.getLogger(ServletTestUtil.class.getName());
   /**
    * Private as this class contains only public static methods.
    */
@@ -124,7 +120,7 @@ public class ServletTestUtil {
         count++;
         if (!allowDuplicates) {
           if (foundValues.contains(val)) {
-            LOGGER.debug("[ServletTestUtil] Duplicate values found in "
+            LOGGER.log(Logger.Level.DEBUG, "[ServletTestUtil] Duplicate values found in "
                 + "Enumeration when duplicates are not allowed."
                 + "Values found in the Enumeration: {}", getAsString(e));
             valuesFound = false;
@@ -134,14 +130,14 @@ public class ServletTestUtil {
         }
 
       } catch (NoSuchElementException nsee) {
-        LOGGER.info("[ServletTestUtil] There were less elements in the "
+        LOGGER.log(Logger.Level.INFO, "[ServletTestUtil] There were less elements in the "
             + "Enumeration than expected");
         valuesFound = false;
         break;
       }
-      LOGGER.debug("[ServletTestUtil] Looking for '{}' in values: {}", val, getAsString(values));
+      LOGGER.log(Logger.Level.DEBUG, "[ServletTestUtil] Looking for '{"+val+"}' in values: {"+getAsString(values)+"}");
       if ((Arrays.binarySearch(values, val) < 0) && (enforceSizes)) {
-        LOGGER.info("[ServletTestUtil] Value '{}' not found.", val);
+        LOGGER.log(Logger.Level.INFO, "[ServletTestUtil] Value '{"+val+"}' not found.");
         valuesFound = false;
         continue;
       }
@@ -150,11 +146,11 @@ public class ServletTestUtil {
     if (enforceSizes) {
       if (e.hasMoreElements()) {
         // more elements than should have been.
-        LOGGER.info("[ServletTestUtil] There were more elements in the Enumeration than expected.");
+        LOGGER.log(Logger.Level.INFO, "[ServletTestUtil] There were more elements in the Enumeration than expected.");
         valuesFound = false;
       }
       if (count != values.length) {
-        LOGGER.info("[ServletTestUtil] There number of elements in the Enumeration did not match number of expected values."
+        LOGGER.log(Logger.Level.INFO, "[ServletTestUtil] There number of elements in the Enumeration did not match number of expected values."
             + "Expected number of Values= {}, Actual number of Enumeration elements= {}", values.length, count);
 
         valuesFound = false;
@@ -182,19 +178,19 @@ public class ServletTestUtil {
     for (int i = 0; i < len; i++) {
       Object val = null;
       val = (String) al.get(i);
-      LOGGER.debug("[ServletTestUtil] val= {}", val);
+      LOGGER.log(Logger.Level.DEBUG, "[ServletTestUtil] val= {}", val);
       if (!allowDuplicates) {
         if (foundValues.contains(val)) {
-          LOGGER.info("[ServletTestUtil] Duplicate values found in ArrayList when duplicates are not allowed."
+          LOGGER.log(Logger.Level.INFO, "[ServletTestUtil] Duplicate values found in ArrayList when duplicates are not allowed."
               + "Values found in the ArrayList: {}", getAsString(al));
           valuesFound = false;
           break;
         }
         foundValues.add(val);
       }
-      LOGGER.debug("[ServletTestUtil] Looking for '{}' in values: {}", val, getAsString(values));
+      LOGGER.log(Logger.Level.DEBUG, "[ServletTestUtil] Looking for '{}' in values: {}" + val + getAsString(values));
       if ((Arrays.binarySearch(values, val) < 0) && (enforceSizes)) {
-        LOGGER.info("[ServletTestUtil] Value '{}' not found.", val);
+        LOGGER.log(Logger.Level.INFO, "[ServletTestUtil] Value '{}' not found."+ val);
         valuesFound = false;
         continue;
       }
@@ -202,9 +198,9 @@ public class ServletTestUtil {
 
     if (enforceSizes) {
       if (len != values.length) {
-        LOGGER.info("[ServletTestUtil] There number of elements in the ArrayList "
+        LOGGER.log(Logger.Level.INFO, "[ServletTestUtil] There number of elements in the ArrayList "
             + "did not match number of expected values."
-            + "Expected number of Values= {}, Actual number of ArrayList elements= {}", values.length, len);
+            + "Expected number of Values= {"+values.length+"}, Actual number of ArrayList elements= {"+len+"}");
 
         valuesFound = false;
       }
@@ -226,8 +222,7 @@ public class ServletTestUtil {
       int searchIdx = actual.toLowerCase().indexOf(search.toLowerCase(),
           startIdx);
 
-      LOGGER.debug("[ServletTestUtil] Scanning response for search string: '{}' starting at index " + "location: {}",
-              search , startIdx);
+      LOGGER.log(Logger.Level.DEBUG, "[ServletTestUtil] Scanning response for search string: '{"+search+"}' starting at index " + "location: {"+startIdx+"}");
       if (searchIdx < 0) {
         found = false;
         StringBuffer sb = new StringBuffer(255);
@@ -238,12 +233,11 @@ public class ServletTestUtil {
           .append("-------------------------------------------\n")
           .append(actual)
           .append("\n-------------------------------------------\n");
-        LOGGER.debug(sb.toString());
+          LOGGER.log(Logger.Level.DEBUG, sb.toString());
         break;
       }
 
-      LOGGER.debug("[ServletTestUtil] Found search string: '{}' at index '{}' in the server's response",
-              search, searchIdx);
+      LOGGER.log(Logger.Level.DEBUG, "[ServletTestUtil] Found search string: '{"+search+"}' at index '{"+searchIdx+"}' in the server's response");
       // the new searchIdx is the old index plus the lenght of the
       // search string.
       startIdx = searchIdx + search.length();

--- a/servlet/src/main/java/com/sun/ts/tests/servlet/spec/srlistener/TestServlet.java
+++ b/servlet/src/main/java/com/sun/ts/tests/servlet/spec/srlistener/TestServlet.java
@@ -31,6 +31,7 @@ import jakarta.servlet.RequestDispatcher;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.lang.System.Logger;
 
 public class TestServlet extends HttpTCKServlet {
 
@@ -40,7 +41,7 @@ public class TestServlet extends HttpTCKServlet {
 
     String path = "/include/IncludedServlet?testname=simple";
     RequestDispatcher rd = getServletContext().getRequestDispatcher(path);
-    logger.info("In method includes");
+    logger.log(Logger.Level.INFO, "In method includes");
     if (rd == null) {
       pw.println("Null RequestDispatcher got for path=" + path);
     } else {
@@ -54,7 +55,7 @@ public class TestServlet extends HttpTCKServlet {
 
     String path = "/include/IncludedServlet?testname=includeagain";
     RequestDispatcher rd = getServletContext().getRequestDispatcher(path);
-    logger.debug("In method multipleincludes");
+    logger.log(Logger.Level.DEBUG, "In method multipleincludes");
 
     if (rd == null) {
       pw.println("Null RequestDispatcher got for path=" + path);
@@ -69,7 +70,7 @@ public class TestServlet extends HttpTCKServlet {
 
     String path = "/include/IncludedServlet?testname=forward";
     RequestDispatcher rd = getServletContext().getRequestDispatcher(path);
-    logger.debug("In method includeforward");
+    logger.log(Logger.Level.DEBUG, "In method includeforward");
     if (rd == null) {
       pw.println("Null RequestDispatcher got for path=" + path);
     } else {
@@ -83,7 +84,7 @@ public class TestServlet extends HttpTCKServlet {
 
     String path = "/include/IncludedServlet?testname=error";
     RequestDispatcher rd = getServletContext().getRequestDispatcher(path);
-    logger.debug("In method includeerror");
+    logger.log(Logger.Level.DEBUG, "In method includeerror");
     if (rd == null) {
       pw.println("Null RequestDispatcher got for path=" + path);
     } else {
@@ -104,7 +105,7 @@ public class TestServlet extends HttpTCKServlet {
 
     String path = "/forward/ForwardedServlet?testname=simple";
     RequestDispatcher rd = getServletContext().getRequestDispatcher(path);
-    logger.debug("In method forward");
+    logger.log(Logger.Level.DEBUG, "In method forward");
     if (rd == null) {
       pw.println("Null RequestDispatcher got for path=" + path);
     } else {
@@ -118,7 +119,7 @@ public class TestServlet extends HttpTCKServlet {
 
     String path = "/forward/ForwardedServlet?testname=forwardagain";
     RequestDispatcher rd = getServletContext().getRequestDispatcher(path);
-    logger.debug("In method multipleforward");
+    logger.log(Logger.Level.DEBUG, "In method multipleforward");
     if (rd == null) {
       pw.println("Null RequestDispatcher got for path=" + path);
     } else {
@@ -132,7 +133,7 @@ public class TestServlet extends HttpTCKServlet {
 
     String path = "/forward/ForwardedServlet?testname=include";
     RequestDispatcher rd = getServletContext().getRequestDispatcher(path);
-    logger.debug("In method forwardinclude");
+    logger.log(Logger.Level.DEBUG, "In method forwardinclude");
     if (rd == null) {
       pw.println("Null RequestDispatcher got for path=" + path);
     } else {
@@ -146,7 +147,7 @@ public class TestServlet extends HttpTCKServlet {
 
     String path = "/forward/ForwardedServlet?testname=error";
     RequestDispatcher rd = getServletContext().getRequestDispatcher(path);
-    logger.debug("In method forwarderror");
+    logger.log(Logger.Level.DEBUG, "In method forwarderror");
     if (rd == null) {
       pw.println("Null RequestDispatcher got for path=" + path);
     } else {
@@ -159,7 +160,7 @@ public class TestServlet extends HttpTCKServlet {
     PrintWriter pw = response.getWriter();
     pw.println("TestServlet Invoked");
     pw.println("In method async");
-    logger.debug("In method async");
+    logger.log(Logger.Level.DEBUG, "In method async");
     try {
       AsyncContext asyncc = request.startAsync();
       response.getWriter().println("TestServlet_Async=STARTED");
@@ -176,7 +177,7 @@ public class TestServlet extends HttpTCKServlet {
     PrintWriter pw = response.getWriter();
     pw.println("TestServlet Invoked");
     pw.println("In method simpleasyncinclude");
-    logger.debug("In method simpleasyncinclude");
+    logger.log(Logger.Level.DEBUG, "In method simpleasyncinclude");
     try {
       AsyncContext asyncc = request.startAsync();
       response.getWriter().println("TestServlet_Async=STARTED");
@@ -202,7 +203,7 @@ public class TestServlet extends HttpTCKServlet {
     PrintWriter pw = response.getWriter();
     pw.println("TestServlet Invoked");
     pw.println("In method simpleasyncforward");
-    logger.debug("In method simpleasyncforward");
+    logger.log(Logger.Level.DEBUG, "In method simpleasyncforward");
     try {
       AsyncContext asyncc = request.startAsync();
       response.getWriter().println("TestServlet_Async=STARTED");
@@ -228,7 +229,7 @@ public class TestServlet extends HttpTCKServlet {
     PrintWriter pw = response.getWriter();
     pw.println("TestServlet Invoked");
     pw.println("In method simpleasyncerror");
-    logger.debug("In method simpleasyncerror");
+    logger.log(Logger.Level.DEBUG, "In method simpleasyncerror");
     try {
       AsyncContext asyncc = request.startAsync();
       response.getWriter().println("TestServlet_Async=STARTED");
@@ -243,7 +244,7 @@ public class TestServlet extends HttpTCKServlet {
 
   public void error(HttpServletRequest req, HttpServletResponse res)
       throws ServletException, IOException {
-    logger.debug("In TestServlet, error method");
+    logger.log(Logger.Level.DEBUG, "In TestServlet, error method");
     res.sendError(403);
   }
 


### PR DESCRIPTION
**Describe the change**
The 24 refactored tests in javaee module was failing with Glassfish 7.0.10+ due to org/slf4j/Logger not found error.
The changes replaced the usage of slf4j logger with System.Logger.

- The tests pass with 8.0.0-JDK17-M5 + JDK17
- The tests pass with 8.0.0-M5 + JDK21

**Additional context**
- javaee module tests were refactored in https://github.com/jakartaee/platform-tck/pull/1205 to use Arquillian/Junit.
- Currently the javaee tests uses the servlet module of which the tests were migrated to spec project. In case the servlet module is removed from platform-tck project in future changes, the parts of servlet module which is used by other modules should be retained.