### PR TITLE
Fix dependency for Jaxrs module

### DIFF
--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -38,6 +38,8 @@
         <jakarta.validation-api.version>3.1.0-M2</jakarta.validation-api.version>
         <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
+        <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
     </properties>
 
     <dependencies>
@@ -49,6 +51,16 @@
         <dependency>
             <groupId>commons-httpclient</groupId>
             <artifactId>commons-httpclient</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <version>${jakarta.inject-api.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+            <version>${jakarta.enterprise.cdi-api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.validation</groupId>

--- a/jaxrs/pom.xml
+++ b/jaxrs/pom.xml
@@ -33,13 +33,13 @@
     <description>JAXRS Tests for Jakarta EE Platform</description>
 
     <properties>
+        <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
         <jakarta.validation-api.version>3.1.0-M2</jakarta.validation-api.version>
         <jakarta.ws.rs-api.version>4.0.0</jakarta.ws.rs-api.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
-        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
-        <jakarta.enterprise.cdi-api.version>4.1.0</jakarta.enterprise.cdi-api.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
**Describe the change**
2 dependencies were missed out from jaxrs module during last update. Adding them back to fix the compilation errors.
