### PR TITLE
TCK Challenge issue # 1260 -  SQL DML change for running on Java 21

### DIFF
--- a/release/tools/jakartaee.xml
+++ b/release/tools/jakartaee.xml
@@ -30,7 +30,7 @@
     <property name="sjsas.internal.compat"         value="NULL"/>
     <property name="cts.internal.comment"          value=""/>
     <property name="deliverable.version"           value="10.0"/>
-    <property name="deliverable.tck.version"           value="10.0.4"/>
+    <property name="deliverable.tck.version"           value="10.0.5"/>
 
 	<property name="the.excludes" value="**/internal/**/*,
 	     **/jaxm/**/*, **/jaxm1.0.1/**/*,

--- a/sql/derby/derby.dml.sql
+++ b/sql/derby/derby.dml.sql
@@ -70,9 +70,9 @@ Longvarbinary_Tab_Delete=delete from Longvarbinary_Tab
 # SQL Statements for inserting values into the tables 
 #****************************************************
 
-Numeric_Tab_Insert=insert into Numeric_Tab values(999999999999999,0.000000000000001, null)
+Numeric_Tab_Insert=insert into Numeric_Tab values(9999999999,0.000000000000001, null)
 
-Decimal_Tab_Insert= insert into Decimal_Tab values(999999999999999,0.000000000000001, null)
+Decimal_Tab_Insert= insert into Decimal_Tab values(9999999999,0.000000000000001, null)
 
 #Double_Tab_Insert=insert into Double_Tab values(1.7976931348623157E308,4.9E-324,null)
 Double_Tab_Insert=insert into Double_Tab values(1.0E125,1.0E-130,null)

--- a/sql/mssqlserver/mssqlserver.dml.sql
+++ b/sql/mssqlserver/mssqlserver.dml.sql
@@ -70,9 +70,9 @@ Longvarbinary_Tab_Delete=delete from Longvarbinary_Tab
 # SQL Statements for inserting values into the tables 
 #****************************************************
 
-Numeric_Tab_Insert=insert into Numeric_Tab values(999999999999999,0.000000000000001, null)
+Numeric_Tab_Insert=insert into Numeric_Tab values(9999999999,0.000000000000001, null)
 
-Decimal_Tab_Insert= insert into Decimal_Tab values(999999999999999,0.000000000000001, null)
+Decimal_Tab_Insert= insert into Decimal_Tab values(9999999999,0.000000000000001, null)
 
 #Double_Tab_Insert=insert into Double_Tab values(1.7976931348623157E308,4.9E-324,null)
 Double_Tab_Insert=insert into Double_Tab values(1.0E125,1.0E-130,null)

--- a/sql/mysql/mysql.dml.sql
+++ b/sql/mysql/mysql.dml.sql
@@ -64,11 +64,11 @@ Longvarbinary_Tab_Delete=delete from Longvarbinary_Tab
 # SQL Statements for inserting values into the tables 
 #****************************************************
 
-#Numeric_Tab_Insert=insert into Numeric_Tab values(999999999999999,0.000000000000001, null)
+#Numeric_Tab_Insert=insert into Numeric_Tab values(9999999999,0.000000000000001, null)
 
 Numeric_Tab_Insert=insert into Numeric_Tab values(9999999999,0.0000000001, null)
 
-#Decimal_Tab_Insert= insert into Decimal_Tab values(999999999999999,0.000000000000001, null)
+#Decimal_Tab_Insert= insert into Decimal_Tab values(9999999999,0.000000000000001, null)
 
 Decimal_Tab_Insert= insert into Decimal_Tab values(9999999999,0.0000000001, null)
 

--- a/sql/oracle/oracle.dml.sql
+++ b/sql/oracle/oracle.dml.sql
@@ -64,9 +64,9 @@ Longvarbinary_Tab_Delete=delete from Longvarbinary_Tab
 # SQL Statements for inserting values into the tables 
 #****************************************************
 
-Numeric_Tab_Insert=insert into Numeric_Tab values(999999999999999,0.000000000000001, null)
+Numeric_Tab_Insert=insert into Numeric_Tab values(9999999999,0.000000000000001, null)
 
-Decimal_Tab_Insert= insert into Decimal_Tab values(999999999999999,0.000000000000001, null)
+Decimal_Tab_Insert= insert into Decimal_Tab values(9999999999,0.000000000000001, null)
 
 Double_Tab_Insert=insert into Double_Tab values(1.0E125,1.0E-130,null)
 

--- a/sql/pointbase/pointbase.dml.sql
+++ b/sql/pointbase/pointbase.dml.sql
@@ -67,9 +67,9 @@ Longvarbinary_Tab_Delete=delete from Longvarbinary_Tab
 # SQL Statements for inserting values into the tables 
 #****************************************************
 
-Numeric_Tab_Insert=insert into Numeric_Tab values(999999999999999,0.000000000000000, null)
+Numeric_Tab_Insert=insert into Numeric_Tab values(9999999999,0.000000000000000, null)
 
-Decimal_Tab_Insert= insert into Decimal_Tab values(999999999999999,0.000000000000000, null)
+Decimal_Tab_Insert= insert into Decimal_Tab values(9999999999,0.000000000000000, null)
 
 #Double_Tab_Insert=insert into Double_Tab values(1.7976931348623157E308,4.9E-324,null)
 #Double_Tab_Insert=insert into Double_Tab values(1.0E125,1.0E-130,null)

--- a/sql/postgresql/postgresql.dml.sql
+++ b/sql/postgresql/postgresql.dml.sql
@@ -64,10 +64,10 @@ Longvarbinary_Tab_Delete=delete from Longvarbinary_Tab
 # SQL Statements for inserting values into the tables 
 #****************************************************
 
-#Numeric_Tab_Insert=insert into Numeric_Tab values(999999999999999,0.0000000001, null)
+#Numeric_Tab_Insert=insert into Numeric_Tab values(9999999999,0.0000000001, null)
 Numeric_Tab_Insert=insert into Numeric_Tab values(9999999999,0.0000000001, null)
 
-#Decimal_Tab_Insert= insert into Decimal_Tab values(999999999999999,0.0000000001, null)
+#Decimal_Tab_Insert= insert into Decimal_Tab values(9999999999,0.0000000001, null)
 Decimal_Tab_Insert= insert into Decimal_Tab values(9999999999,0.0000000001, null)
 
 Double_Tab_Insert=insert into Double_Tab values(1.0E125,1.0E-130,null)

--- a/sql/sybase/sybase.dml.sql
+++ b/sql/sybase/sybase.dml.sql
@@ -70,9 +70,9 @@ Longvarbinary_Tab_Delete=delete from Longvarbinary_Tab
 # SQL Statements for inserting values into the tables 
 #****************************************************
 
-Numeric_Tab_Insert=insert into Numeric_Tab values(999999999999999,0.000000000000001, null)
+Numeric_Tab_Insert=insert into Numeric_Tab values(9999999999,0.000000000000001, null)
 
-Decimal_Tab_Insert= insert into Decimal_Tab values(999999999999999,0.000000000000001, null)
+Decimal_Tab_Insert= insert into Decimal_Tab values(9999999999,0.000000000000001, null)
 
 #Double_Tab_Insert=insert into Double_Tab values(1.7976931348623157E308,4.9E-324,null)
 Double_Tab_Insert=insert into Double_Tab values(1.0E125,1.0E-130,null)


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/1260

As described in the related https://issues.apache.org/jira/browse/DERBY-7160 issue, https://bugs.openjdk.org/browse/JDK-4511638 (https://github.com/openjdk/jdk/commit/72bcf2aa03d53b0f68eb07a902575b4e8628d859) changed OpenJDK 19 behavior that impacts the failing JDBC test as described in https://github.com/jakartaee/platform-tck/issues/1260.
