### PR TITLE
Remove getRootCause() 10.0.x

### DIFF
--- a/src/com/sun/ts/tests/jstl/common/tags/ExceptionCheckTag.java
+++ b/src/com/sun/ts/tests/jstl/common/tags/ExceptionCheckTag.java
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Contributors to the Eclipse Foundation
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -171,7 +172,7 @@ public class ExceptionCheckTag extends TagSupport implements TryCatchFinally {
         sb.append("</strong> was thrown!");
 
         if (t instanceof JspException && _checkRootCause) {
-          Throwable rt = ((JspException) t).getRootCause();
+          Throwable rt = ((JspException) t).getCause();
           if (rt != null) {
             if (_rootException == null) {
               sb.append("<br>\nThe root cause of Exception defined");


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/tags/issues/256

**Related Issue(s)**
https://github.com/jakartaee/tags/issues/256

**Describe the change**
[JspException.getRootCause()](https://jakarta.ee/specifications/pages/3.1/apidocs/jakarta.servlet.jsp/jakarta/servlet/jsp/jspexception#getRootCause()) has been deprecated and was removed in Pages 4.0 (Jakarta EE11).

For some of the Jakarta Tags tck tests getRootCause was being invoked and causing the following exception:
`java.lang.NoSuchMethodError: 'java.lang.Throwable jakarta.servlet.jsp.JspException.getRootCause()`

**Additional context**
N/A

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
