### PR TITLE
EL TCK : update versions for 6.0.1 release

### DIFF
--- a/el/pom.xml
+++ b/el/pom.xml
@@ -23,18 +23,18 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0-M1</version>
     </parent>
 
     <artifactId>jakarta-expression-language-tck</artifactId>
-    <version>6.0.0</version>
+    <version>6.0.1</version>
     <packaging>jar</packaging>
 
     <name>el-tck</name>
     <description>EL TCK</description>
 
     <properties>
-        <jakarta.el-api.version>6.0.0-RC1</jakarta.el-api.version>
+        <jakarta.el-api.version>6.0.0</jakarta.el-api.version>
     </properties>
 
     <dependencies>
@@ -51,7 +51,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>2.1</version>
+            <version>2.3</version>
         </dependency>
 
     </dependencies>
@@ -150,7 +150,7 @@
                     <plugin>
                         <groupId>jakarta.tck</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
-                        <version>2.2</version>
+                        <version>2.3</version>
                         <configuration>
                             <FileName>${project.build.directory}/jakarta.el.sig_${project.parent.version}</FileName>
                             <packages>jakarta.el</packages>


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1298

**Describe the change**
-Update the EL TCK version to 6.0.1 for service release 
-Correct parent jakarta.tck/project version to 11.0.0-M1 instead of SNAPSHOT