### PR TITLE
JSTL Test Fix(tckrefactor branch) for issues/255 in JDK21 due to space character before AM/PM

### DIFF
--- a/jstl/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -14,9 +14,6 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-/*
- * $URL$ $LastChangedDate$
- */
 
 package com.sun.ts.tests.jstl.common.client;
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2023 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -231,4 +231,20 @@ public class AbstractUrlClient extends BaseUrlClient {
     testCase.setRequest(req);
 
   }
+
+  public boolean isJavaVersion20OrGreater() {
+    boolean isJavaVersion20OrGreater = false;
+
+    String version = System.getProperty("java.version");
+    int majorVersionDot = version.indexOf(".");
+
+    version = version.substring(0, majorVersionDot);
+
+    if (Integer.parseInt(version) >= 20) {
+        isJavaVersion20OrGreater = true;
+    }
+
+    return isJavaVersion20OrGreater;
+  }
+
 }

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/JSTLClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -58,6 +58,7 @@ public class JSTLClientIT extends CompatAbstractUrlClient {
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFDValueTest.jsp")), "positiveFDValueTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFNScopeTest.jsp")), "positiveFNScopeTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextI18NTest.jsp")), "positiveFormatLocalizationContextI18NTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextI18NTestJava20Plus.jsp")), "positiveFormatLocalizationContextI18NTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveForTokensTest.jsp")), "positiveForTokensTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveIfScopeTest.jsp")), "positiveIfScopeTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveImportAbsUrlTest.jsp")), "positiveImportAbsUrlTest.jsp");
@@ -246,14 +247,19 @@ public class JSTLClientIT extends CompatAbstractUrlClient {
    */
   @Test
   public void positiveFormatLocalizationContextI18NTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextI18NTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(TEST_NAME,
         "positiveFormatLocalizationContextI18NTest");
-    TEST_PROPS.setProperty(REQUEST,
-        "positiveFormatLocalizationContextI18NTest.jsp");
-    // TEST_PROPS.setProperty(GOLDENFILE,
-    //     "positiveFormatLocalizationContextI18NTest.gf");
+    if (isJavaVersion20OrGreater()) {
+          TEST_PROPS.setProperty(REQUEST,
+              "positiveFormatLocalizationContextI18NTestJava20Plus.jsp");
+          gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextI18NTestJava20Plus.gf");
+    } else {
+          TEST_PROPS.setProperty(REQUEST,
+              "positiveFormatLocalizationContextI18NTest.jsp");
+          gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextI18NTest.gf");
+    }
+    setGoldenFileStream(gfStream);
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en-US");
     invoke();
   }
@@ -760,9 +766,14 @@ public class JSTLClientIT extends CompatAbstractUrlClient {
    */
   @Test
   public void positiveSetTimezoneValueTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveSetTimezoneValueTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(STANDARD_COMPAT, "positiveSetTimezoneValueTest");
+    if (isJavaVersion20OrGreater()) {
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveSetTimezoneValueTestJava20Plus.gf");
+    } else {
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveSetTimezoneValueTest.gf");
+    }
+    setGoldenFileStream(gfStream);
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en");
     invoke();
   }
@@ -779,9 +790,15 @@ public class JSTLClientIT extends CompatAbstractUrlClient {
    */
   @Test
   public void positiveTimezoneValueTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveTimezoneValueTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(STANDARD_COMPAT, "positiveTimezoneValueTest");
+    if (isJavaVersion20OrGreater()) {
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveTimezoneValueTestJava20Plus.gf");
+    } else {
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveTimezoneValueTest.gf");
+    }
+    setGoldenFileStream(gfStream);
+
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en");
     invoke();
   }

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/JSTLClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/JSTLClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -48,10 +48,13 @@ public class JSTLClientIT extends AbstractUrlClient {
     archive.setWebXML(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/jstl_fmt_locctx_web.xml"));
 
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextBrowserLocaleTest.jsp")), "positiveFormatLocalizationContextBrowserLocaleTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp")), "positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextBundleTest.jsp")), "positiveFormatLocalizationContextBundleTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextBundleTestJava20Plus.jsp")), "positiveFormatLocalizationContextBundleTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextI18NTest.jsp")), "positiveFormatLocalizationContextI18NTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextI18NTestJava20Plus.jsp")), "positiveFormatLocalizationContextI18NTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextLocaleTest.jsp")), "positiveFormatLocalizationContextLocaleTest.jsp");
-
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp")), "positiveFormatLocalizationContextLocaleTestJava20Plus.jsp");
     archive.addAsLibrary(getCommonJarArchive());
 
     return archive;
@@ -73,14 +76,19 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positiveFormatLocalizationContextBundleTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextBundleTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(TEST_NAME,
         "positiveFormatLocalizationContextBundleTest");
-    TEST_PROPS.setProperty(REQUEST,
-        "positiveFormatLocalizationContextBundleTest.jsp");
-    // TEST_PROPS.setProperty(GOLDENFILE,
-    //     "positiveFormatLocalizationContextBundleTest.gf");
+    if (isJavaVersion20OrGreater()) {
+        TEST_PROPS.setProperty(REQUEST,
+            "positiveFormatLocalizationContextBundleTestJava20Plus.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextBundleTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positiveFormatLocalizationContextBundleTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextBundleTest.gf");    
+    }
+    setGoldenFileStream(gfStream);
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en-US");
     invoke();
   }
@@ -101,12 +109,20 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positiveFormatLocalizationContextI18NTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextI18NTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(TEST_NAME,
         "positiveFormatLocalizationContextI18NTest");
-    TEST_PROPS.setProperty(REQUEST,
-        "positiveFormatLocalizationContextI18NTest.jsp");
+    if (isJavaVersion20OrGreater()) {
+        TEST_PROPS.setProperty(REQUEST,
+            "positiveFormatLocalizationContextI18NTestJava20Plus.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextI18NTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positiveFormatLocalizationContextI18NTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextI18NTest.gf");
+    }
+      setGoldenFileStream(gfStream);
+  
     // TEST_PROPS.setProperty(GOLDENFILE,
     //     "positiveFormatLocalizationContextI18NTest.gf");
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en-US");
@@ -127,14 +143,19 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positiveFormatLocalizationContextLocaleTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextLocaleTest.gf");
+    InputStream gfStream;
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positiveFormatLocalizationContextLocaleTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextLocaleTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positiveFormatLocalizationContextLocaleTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextLocaleTest.gf");
+    }
     setGoldenFileStream(gfStream);
     TEST_PROPS.setProperty(TEST_NAME,
         "positiveFormatLocalizationContextLocaleTest");
-    TEST_PROPS.setProperty(REQUEST,
-        "positiveFormatLocalizationContextLocaleTest.jsp");
-    // TEST_PROPS.setProperty(GOLDENFILE,
-    //     "positiveFormatLocalizationContextLocaleTest.gf");
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: de-DE");
     invoke();
   }
@@ -153,15 +174,24 @@ public class JSTLClientIT extends AbstractUrlClient {
   @Test
   public void positiveFormatLocalizationContextBrowserLocaleTest()
       throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextBrowserLocaleTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream ;
     TEST_PROPS.setProperty(TEST_NAME,
         "positiveFormatLocalizationContextBrowserLocaleTest");
-    TEST_PROPS.setProperty(REQUEST,
-        "positiveFormatLocalizationContextBrowserLocaleTest.jsp");
     // TEST_PROPS.setProperty(GOLDENFILE,
     //     "positiveFormatLocalizationContextBrowserLocaleTest.gf");
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positiveFormatLocalizationContextBrowserLocaleTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveFormatLocalizationContextBrowserLocaleTest.gf");
+    }
+    setGoldenFileStream(gfStream);
+
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en-US");
     invoke();
   }
+
 }

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/JSTLClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/JSTLClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/JSTLClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -52,18 +52,28 @@ public class JSTLClientIT extends AbstractUrlClient {
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/negativePDScopeNoVarTest.jsp")), "negativePDScopeNoVarTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/negativePDUnableToParseValueTest.jsp")), "negativePDUnableToParseValueTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDBodyValueTest.jsp")), "positivePDBodyValueTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDBodyValueTestJava20Plus.jsp")), "positivePDBodyValueTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDDateStyleTest.jsp")), "positivePDDateStyleTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDDateStyleTestJava20Plus.jsp")), "positivePDDateStyleTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDFallbackLocaleTest.jsp")), "positivePDFallbackLocaleTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDFallbackLocaleTestJava20Plus.jsp")), "positivePDFallbackLocaleTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDLocalizationContextTest.jsp")), "positivePDLocalizationContextTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDLocalizationContextTestJava20Plus.jsp")), "positivePDLocalizationContextTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDParseLocaleNullEmptyTest.jsp")), "positivePDParseLocaleNullEmptyTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDParseLocaleTest.jsp")), "positivePDParseLocaleTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDParseLocaleTestJava20Plus.jsp")), "positivePDParseLocaleTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDPatternTest.jsp")), "positivePDPatternTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDScopeTest.jsp")), "positivePDScopeTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTimeStyleTest.jsp")), "positivePDTimeStyleTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTimeStyleTestJava20Plus.jsp")), "positivePDTimeStyleTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTimeZoneNullEmptyTest.jsp")), "positivePDTimeZoneNullEmptyTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTimeZoneNullEmptyTestJava20Plus.jsp")), "positivePDTimeZoneNullEmptyTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTimeZonePrecedenceTest.jsp")), "positivePDTimeZonePrecedenceTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTimeZonePrecedenceTestJava20Plus.jsp")), "positivePDTimeZonePrecedenceTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTimeZoneTest.jsp")), "positivePDTimeZoneTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTimeZoneTestJava20Plus.jsp")), "positivePDTimeZoneTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTypeTest.jsp")), "positivePDTypeTest.jsp");
+    archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDTypeTestJava20Plus.jsp")), "positivePDTypeTestJava20Plus.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDValueNullEmptyTest.jsp")), "positivePDValueNullEmptyTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDValueTest.jsp")), "positivePDValueTest.jsp");
     archive.add(new UrlAsset(JSTLClientIT.class.getClassLoader().getResource(packagePath+"/positivePDVarTest.jsp")), "positivePDVarTest.jsp");
@@ -104,9 +114,19 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDTypeTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTypeTest.gf");
+    InputStream gfStream;
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positivePDTypeTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTypeTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDTypeTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTypeTest.gf");
+    }
     setGoldenFileStream(gfStream);
-    TEST_PROPS.setProperty(STANDARD, "positivePDTypeTest");
+    // TEST_PROPS.setProperty(STANDARD, "positivePDTypeTest");
+    TEST_PROPS.setProperty(TEST_NAME, "positivePDTypeTest");
     invoke();
   }
 
@@ -125,10 +145,18 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDDateStyleTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDDateStyleTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(TEST_NAME, "positivePDDateStyleTest");
-    TEST_PROPS.setProperty(REQUEST, "positivePDDateStyleTest.jsp");
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positivePDDateStyleTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDDateStyleTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDDateStyleTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDDateStyleTest.gf");
+    }
+    setGoldenFileStream(gfStream);
     TEST_PROPS.setProperty(STATUS_CODE, OK);
     invoke();
   }
@@ -147,10 +175,20 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDTimeStyleTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeStyleTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(TEST_NAME, "positivePDTimeStyleTest");
-    TEST_PROPS.setProperty(REQUEST, "positivePDTimeStyleTest.jsp");
+    
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positivePDTimeStyleTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeStyleTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDTimeStyleTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeStyleTest.gf");
+    }
+    setGoldenFileStream(gfStream);
+
     TEST_PROPS.setProperty(STATUS_CODE, OK);
     invoke();
   }
@@ -167,10 +205,18 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDParseLocaleTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDParseLocaleTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(TEST_NAME, "positivePDParseLocaleTest");
-    TEST_PROPS.setProperty(REQUEST, "positivePDParseLocaleTest.jsp");
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positivePDParseLocaleTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDParseLocaleTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDParseLocaleTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDParseLocaleTest.gf");
+    }
+    setGoldenFileStream(gfStream);
     TEST_PROPS.setProperty(STATUS_CODE, OK);
     invoke();
   }
@@ -258,9 +304,19 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDBodyValueTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDBodyValueTest.gf");
+    InputStream gfStream;
+    // TEST_PROPS.setProperty(STANDARD, "positivePDBodyValueTest");
+    TEST_PROPS.setProperty(TEST_NAME, "positivePDBodyValueTest");
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positivePDBodyValueTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDBodyValueTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDBodyValueTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDBodyValueTest.gf");
+    }
     setGoldenFileStream(gfStream);
-    TEST_PROPS.setProperty(STANDARD, "positivePDBodyValueTest");
     invoke();
   }
 
@@ -295,10 +351,18 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDLocalizationContextTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDLocalizationContextTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(TEST_NAME, "positivePDLocalizationContextTest");
-    TEST_PROPS.setProperty(REQUEST, "positivePDLocalizationContextTest.jsp");
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positivePDLocalizationContextTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDLocalizationContextTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDLocalizationContextTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDLocalizationContextTest.gf");
+    }
+    setGoldenFileStream(gfStream);
     // TEST_PROPS.setProperty(GOLDENFILE, "positivePDLocalizationContextTest.gf");
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en-US");
     invoke();
@@ -315,10 +379,19 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDFallbackLocaleTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDFallbackLocaleTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(TEST_NAME, "positivePDFallbackLocaleTest");
-    TEST_PROPS.setProperty(REQUEST, "positivePDFallbackLocaleTest.jsp");
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positivePDFallbackLocaleTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDFallbackLocaleTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDFallbackLocaleTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDFallbackLocaleTest.gf");
+    }
+
+    setGoldenFileStream(gfStream);
     // TEST_PROPS.setProperty(GOLDENFILE, "positivePDFallbackLocaleTest.gf");
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: xx-XX");
     invoke();
@@ -355,9 +428,21 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDTimeZoneTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeZoneTest.gf");
+    InputStream gfStream;
+    // TEST_PROPS.setProperty(STANDARD, "positivePDTimeZoneTest");
+    TEST_PROPS.setProperty(TEST_NAME, "positivePDTimeZoneTest");
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positivePDTimeZoneTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeZoneTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDTimeZoneTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeZoneTest.gf");
+
+    }
     setGoldenFileStream(gfStream);
-    TEST_PROPS.setProperty(STANDARD, "positivePDTimeZoneTest");
+
     invoke();
   }
 
@@ -373,9 +458,20 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDTimeZoneNullEmptyTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeZoneNullEmptyTest.gf");
+    InputStream gfStream;
+    // TEST_PROPS.setProperty(STANDARD, "positivePDTimeZoneNullEmptyTest");
+    TEST_PROPS.setProperty(TEST_NAME, "positivePDTimeZoneNullEmptyTest");
+    if (isJavaVersion20OrGreater()) {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDTimeZoneNullEmptyTestJava20Plus.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeZoneNullEmptyTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDTimeZoneNullEmptyTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeZoneNullEmptyTest.gf");
+    }
     setGoldenFileStream(gfStream);
-    TEST_PROPS.setProperty(STANDARD, "positivePDTimeZoneNullEmptyTest");
+
     invoke();
   }
 
@@ -395,9 +491,19 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positivePDTimeZonePrecedenceTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeZonePrecedenceTest.gf");
+    InputStream gfStream;
+    // TEST_PROPS.setProperty(STANDARD, "positivePDTimeZonePrecedenceTest");
+    TEST_PROPS.setProperty(TEST_NAME, "positivePDTimeZonePrecedenceTest");
+    if (isJavaVersion20OrGreater()) {
+      TEST_PROPS.setProperty(REQUEST,
+          "positivePDTimeZonePrecedenceTestJava20Plus.jsp");
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeZonePrecedenceTestJava20Plus.gf");
+    } else {
+        TEST_PROPS.setProperty(REQUEST,
+            "positivePDTimeZonePrecedenceTest.jsp");
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positivePDTimeZonePrecedenceTest.gf");
+    }
     setGoldenFileStream(gfStream);
-    TEST_PROPS.setProperty(STANDARD, "positivePDTimeZonePrecedenceTest");
     invoke();
   }
 
@@ -416,4 +522,5 @@ public class JSTLClientIT extends AbstractUrlClient {
     TEST_PROPS.setProperty(STATUS_CODE, INTERNAL_SERVER_ERROR);
     invoke();
   }
+
 }

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/JSTLClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/JSTLClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -74,10 +74,15 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positiveSetTimezoneValueTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveSetTimezoneValueTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(STANDARD, "positiveSetTimezoneValueTest");
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en");
+    if (isJavaVersion20OrGreater()) {
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveSetTimezoneValueTestJava20Plus.gf");
+    } else {
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveSetTimezoneValueTest.gf");
+    }
+    setGoldenFileStream(gfStream);
     invoke();
   }
 
@@ -126,10 +131,15 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positiveSetTimezoneValueNullEmptyTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveSetTimezoneValueNullEmptyTest.gf");
-    setGoldenFileStream(gfStream);
+    InputStream gfStream;
     TEST_PROPS.setProperty(STANDARD, "positiveSetTimezoneValueNullEmptyTest");
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en");
+    if (isJavaVersion20OrGreater()) {
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveSetTimezoneValueNullEmptyTestJava20Plus.gf");
+    } else {
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveSetTimezoneValueNullEmptyTest.gf");
+    }
+    setGoldenFileStream(gfStream);
     invoke();
   }
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/timezone/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/timezone/JSTLClientIT.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/timezone/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/timezone/JSTLClientIT.java
@@ -66,10 +66,16 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positiveTimezoneValueTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveTimezoneValueTest.gf");
-    setGoldenFileStream(gfStream);
     TEST_PROPS.setProperty(STANDARD, "positiveTimezoneValueTest");
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en");
+    InputStream gfStream;
+    if (isJavaVersion20OrGreater()) {
+       gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveTimezoneValueTestJava20Plus.gf");
+    } else {
+      gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveTimezoneValueTest.gf");
+
+    }
+    setGoldenFileStream(gfStream);
     invoke();
   }
 
@@ -83,10 +89,16 @@ public class JSTLClientIT extends AbstractUrlClient {
    */
   @Test
   public void positiveTimezoneValueNullEmptyTest() throws Exception {
-    InputStream gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveTimezoneValueNullEmptyTest.gf");
-    setGoldenFileStream(gfStream);
     TEST_PROPS.setProperty(STANDARD, "positiveTimezoneValueNullEmptyTest");
     TEST_PROPS.setProperty(REQUEST_HEADERS, "Accept-Language: en");
+    InputStream gfStream;
+    if (isJavaVersion20OrGreater()) {
+       gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveTimezoneValueNullEmptyTestJava20Plus.gf");
+    } else {
+        gfStream = JSTLClientIT.class.getClassLoader().getResourceAsStream(packagePath+"/positiveTimezoneValueNullEmptyTest.gf");
+    }
+    setGoldenFileStream(gfStream);
     invoke();
   }
+
 }

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.gf
@@ -1,0 +1,36 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveFormatLocalizationContextI18NTest</title></head>
+<body>
+
+    
+    
+    
+    
+    
+    <!-- EL: If the jakarta.servlet.jstl.fmt.localizationContext scoped attribute is available,
+             this will be used in preference to the jakarta.servlet.jstl.fmt.locale
+             attribute. -->
+    
+    Nov 21, 2000, 3:45:02 AM
+    1234
+    1,234
+
+    <!-- EL: If the jakarta.servlet.jstl.fmt.localizationContext scoped attribute is available,
+             this will be used in preference to the jakarta.servlet.jstl.fmt.locale
+             attribute. -->
+    
+    Nov 21, 2000, 3:45:02 AM
+    1234
+    1,234
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
@@ -1,0 +1,50 @@
+<%--
+
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+--%>
+
+<%@ page pageEncoding="UTF-8"%>
+<%@ taglib prefix="fmt" uri="http://java.sun.com/jstl/fmt" %>
+<%@ taglib prefix="fmt_rt" uri="http://java.sun.com/jstl/fmt_rt" %>
+<%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>
+<%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
+<%@ page import="java.util.Date" %>
+<tck:test testName="positiveFormatLocalizationContextI18NTest">
+    <%  
+        Date date = new Date(883192294202L);
+        pageContext.setAttribute("dte", date);
+    %>
+    <fmt:setTimeZone value="EST"/>
+    <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.Resources1"/>
+    <fmt:setLocale value="de_DE"/>
+    <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
+    <!-- EL: If the jakarta.servlet.jstl.fmt.localizationContext scoped attribute is available,
+             this will be used in preference to the jakarta.servlet.jstl.fmt.locale
+             attribute. -->
+    <fmt:parseDate value="${dt}" type="both" var="p1"/>
+    <fmt:formatDate value="${p1}" type="both"/>
+    <fmt:parseNumber value="1,234"/>
+    <fmt:formatNumber value="1234"/>
+
+    <!-- EL: If the jakarta.servlet.jstl.fmt.localizationContext scoped attribute is available,
+             this will be used in preference to the jakarta.servlet.jstl.fmt.locale
+             attribute. -->
+    <fmt_rt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="p2"/>
+    <fmt_rt:formatDate value='<%= (Date) pageContext.getAttribute("p2") %>' type="both"/>
+    <fmt_rt:parseNumber value="1,234"/>
+    <fmt_rt:formatNumber value="1234"/>
+</tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
     Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 --%>
 
+<%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jstl/fmt" %>
 <%@ taglib prefix="fmt_rt" uri="http://java.sun.com/jstl/fmt_rt" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTestJava20Plus.gf
@@ -1,0 +1,41 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveTimezoneValueTest</title></head>
+<body>
+
+   
+    
+    <!-- EL: Behavioral test of value attribute -->
+    <!-- Timezone object -->
+    
+    Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    <!-- Timezone as a String -->
+    
+    Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+   
+    
+    Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+   
+    <!-- RT: Behavioral test of value attribute -->
+    <!-- Timezone object -->
+    
+    Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    <!-- Timezone as a String -->
+    
+    Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    
+    Saturday, December 27, 1997, 2:11:34 AM GMT-01:00   
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
     Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 --%>
 
+<%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="http://java.sun.com/jstl/fmt" %>
 <%@ taglib prefix="fmt_rt" uri="http://java.sun.com/jstl/fmt_rt" %>
 <%@ taglib prefix="c" uri="http://java.sun.com/jstl/core" %>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTestJava20Plus.gf
@@ -1,0 +1,43 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveTimezoneValueTest</title></head>
+<body>
+
+    
+    
+    <!-- EL: Behavioral test of value attribute -->
+    <!-- Timezone object -->
+    
+        Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    <!-- Timezone as a String -->
+    
+        Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    
+        Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+
+    <!-- RT: Behavioral test of value attribute -->
+    <!-- Timezone object -->
+    
+        Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    <!-- Timezone as a String -->
+    
+        Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    
+        Saturday, December 27, 1997, 2:11:34 AM GMT-01:00
+    
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
     Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 --%>
 
+<%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTestJava20Plus.gf
@@ -1,0 +1,73 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveFDDateStyleTest</title></head>
+<body>
+
+     <!-- dateStyle specifies what date style the formated value                  will be returned in.  This will only be applied
+             when type is not specified, or is set to date or both.                   if dateStyle is not specified, the default of 'default' 
+             will be applied if applicable. -->
+     <br>'type' not specified -- dateStyle should be applied<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     12/26/97<br>
+     12/26/97<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     December 26, 1997<br>
+     December 26, 1997<br>
+     Friday, December 26, 1997<br>
+     Friday, December 26, 1997<br>
+
+     <br>'type' set to 'date' -- dateStyle should be applied<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     12/26/97<br>
+     12/26/97<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     December 26, 1997<br>
+     December 26, 1997<br>
+     Friday, December 26, 1997<br>
+     Friday, December 26, 1997<br>
+
+     <br>'type' set to 'time' -- dateStyle should not be applied<br>          10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+
+     <br>'type' set to 'both' -- dateStyle should be applied<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     12/26/97, 10:11:34 PM<br>
+     12/26/97, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     December 26, 1997, 10:11:34 PM<br>
+     December 26, 1997, 10:11:34 PM<br>
+     Friday, December 26, 1997, 10:11:34 PM<br>
+     Friday, December 26, 1997, 10:11:34 PM<br>
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTestJava20Plus.gf
@@ -1,0 +1,19 @@
+
+
+
+
+
+
+<html>
+<head><title>positiveFDFallbackLocaleTest</title></head>
+<body>
+
+    <!-- The fallbackLocale configuration variable will be
+             used if no locale match can be determined. -->
+    Dec 26, 1997
+    10:11:34 PM
+    Dec 26, 1997, 10:11:34 PM
+
+</body>
+</html>
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTestJava20Plus.gf
@@ -1,0 +1,21 @@
+
+
+
+
+
+
+<html>
+<head><title>positiveFDLocalizationContextTest</title></head>
+<body>
+
+    <!-- Validate that the action is able to dermine the
+             formatting locale based on the localizationContext configuration
+             variable. -->
+    Dec 26, 1997
+    10:11:34 PM
+    Dec 26, 1997, 10:11:34 PM
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
     Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 --%>
 
+<%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTestJava20Plus.gf
@@ -1,0 +1,73 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveFDTimeStyleTest</title></head>
+<body>
+
+     <!-- timeStyle specifies what time style the formated value                  will be returned in.  This will only be applied
+             when type is set to time or both. If typeStyle is not
+             specified, the default of 'default' will be applied
+             to the formatted value, if applicable. -->
+     <br>'type' not specified -- timeStyle should not be applied<br>          Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+
+     <br>'type' set to 'date' -- timeStyle should not be applied<br>          Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+     Dec 26, 1997<br>
+
+     <br>'type' set to 'time' -- timeStyle should be applied<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11 PM<br>
+     10:11 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM<br>
+     10:11:34 PM EST<br>
+     10:11:34 PM EST<br>
+     10:11:34 PM Eastern Standard Time<br>
+     10:11:34 PM Eastern Standard Time<br>
+
+     <br>'type' set to 'both' -- timeStyle should be applied<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11 PM<br>
+     Dec 26, 1997, 10:11 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM<br>
+     Dec 26, 1997, 10:11:34 PM EST<br>
+     Dec 26, 1997, 10:11:34 PM EST<br>
+     Dec 26, 1997, 10:11:34 PM Eastern Standard Time<br>
+     Dec 26, 1997, 10:11:34 PM Eastern Standard Time<br>
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTestJava20Plus.gf
@@ -10,8 +10,8 @@
 
     <!-- If timeZone is null or empty, it will be treated as
              if it was not present. -->
-    Dec 26, 1997, 10:11:34 PM<br>
-    Dec 26, 1997, 10:11:34 PM<br>
+    Dec 26, 1997, 10:11:34 PM<br>
+    Dec 26, 1997, 10:11:34 PM<br>
 
 </body>
 </html>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2020 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTestJava20Plus.gf
@@ -1,0 +1,40 @@
+
+
+
+
+
+
+<html>
+<head><title>positiveFDTimeZonePrecedenceTest</title></head>
+<body>
+
+    <!--  The time zone to be used when formatting operates
+              with the following order of presendence:
+              - If timeZone specified, use that value.
+              - If wrapped by a timeZone action, use that 
+                value.
+              - Use the value of the scoped attribute
+                jakarta.servlet.jsp.jstl.fmt.timeZone. -->
+    <br>TimeZone attribute specified with a value of PST:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 7:11:34 PM:<br>
+      
+        Dec 26, 1997, 7:11:34 PM<br>
+      
+
+      Not wrapped.  Page has a time zone of EST.  Time should be 7:11:34 PM<br>
+      Dec 26, 1997, 7:11:34 PM<br>
+
+    <br>No TimeZone attribute specified:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 8:11:34 PM:<br>
+      
+        Dec 26, 1997, 8:11:34 PM<br>
+      
+
+      Not wrapped.  Page has a time zone of EST.  Time should be 10:11:34 PM<br>
+      Dec 26, 1997, 10:11:34 PM<br>
+    <br>
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTestJava20Plus.gf
@@ -1,0 +1,21 @@
+
+
+
+
+
+
+<html>
+<head><title>positiveFDTimeZoneTest</title></head>
+<body>
+
+    <!-- The time zone to be applied to the formatted value can                   be explicitly provided to the action.  This will effectively
+             overried the timezone of the page -->
+    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be minus 3 hours.<br>
+    No timeZone attribute: Dec 26, 1997, 10:11:34 PM<br>
+    Dec 26, 1997, 7:11:34 PM<br>
+    Dec 26, 1997, 7:11:34 PM<br>
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
     Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 --%>
 
+<%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTestJava20Plus.gf
@@ -1,0 +1,28 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveFDTypeTest</title></head>
+<body>
+
+    <!-- the type attribute specifies if either the time or date
+             or both components of the provided date value will
+             be formatted. If type is not specified, the default is
+             date. -->
+    date: Dec 26, 1997<br>
+    date: Dec 26, 1997<br>
+    date: Dec 26, 1997<br>
+    time: 10:11:34 PM<br>
+    time: 10:11:34 PM<br>
+    both: Dec 26, 1997, 10:11:34 PM<br>
+    both: Dec 26, 1997, 10:11:34 PM<br>
+    
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.gf
@@ -1,0 +1,23 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveFormatLocalizationContextBrowserLocaleTest</title></head>
+<body>
+
+    <!-- If the action is not wrapped in a fmt:bundle action,
+             or the basename or locale scoped attributes don't exist,
+             the browser's preferred locales are used. -->
+    
+    Nov 21, 2000, 3:45:02 AM
+    1234
+    1,234
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -20,20 +20,22 @@
 <%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
-<tck:test testName="positiveTimezoneValueNullEmptyTest">
-    <%
+<tck:test testName="positiveFormatLocalizationContextBrowserLocaleTest">
+    <%  
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
+    <fmt:setTimeZone value="EST"/>
+    <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
 
-    <!-- If value is null or empty, the default TZ of GMT
-             is used -->
-    <fmt:setTimeZone value='<%= null %>'/>
-    <fmt:formatDate type="both" dateStyle="full" timeStyle="full" value="${dte}"/>
-
-    <fmt:setTimeZone value=""/>
-    <fmt:formatDate type="both" dateStyle="full" timeStyle="full" value="${dte}"/>
-   
+    <!-- If the action is not wrapped in a fmt:bundle action,
+             or the basename or locale scoped attributes don't exist,
+             the browser's preferred locales are used. -->
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="p2"/>
+    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("p2") %>' type="both"/>
+    <fmt:parseNumber value="1,234"/>
+    <fmt:formatNumber value="1234"/>
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.gf
@@ -1,0 +1,29 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveFormatLocalizationContextBundleTest</title></head>
+<body>
+
+    <!-- The localization context for formatting actions can
+             be provided by wrapping these actions in a fmt:bundle
+             action.  The Locale of the selected resource bundle
+             will be used as the locale for the formatting action.
+             Additionally, if the action is wrapped by the bundle action
+             the jakarta.servlet.jsp.jstl.fmt.localizationContext config variable
+             will not be considered. -->
+    
+        
+        Nov 21, 2000, 3:45:02 AM
+        1234
+        1,234
+    
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
@@ -1,0 +1,48 @@
+<%--
+
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+--%>
+
+<%@ page pageEncoding="UTF-8"%>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
+<%@ page import="java.util.Date" %>
+<tck:test testName="positiveFormatLocalizationContextBundleTest">
+    <%  
+        Date date = new Date(883192294202L);
+        pageContext.setAttribute("dte", date);
+    %>
+    <fmt:setTimeZone value="EST"/>
+    <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.AlgoResources6"/>
+    <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
+
+    <!-- The localization context for formatting actions can
+             be provided by wrapping these actions in a fmt:bundle
+             action.  The Locale of the selected resource bundle
+             will be used as the locale for the formatting action.
+             Additionally, if the action is wrapped by the bundle action
+             the jakarta.servlet.jsp.jstl.fmt.localizationContext config variable
+             will not be considered. -->
+    <fmt:bundle basename="com.sun.ts.tests.jstl.common.resources.Resources1">
+        <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="p2"/>
+        <fmt:formatDate value='<%= (Date) pageContext.getAttribute("p2") %>' type="both"/>
+        <fmt:parseNumber value="1,234"/>
+        <fmt:formatNumber value="1234"/>
+    </fmt:bundle>
+</tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.gf
@@ -1,0 +1,23 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveFormatLocalizationContextI18NTest</title></head>
+<body>
+
+    <!-- If the jakarta.servlet.jstl.fmt.localizationContext scoped attribute is available,
+             this will be used in preference to the jakarta.servlet.jstl.fmt.locale
+             attribute. -->
+    
+    Nov 21, 2000, 3:45:02 AM
+    1234
+    1,234
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -20,20 +20,24 @@
 <%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
-<tck:test testName="positiveTimezoneValueNullEmptyTest">
-    <%
+<tck:test testName="positiveFormatLocalizationContextI18NTest">
+    <%  
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
+    <fmt:setTimeZone value="EST"/>
+    <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.Resources1"/>
+    <fmt:setLocale value="de_DE"/>
+    <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
 
-    <!-- If value is null or empty, the default TZ of GMT
-             is used -->
-    <fmt:setTimeZone value='<%= null %>'/>
-    <fmt:formatDate type="both" dateStyle="full" timeStyle="full" value="${dte}"/>
-
-    <fmt:setTimeZone value=""/>
-    <fmt:formatDate type="both" dateStyle="full" timeStyle="full" value="${dte}"/>
-   
+    <!-- If the jakarta.servlet.jstl.fmt.localizationContext scoped attribute is available,
+             this will be used in preference to the jakarta.servlet.jstl.fmt.locale
+             attribute. -->
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="p2"/>
+    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("p2") %>' type="both"/>
+    <fmt:parseNumber value="1,234"/>
+    <fmt:formatNumber value="1234"/>
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.gf
@@ -1,0 +1,23 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveFormatLocalizationContextLocaleTest</title></head>
+<body>
+
+    <!-- If the jakarta.servlet.jsp.jstl.fmt.locale attribute
+             is present, it will take precedence over the browser
+             supplied preferred locales. --> 
+    
+    Nov 21, 2000, 3:45:02 AM
+    1234
+    1,234
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -20,20 +20,23 @@
 <%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
-<tck:test testName="positiveTimezoneValueNullEmptyTest">
-    <%
+<tck:test testName="positiveFormatLocalizationContextLocaleTest">
+    <%  
         Date date = new Date(883192294202L);
         pageContext.setAttribute("dte", date);
     %>
+    <fmt:setTimeZone value="EST"/>
+    <fmt:setLocale value="en_US"/>
+    <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/>
 
-    <!-- If value is null or empty, the default TZ of GMT
-             is used -->
-    <fmt:setTimeZone value='<%= null %>'/>
-    <fmt:formatDate type="both" dateStyle="full" timeStyle="full" value="${dte}"/>
-
-    <fmt:setTimeZone value=""/>
-    <fmt:formatDate type="both" dateStyle="full" timeStyle="full" value="${dte}"/>
-   
+    <!-- If the jakarta.servlet.jsp.jstl.fmt.locale attribute
+             is present, it will take precedence over the browser
+             supplied preferred locales. --> 
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="p2"/>
+    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("p2") %>' type="both"/>
+    <fmt:parseNumber value="1,234"/>
+    <fmt:formatNumber value="1234"/>
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.gf
@@ -1,0 +1,19 @@
+
+
+
+
+
+<html>
+<head><title>positivePDBodyValueTest</title></head>
+<body>
+
+    <!-- The date to be parsed can be provided as body content to the
+              action. -->
+    
+    Nov 21, 2000, 3:45:02 AM
+
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -21,19 +21,15 @@
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
-<%@ page import="java.util.Date" %>
-<tck:test testName="positiveTimezoneValueNullEmptyTest">
-    <%
-        Date date = new Date(883192294202L);
-        pageContext.setAttribute("dte", date);
-    %>
+<tck:test testName="positivePDBodyValueTest">
+    <fmt:setLocale value="en_US"/>
+    <fmt:setTimeZone value="EST"/>
 
-    <!-- If value is null or empty, the default TZ of GMT
-             is used -->
-    <fmt:setTimeZone value='<%= null %>'/>
-    <fmt:formatDate type="both" dateStyle="full" timeStyle="full" value="${dte}"/>
+    <!-- The date to be parsed can be provided as body content to the
+              action. -->
+    <fmt:parseDate type="both" var="e2">
+        Nov 21, 2000, 3:45:02 AM
+    </fmt:parseDate>
+    <fmt:formatDate value="${e2}" type="both" timeZone="EST"/>
 
-    <fmt:setTimeZone value=""/>
-    <fmt:formatDate type="both" dateStyle="full" timeStyle="full" value="${dte}"/>
-   
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
@@ -1,0 +1,114 @@
+<%--
+
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+--%>
+
+<%@ page pageEncoding="UTF-8"%>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
+<tck:test testName="positivePDDateStyleTest">
+    <c:set var="def" value="default"/>
+    <c:set var="sho" value="short"/>
+    <c:set var="med" value="medium"/>
+    <c:set var="lon" value="long"/>
+    <c:set var="ful" value="full"/>
+    <fmt:setLocale value="en_US"/>
+    <fmt:setTimeZone value="EST"/>
+
+     <!-- dateStyle specifies the formatting style that determines how
+             the provided value will be parsed. dateStyle should be
+             applied when type is not specified or is set to date or
+             both.  -->
+     <br>'type' not specified -- dateStyle should be applied.<br>
+     <fmt:parseDate value="Nov 21, 2000"/><br>
+     <fmt:parseDate value="Nov 21, 2000"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       dateStyle='<%= (String) pageContext.getAttribute("def") %>'/><br>
+     <fmt:parseDate value="Nov 21, 2000" dateStyle="default"/><br>
+     <fmt:parseDate value="11/21/00"
+                       dateStyle='<%= (String) pageContext.getAttribute("sho") %>'/><br>
+     <fmt:parseDate value="11/21/00" dateStyle="short"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       dateStyle='<%= (String) pageContext.getAttribute("med") %>'/><br>
+     <fmt:parseDate value="Nov 21, 2000" dateStyle="medium"/><br>
+     <fmt:parseDate value="November 21, 2000"
+                       dateStyle='<%= (String) pageContext.getAttribute("lon") %>'/><br>
+     <fmt:parseDate value="November 21, 2000" dateStyle="long"/><br>
+     <fmt:parseDate value="Tuesday, November 21, 2000"
+                       dateStyle='<%= (String) pageContext.getAttribute("ful") %>'/><br>
+     <fmt:parseDate value="Tuesday, November 21, 2000" dateStyle="full"/><br>
+
+     <br>'type' set to 'date' -- dateStyle should be applied.<br>
+     <fmt:parseDate value="Nov 21, 2000" type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000" type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       dateStyle='<%= (String) pageContext.getAttribute("def") %>' type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000" dateStyle="default" type="date"/><br>
+     <fmt:parseDate value="11/21/00"
+                       dateStyle='<%= (String) pageContext.getAttribute("sho") %>' type="date"/><br>
+     <fmt:parseDate value="11/21/00" dateStyle="short" type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       dateStyle='<%= (String) pageContext.getAttribute("med") %>' type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000" dateStyle="medium" type="date"/><br>
+     <fmt:parseDate value="November 21, 2000"
+                       dateStyle='<%= (String) pageContext.getAttribute("lon") %>' type="date"/><br>
+     <fmt:parseDate value="November 21, 2000" dateStyle="long" type="date"/><br>
+     <fmt:parseDate value="Tuesday, November 21, 2000"
+                       dateStyle='<%= (String) pageContext.getAttribute("ful") %>' type="date"/><br>
+     <fmt:parseDate value="Tuesday, November 21, 2000" dateStyle="full" type="date"/><br>
+
+     <br>'type' set to 'time' -- dateStyle should not be applied.  If applied, a parse exception would occur.<br>
+     <fmt:parseDate value="3:45:03 AM" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("def") %>' type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM" dateStyle="default" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("sho") %>' type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM" dateStyle="short" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("med") %>' type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM" dateStyle="medium" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("lon") %>' type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM" dateStyle="long" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("ful") %>' type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM" dateStyle="full" type="time"/><br>
+
+     <br>'type' set to 'both' -- dateStyle should be applied<br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("def") %>' type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" dateStyle="default" type="both"/><br>
+     <fmt:parseDate value="11/21/00, 3:45:02 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("sho") %>' type="both"/><br>
+     <fmt:parseDate value="11/21/00, 3:45:02 AM" dateStyle="short" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("med") %>' type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" dateStyle="medium" type="both"/><br>
+     <fmt:parseDate value="November 21, 2000, 3:45:02 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("lon") %>' type="both"/><br>
+     <fmt:parseDate value="November 21, 2000, 3:45:02 AM" dateStyle="long" type="both"/><br>
+     <fmt:parseDate value="Tuesday, November 21, 2000, 3:45:02 AM"
+                       dateStyle='<%= (String) pageContext.getAttribute("ful") %>' type="both"/><br>
+     <fmt:parseDate value="Tuesday, November 21, 2000, 3:45:02 AM"
+                       dateStyle="full" type="both"/><br>
+</tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.gf
@@ -1,0 +1,23 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positivePDFallbackLocaleTest</title></head>
+<body>
+
+    <!-- The fallbackLocale configuration variable will be
+             used if no locale match can be determined. -->
+
+
+
+    Nov 21, 2000<br>
+    3:45:02 AM<br>
+    Nov 21, 2000, 3:45:02 AM<br>
+
+</body>
+</html>
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -20,18 +20,22 @@
 <%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
-<tck:test testName="positiveFDFallbackLocaleTest">
-    <%  
-        Date date = new Date(883192294202L);
-        pageContext.setAttribute("dte", date);
-    %>
+<tck:test testName="positivePDFallbackLocaleTest">
     <fmt:setTimeZone value="EST"/>
+    <c:set var="dte" value="Nov 21, 2000"/>
+    <c:set var="dtim" value="3:45:02 AM"/>
+    <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/> 
     <tck:config op="set" configVar="fallback" value="en-US"/>
+
     <!-- The fallbackLocale configuration variable will be
              used if no locale match can be determined. -->
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>'/>
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="time"/>
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="both"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' var="r1"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dtim") %>' type="time" var="r2"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="r3"/>
+    <fmt:formatDate value="${r1}" timeZone="EST"/><br>
+    <fmt:formatDate value="${r2}" timeZone="EST" type="time"/><br>
+    <fmt:formatDate value="${r3}" timeZone="EST" type="both"/><br>
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.gf
@@ -1,0 +1,27 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positivePDLocalizationContextTest</title></head>
+<body>
+
+    <!-- Validate that the action is able to dermine the
+             formatting locale based on the localizationContext configuration
+             variable. -->
+
+
+
+    Nov 21, 2000<br>
+    3:45:02 AM<br>
+    Nov 21, 2000, 3:45:02 AM<br>
+
+
+</body>
+</html>
+
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -20,20 +20,23 @@
 <%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
-<%@ page import="java.util.Date" %>
-<tck:test testName="positiveFDLocalizationContextTest">
-    <%  
-        Date date = new Date(883192294202L);
-        pageContext.setAttribute("dte", date);
-    %>
+<tck:test testName="positivePDLocalizationContextTest">
     <fmt:setTimeZone value="EST"/>
+    <c:set var="dte" value="Nov 21, 2000"/>
+    <c:set var="dtim" value="3:45:02 AM"/>
+    <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/> 
     <fmt:setBundle basename="com.sun.ts.tests.jstl.common.resources.Resources"/>
 
     <!-- Validate that the action is able to dermine the
              formatting locale based on the localizationContext configuration
              variable. -->
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>'/>
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="time"/>
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="both"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' var="r1"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dtim") %>' type="time" var="r2"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>' type="both" var="r3"/>
+    <fmt:formatDate value="${r1}" timeZone="EST"/><br>
+    <fmt:formatDate value="${r2}" timeZone="EST" type="time"/><br>
+    <fmt:formatDate value="${r3}" timeZone="EST" type="both"/><br>
+
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
@@ -1,0 +1,44 @@
+<%--
+
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+--%>
+
+<%@ page pageEncoding="UTF-8"%>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
+<%@ page import="java.util.Locale" %>
+<tck:test testName="positivePDParseLocaleTest">
+    <%
+        pageContext.setAttribute("loc", new Locale("en", "US"));
+    %>
+    <c:set var="dte" value="Nov 21, 2000, 3:45:02 AM"/>
+    <c:set var="us" value="en_US"/>
+    <fmt:setLocale value="de_DE"/>
+    <fmt:setTimeZone value="EST"/>
+
+    <!-- parseLocale specifies the locale specific formatting pattern
+             to apply when parsing the provided value.  The presence of this
+             attribute will override the page locale. Also validate that
+             parseLocale attribute can accept both Strings and Locale objects. -->
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
+                      parseLocale='<%= (String) pageContext.getAttribute("us") %>' type="both"/><br>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
+                      parseLocale='<%= (Locale) pageContext.getAttribute("loc") %>' type="both"/><br>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' parseLocale="en_US" type="both"/><br>
+</tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
@@ -1,0 +1,114 @@
+<%--
+
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+--%>
+
+<%@ page pageEncoding="UTF-8"%>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
+<tck:test testName="positivePDTimeStyleTest">
+    <c:set var="def" value="default"/>
+    <c:set var="sho" value="short"/>
+    <c:set var="med" value="medium"/>
+    <c:set var="lon" value="long"/>
+    <c:set var="ful" value="full"/>
+    <fmt:setLocale value="en_US"/>
+    <fmt:setTimeZone value="EST"/>
+
+     <!-- timeStyle specifies formatting style that determines how
+             the provided value will be parsed. timeStyle should be
+             applied when type is not specified or is set to date or
+             both.  -->
+     <br>'type' not specified -- timeStyle should not be applied. If it is, a parse exception would occur.<br>
+     <fmt:parseDate value="Nov 21, 2000"/><br>
+     <fmt:parseDate value="Nov 21, 2000"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("def") %>'/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="default"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("sho") %>'/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="short"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("med") %>'/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="medium"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("lon") %>'/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="long"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("ful") %>'/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="full"/><br>
+
+     <br>'type' set to 'date' -- timeStyle should not be applied. If it is, a parse exception would occur.<br>
+     <fmt:parseDate value="Nov 21, 2000" type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000" type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("def") %>' type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="default" type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("sho") %>' type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="short" type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("med") %>' type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="medium" type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("lon") %>' type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="long" type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000"
+                       timeStyle='<%= (String) pageContext.getAttribute("ful") %>' type="date"/><br>
+     <fmt:parseDate value="Nov 21, 2000" timeStyle="full" type="date"/><br>
+
+     <br>'type' set to 'time' -- timeStyle should be applied.<br>
+     <fmt:parseDate value="3:45:03 AM" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM"
+                       timeStyle='<%= (String) pageContext.getAttribute("def") %>' type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM" timeStyle="default" type="time"/><br>
+     <fmt:parseDate value="3:45 AM"
+                       timeStyle='<%= (String) pageContext.getAttribute("sho") %>' type="time"/><br>
+     <fmt:parseDate value="3:45 AM" timeStyle="short" type="time"/><br>
+     <fmt:parseDate value="3:45:02 AM"
+                       timeStyle='<%= (String) pageContext.getAttribute("med") %>' type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM" timeStyle="medium" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM EST"
+                       timeStyle='<%= (String) pageContext.getAttribute("lon") %>' type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM EST" timeStyle="long" type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM EST"
+                       timeStyle='<%= (String) pageContext.getAttribute("ful") %>' type="time"/><br>
+     <fmt:parseDate value="3:45:03 AM EST" timeStyle="full" type="time"/><br>
+
+     <br>'type' set to 'both' -- timeStyle should be applied.<br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM"
+                       timeStyle='<%= (String) pageContext.getAttribute("def") %>' type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" timeStyle="default" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45 AM"
+                       timeStyle='<%= (String) pageContext.getAttribute("sho") %>' type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45 AM" timeStyle="short" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM"
+                       timeStyle='<%= (String) pageContext.getAttribute("med") %>' type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM" timeStyle="medium" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST"
+                       timeStyle='<%= (String) pageContext.getAttribute("lon") %>' type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST" timeStyle="long" type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST"
+                       timeStyle='<%= (String) pageContext.getAttribute("ful") %>' type="both"/><br>
+     <fmt:parseDate value="Nov 21, 2000, 3:45:02 AM EST"
+                       timeStyle="full" type="both"/><br>
+</tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
@@ -20,7 +20,7 @@
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
-<tck:test testName="positivePDTimeZoneNullEmpytTest">
+<tck:test testName="positivePDTimeZoneNullEmptyTest">
     <c:set var="dt" value="Nov 21, 2000, 3:45 AM"/> 
     <fmt:setLocale value="en_US"/>
     <fmt:setTimeZone value="MST"/>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.gf
@@ -12,12 +12,11 @@
     <!-- If timeZone is null or empty, it will be treated as
              if it was not present (only type short times is specified
              as any other style has no impact on the result). -->
-    
-    
-    Nov 21, 2000, 5:45 AM<br>
-    Nov 21, 2000, 5:45 AM<br>
+
+
+    Nov 21, 2000, 5:45 AM<br>
+    Nov 21, 2000, 5:45 AM<br>
 
 </body>
 </html>
-
 

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -20,20 +20,20 @@
 <%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
-<%@ page import="java.util.Date" %>
-<tck:test testName="positiveFDTimeZoneNullEmptyTest">
-    <%  
-        Date date = new Date(883192294202L);
-        pageContext.setAttribute("dte", date);
-    %>
+<tck:test testName="positivePDTimeZoneNullEmptyTest">
+    <c:set var="dt" value="Nov 21, 2000, 3:45 AM"/> 
     <fmt:setLocale value="en_US"/>
-    <fmt:setTimeZone value="EST"/>
+    <fmt:setTimeZone value="MST"/>
 
     <!-- If timeZone is null or empty, it will be treated as
-             if it was not present. -->
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>'
-                       timeZone='<%= null %>' type="both"/><br>
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>'
-                       timeZone="" type="both"/><br>
+             if it was not present (only type short times is specified
+             as any other style has no impact on the result). -->
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>'
+                       timeZone='<%= null %>' type="both" timeStyle="short" var="rn1"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>'
+                       timeZone="" type="both" timeStyle="short" var="re1"/>
+    <fmt:formatDate value="${rn1}" timeZone="EST" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${re1}" timeZone="EST" type="both" timeStyle="short"/><br>
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.gf
@@ -1,0 +1,44 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positivePDTimeZonePrecedenceTest</title></head>
+<body>
+
+    <!-- The time zone to be used when formatting operates
+              with the following order of presendence:
+              - If timeZone specified, use that value.
+              - If wrapped by a timeZone action, use that 
+                value.
+              - Use the value of the scoped attribute
+                jakarta.servlet.jsp.jstl.fmt.timeZone. -->
+    <br>TimeZone attribute specified with a value of PST:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 3 hours:<br>
+      
+        
+      
+      Nov 21, 2000, 6:45 AM<br>
+
+      Not wrapped.  Page has a time zone of EST, timeZone attribute specified.  Time should be offset by 3 hours:<br>
+      <br>
+      Nov 21, 2000, 6:45 AM<br>
+
+    <br>No TimeZone attribute specified:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 2 hours:<br>
+      
+        <br>
+      
+      Nov 21, 2000, 5:45 AM<br>
+      
+      Not wrapped.  Page has a time zone of EST.  Time should not be offset:<br>
+      <br>
+      Nov 21, 2000, 3:45 AM<br>
+    <br>
+
+</body>
+</html>
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -20,13 +20,11 @@
 <%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
 <%@ page import="java.util.Date" %>
-<tck:test testName="positiveFDTimeZonePrecedenceTest">
-    <%  
-        Date date = new Date(883192294202L);
-        pageContext.setAttribute("dte", date);
-    %>
+<tck:test testName="positivePDTimeZonePrecedenceTest">
+    <c:set var="dte" value="Nov 21, 2000, 3:45 AM"/>
     <fmt:setTimeZone value="EST"/>
     <fmt:setLocale value="en_US"/>
 
@@ -38,21 +36,25 @@
               - Use the value of the scoped attribute
                 jakarta.servlet.jsp.jstl.fmt.timeZone. -->
     <br>TimeZone attribute specified with a value of PST:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 7:11:34 PM:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 3 hours:<br>
       <fmt:timeZone value="MST">
-        <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' timeZone="PST" type="both"/><br>
+        <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="PST" type="both" timeStyle="short" var="rd1"/>
       </fmt:timeZone>
+      <fmt:formatDate value="${rd1}" timeZone="EST" type="both" timeStyle="short"/><br>
 
-      Not wrapped.  Page has a time zone of EST.  Time should be 7:11:34 PM<br>
-      <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' timeZone="PST" type="both"/><br>
+      Not wrapped.  Page has a time zone of EST, timeZone attribute specified.  Time should be offset by 3 hours:<br>
+      <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' timeZone="PST" type="both" timeStyle="short" var="rd2"/><br>
+      <fmt:formatDate value="${rd2}" timeZone="EST" type="both" timeStyle="short"/><br>
 
     <br>No TimeZone attribute specified:<br>
-      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be 8:11:34 PM:<br>
+      Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 2 hours:<br>
       <fmt:timeZone value="MST">
-        <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="both"/><br>
+        <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rd3"/><br>
       </fmt:timeZone>
+      <fmt:formatDate value="${rd3}" timeZone="EST" type="both" timeStyle="short"/><br>
 
-      Not wrapped.  Page has a time zone of EST.  Time should be 10:11:34 PM<br>
-      <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="both"/><br>
+      Not wrapped.  Page has a time zone of EST.  Time should not be offset:<br>
+      <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rd4"/><br>
+      <fmt:formatDate value="${rd4}" timeZone="EST" type="both" timeStyle="short"/><br>
     <br>
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.gf
@@ -1,0 +1,25 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positivePDTimeZoneTest</title></head>
+<body>
+
+    <!-- The time zone to be applied to the formatted value can
+             be explicitly provided to the action.  This will effectively
+             overried the timezone of the page -->
+    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be offset 3 hours.<br>
+
+
+
+    No timeZone attribute: Nov 21, 2000, 3:45 AM<br>
+    Nov 21, 2000, 6:45 AM<br>
+    Nov 21, 2000, 6:45 AM<br>
+
+</body>
+</html>
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
@@ -1,43 +1,41 @@
 <%--
-
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
-
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
     http://www.eclipse.org/legal/epl-2.0.
-
     This Source Code may also be made available under the following Secondary
     Licenses when the conditions for such availability set forth in the
     Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
     version 2 with the GNU Classpath Exception, which is available at
     https://www.gnu.org/software/classpath/license.html.
-
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
-
 --%>
 
 <%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
-<%@ page import="java.util.Date,java.util.TimeZone" %>
-<tck:test testName="positiveFDTimeZoneTest">
-    <%  
-        Date date = new Date(883192294202L);
-        pageContext.setAttribute("dte", date);
+<%@ page import="java.util.TimeZone" %>
+<tck:test testName="positivePDTimeZoneTest">
+    <%
         pageContext.setAttribute("tz", TimeZone.getTimeZone("PST"));
     %>
+    <c:set var="dte" value="Nov 21, 2000, 3:45 AM"/>
     <fmt:setLocale value="en_US"/>
     <fmt:setTimeZone value="EST"/>
 
     <!-- The time zone to be applied to the formatted value can
              be explicitly provided to the action.  This will effectively
              overried the timezone of the page -->
-    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be minus 3 hours.<br>
-    No timeZone attribute: <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>' type="both"/><br>
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>'
-                       timeZone='<%= (TimeZone) pageContext.getAttribute("tz") %>' type="both"/><br>
-    <fmt:formatDate value='<%= (Date) pageContext.getAttribute("dte") %>'
-                       timeZone="PST" type="both"/><br>
+    <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be offset 3 hours.<br>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rdef"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
+                       timeZone='<%= (TimeZone) pageContext.getAttribute("tz") %>' type="both" timeStyle="short" var="rpst1"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
+                       timeZone="PST" type="both" timeStyle="short" var="rpst2"/>
+    No timeZone attribute: <fmt:formatDate value="${rdef}" timeZone="EST" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${rpst1}" timeZone="EST" type="both" timeStyle="short"/><br>
+    <fmt:formatDate value="${rpst2}" timeZone="EST" type="both" timeStyle="short"/><br>
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
@@ -1,5 +1,5 @@
 <%--
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
@@ -1,14 +1,16 @@
 <%--
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
+
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
     http://www.eclipse.org/legal/epl-2.0.
+
     This Source Code may also be made available under the following Secondary
     Licenses when the conditions for such availability set forth in the
     Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
     version 2 with the GNU Classpath Exception, which is available at
     https://www.gnu.org/software/classpath/license.html.
+    
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --%>
 

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.gf
@@ -1,0 +1,34 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positivePDTypeTest</title></head>
+<body>
+
+    <!-- the type attribute specifies the the type of date
+             information is contained in the value to be parsed. -->
+
+
+
+
+
+
+
+    date: Nov 21, 2000<br>
+    date: Nov 21, 2000<br>
+    date: Nov 21, 2000<br>
+    time: 3:45:02 AM<br>
+    time: 3:45:02 AM<br>
+    both: Nov 21, 2000, 3:45:02 AM<br>
+    both: Nov 21, 2000, 3:45:02 AM<br>
+
+
+</body>
+</html>
+
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
@@ -1,0 +1,53 @@
+<%--
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+--%>
+
+<%@ page pageEncoding="UTF-8"%>
+<%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
+
+<%@ taglib prefix="c" uri="jakarta.tags.core" %>
+<%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>
+<tck:test testName="positivePDTypeTest">
+    <c:set var="dte" value="Nov 21, 2000"/>
+    <c:set var="dtim" value="3:45:02 AM"/>
+    <c:set var="dt" value="Nov 21, 2000, 3:45:02 AM"/> 
+    <c:set var="tim" value="time"/>
+    <c:set var="dat" value="date"/>
+    <c:set var="bot" value="both"/>
+    <fmt:setLocale value="en_US"/>
+    <fmt:setTimeZone value="EST"/>
+
+    <!-- the type attribute specifies the the type of date
+             information is contained in the value to be parsed. -->
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' var="r1"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
+                             type='<%= (String) pageContext.getAttribute("dat") %>' var="r2"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>'
+                             type="date" var="r3"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dtim") %>'
+                             type='<%= (String) pageContext.getAttribute("tim") %>' var="r4"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dtim") %>'
+                             type="time" var="r5"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>'
+                             type='<%= (String) pageContext.getAttribute("bot") %>' var="r6"/>
+    <fmt:parseDate value='<%= (String) pageContext.getAttribute("dt") %>'
+                             type="both" var="r7"/>
+    date: <fmt:formatDate value="${r1}" type="date"/><br>
+    date: <fmt:formatDate value="${r2}" type="date"/><br>
+    date: <fmt:formatDate value="${r3}" type="date"/><br>
+    time: <fmt:formatDate value="${r4}" type="time"/><br>
+    time: <fmt:formatDate value="${r5}" type="time"/><br>
+    both: <fmt:formatDate value="${r6}" type="both"/><br>
+    both: <fmt:formatDate value="${r7}" type="both"/><br>
+
+</tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
@@ -1,14 +1,16 @@
 <%--
-    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
+
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
     http://www.eclipse.org/legal/epl-2.0.
+    
     This Source Code may also be made available under the following Secondary
     Licenses when the conditions for such availability set forth in the
     Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
     version 2 with the GNU Classpath Exception, which is available at
     https://www.gnu.org/software/classpath/license.html.
+
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 --%>
 

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
@@ -1,5 +1,5 @@
 <%--
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueNullEmptyTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueNullEmptyTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueNullEmptyTestJava20Plus.gf
@@ -1,0 +1,23 @@
+
+
+
+
+
+
+<html>
+<head><title>positiveTimezoneValueNullEmptyTest</title></head>
+<body>
+
+    <!-- If value is null or empty, the default TZ of GMT
+             is used -->
+    
+    Saturday, December 27, 1997, 3:11:34 AM Greenwich Mean Time
+
+    
+    Saturday, December 27, 1997, 3:11:34 AM Greenwich Mean Time
+   
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
     Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 --%>
 
+<%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTestJava20Plus.gf
@@ -1,0 +1,27 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveTimezoneValueTest</title></head>
+<body>
+
+    <!-- Behavioral test of value attribute -->
+    <!-- Timezone object -->
+    
+    Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    <!-- Timezone as a String -->
+    
+    Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    
+    Saturday, December 27, 1997, 2:11:34 AM GMT-01:00   
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
     Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 --%>
 
+<%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="tck" uri="http://java.sun.com/jstltck/jstltck-util" %>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTestJava20Plus.gf
@@ -1,0 +1,23 @@
+
+
+
+
+
+
+<html>
+<head><title>positiveTimezoneValueNullEmptyTest</title></head>
+<body>
+
+    <!-- If value is null or empty, the default TZ of GMT
+             is used -->
+    
+        Saturday, December 27, 1997, 3:11:34 AM Greenwich Mean Time
+    
+    
+        Saturday, December 27, 1997, 3:11:34 AM Greenwich Mean Time
+    
+
+</body>
+</html>
+
+

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
     Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -16,6 +17,7 @@
 
 --%>
 
+<%@ page pageEncoding="UTF-8"%>
 <%@ taglib prefix="fmt" uri="jakarta.tags.fmt" %>
 
 <%@ taglib prefix="c" uri="jakarta.tags.core" %>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
@@ -1,7 +1,6 @@
 <%--
 
-    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
-    Copyright (c) 2024 Contributors to the Eclipse Foundation
+    Copyright (c) 2003 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTestJava20Plus.gf
@@ -1,0 +1,28 @@
+
+
+
+
+
+
+
+<html>
+<head><title>positiveTimezoneValueTest</title></head>
+<body>
+
+    <!-- Behavioral test of value attribute -->
+    <!-- Timezone object -->
+    
+        Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    <!-- Timezone as a String -->
+    
+        Friday, December 26, 1997, 7:11:34 PM Pacific Standard Time
+    
+    
+        Saturday, December 27, 1997, 2:11:34 AM GMT-01:00
+    
+
+</body>
+</html>
+
+


### PR DESCRIPTION
**Related Issue(s)**
- https://github.com/jakartaee/tags/issues/255

**Describe the change**
Copied the changes from https://github.com/jakartaee/platform-tck/pull/1320 to fix the refactored JSTL tests to pass in JDK21 

**To run the jstl tck and test the fix with Glassfish :**
`cd $WORKSPACE/jstl; mvn clean install ` : To install the refactored jstl tck
`cd $WORKSPACE/glassfish-runner/jstl-tck; mvn clean verify` : To run the jstl tck with Glassfish 8.0.0-M5(JDK21)

cc @pnicolucci 
