### PR TITLE
Fixed getter/setter names to conform to java bean specification. 

### DIFF
--- a/src/com/sun/ts/tests/jpa/core/entityManager/Order.java
+++ b/src/com/sun/ts/tests/jpa/core/entityManager/Order.java
@@ -69,17 +69,17 @@ public class Order implements java.io.Serializable {
     this.total = total;
   }
 
-  public String getdescription() {
+  public String getDescription() {
     return description;
   }
 
-  public void setdescription(String description) {
+  public void setDescription(String description) {
     this.description = description;
   }
 
   public String toString() {
     return "Order id=" + getId() + ", total=" + getTotal() + ", desc="
-        + getdescription();
+        + getDescription();
   }
 
   @Override
@@ -95,7 +95,7 @@ public class Order implements java.io.Serializable {
     boolean result = false;
 
     if (this.getId() == o1.getId()
-        && this.getdescription().equals(o1.getdescription())
+        && this.getDescription().equals(o1.getDescription())
         && this.getTotal() == o1.getTotal()) {
       result = true;
     }

--- a/src/com/sun/ts/tests/jpa/core/entityManager2/Order.java
+++ b/src/com/sun/ts/tests/jpa/core/entityManager2/Order.java
@@ -69,16 +69,16 @@ public class Order implements java.io.Serializable {
     this.total = total;
   }
 
-  public String getdescription() {
+  public String getDescription() {
     return description;
   }
 
-  public void setdescription(String description) {
+  public void setDescription(String description) {
     this.description = description;
   }
 
   public String toString() {
     return "Order id=" + getId() + ", total=" + getTotal() + ", desc="
-        + getdescription();
+        + getDescription();
   }
 }

--- a/src/com/sun/ts/tests/jpa/ee/entityManager/Order.java
+++ b/src/com/sun/ts/tests/jpa/ee/entityManager/Order.java
@@ -69,16 +69,16 @@ public class Order implements java.io.Serializable {
     this.total = total;
   }
 
-  public String getdescription() {
+  public String getDescription() {
     return description;
   }
 
-  public void setdescription(String description) {
+  public void setDescription(String description) {
     this.description = description;
   }
 
   public String toString() {
     return "Order id=" + getId() + ", total=" + getTotal() + ", desc="
-        + getdescription();
+        + getDescription();
   }
 }

--- a/src/com/sun/ts/tests/jpa/se/entityManager/Order.java
+++ b/src/com/sun/ts/tests/jpa/se/entityManager/Order.java
@@ -69,16 +69,16 @@ public class Order implements java.io.Serializable {
     this.total = total;
   }
 
-  public String getdescription() {
+  public String getDescription() {
     return description;
   }
 
-  public void setdescription(String description) {
+  public void setDescription(String description) {
     this.description = description;
   }
 
   public String toString() {
     return "Order id=" + getId() + ", total=" + getTotal() + ", desc="
-        + getdescription();
+        + getDescription();
   }
 }


### PR DESCRIPTION
The getter/setter methods were not conforming to java bean specification. Because of these,  persistence using bytecode enhancement was not working. 

**Fixes Issue**
Specify the issue (link) that is solved with this pull request.

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
A clear and concise description of the change.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
