### PR TITLE
Fix copyrights and other clean up

### DIFF
--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveSetTimezoneValueTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/positiveTimezoneValueTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDDateStyleTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDFallbackLocaleTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDLocalizationContextTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeStyleTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneNullEmptyTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZonePrecedenceTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2020 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTimeZoneTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation.
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/positiveFDTypeTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBrowserLocaleTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextBundleTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextI18NTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/positiveFormatLocalizationContextLocaleTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDBodyValueTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDDateStyleTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.gf
@@ -11,13 +11,14 @@
 
     <!-- The fallbackLocale configuration variable will be
              used if no locale match can be determined. -->
-
-
-
+    
+    
+    
     Nov 21, 2000<br>
     3:45:02 AM<br>
-    Nov 21, 2000, 3:45:02 AM<br>
+    Nov 21, 2000, 3:45:02 AM<br>
 
 </body>
 </html>
+
 

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDFallbackLocaleTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.gf
@@ -4,7 +4,6 @@
 
 
 
-
 <html>
 <head><title>positivePDLocalizationContextTest</title></head>
 <body>
@@ -12,16 +11,15 @@
     <!-- Validate that the action is able to dermine the
              formatting locale based on the localizationContext configuration
              variable. -->
-
-
-
+    
+    
+    
     Nov 21, 2000<br>
     3:45:02 AM<br>
-    Nov 21, 2000, 3:45:02 AM<br>
+    Nov 21, 2000, 3:45:02 AM<br>
 
 
 </body>
 </html>
-
 
 

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDLocalizationContextTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDParseLocaleTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeStyleTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTest.jsp
@@ -1,6 +1,6 @@
 <%--
 
-    Copyright (c) 2003 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.gf
@@ -12,11 +12,12 @@
     <!-- If timeZone is null or empty, it will be treated as
              if it was not present (only type short times is specified
              as any other style has no impact on the result). -->
-
-
-    Nov 21, 2000, 5:45 AM<br>
-    Nov 21, 2000, 5:45 AM<br>
+    
+    
+    Nov 21, 2000, 5:45 AM<br>
+    Nov 21, 2000, 5:45 AM<br>
 
 </body>
 </html>
+
 

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneNullEmptyTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.gf
@@ -21,24 +21,25 @@
       
         
       
-      Nov 21, 2000, 6:45 AM<br>
+      Nov 21, 2000, 6:45 AM<br>
 
       Not wrapped.  Page has a time zone of EST, timeZone attribute specified.  Time should be offset by 3 hours:<br>
       <br>
-      Nov 21, 2000, 6:45 AM<br>
+      Nov 21, 2000, 6:45 AM<br>
 
     <br>No TimeZone attribute specified:<br>
       Wrapped by &lt;fmt:timeZone&gt; action with MST.  Time should be offset by 2 hours:<br>
       
         <br>
       
-      Nov 21, 2000, 5:45 AM<br>
+      Nov 21, 2000, 5:45 AM<br>
       
       Not wrapped.  Page has a time zone of EST.  Time should not be offset:<br>
       <br>
-      Nov 21, 2000, 3:45 AM<br>
+      Nov 21, 2000, 3:45 AM<br>
     <br>
 
 </body>
 </html>
+
 

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZonePrecedenceTestJava20Plus.jsp
@@ -1,5 +1,6 @@
 <%--
 
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -51,7 +52,7 @@
         <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rd3"/><br>
       </fmt:timeZone>
       <fmt:formatDate value="${rd3}" timeZone="EST" type="both" timeStyle="short"/><br>
-
+      
       Not wrapped.  Page has a time zone of EST.  Time should not be offset:<br>
       <fmt:parseDate value='<%= (String) pageContext.getAttribute("dte") %>' type="both" timeStyle="short" var="rd4"/><br>
       <fmt:formatDate value="${rd4}" timeZone="EST" type="both" timeStyle="short"/><br>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.gf
@@ -13,13 +13,14 @@
              be explicitly provided to the action.  This will effectively
              overried the timezone of the page -->
     <br>Page is using EST for the timezone.  The formatting action will use PST.  Value should be offset 3 hours.<br>
-
-
-
-    No timeZone attribute: Nov 21, 2000, 3:45 AM<br>
-    Nov 21, 2000, 6:45 AM<br>
-    Nov 21, 2000, 6:45 AM<br>
+    
+    
+    
+    No timeZone attribute: Nov 21, 2000, 3:45 AM<br>
+    Nov 21, 2000, 6:45 AM<br>
+    Nov 21, 2000, 6:45 AM<br>
 
 </body>
 </html>
+
 

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTimeZoneTestJava20Plus.jsp
@@ -1,4 +1,6 @@
 <%--
+
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
@@ -10,8 +12,9 @@
     Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
     version 2 with the GNU Classpath Exception, which is available at
     https://www.gnu.org/software/classpath/license.html.
-    
+
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
 --%>
 
 <%@ page pageEncoding="UTF-8"%>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.gf
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.gf
@@ -4,31 +4,29 @@
 
 
 
-
 <html>
 <head><title>positivePDTypeTest</title></head>
 <body>
 
     <!-- the type attribute specifies the the type of date
              information is contained in the value to be parsed. -->
-
-
-
-
-
-
-
+    
+    
+    
+    
+    
+    
+    
     date: Nov 21, 2000<br>
     date: Nov 21, 2000<br>
     date: Nov 21, 2000<br>
-    time: 3:45:02 AM<br>
-    time: 3:45:02 AM<br>
-    both: Nov 21, 2000, 3:45:02 AM<br>
-    both: Nov 21, 2000, 3:45:02 AM<br>
-
+    time: 3:45:02 AM<br>
+    time: 3:45:02 AM<br>
+    both: Nov 21, 2000, 3:45:02 AM<br>
+    both: Nov 21, 2000, 3:45:02 AM<br>
+    
 
 </body>
 </html>
-
 
 

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/positivePDTypeTestJava20Plus.jsp
@@ -1,10 +1,12 @@
 <%--
+
+    Copyright (c) 2003, 2021 Oracle and/or its affiliates. All rights reserved.
     Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
     http://www.eclipse.org/legal/epl-2.0.
-    
+
     This Source Code may also be made available under the following Secondary
     Licenses when the conditions for such availability set forth in the
     Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
@@ -12,6 +14,7 @@
     https://www.gnu.org/software/classpath/license.html.
 
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
 --%>
 
 <%@ page pageEncoding="UTF-8"%>
@@ -51,5 +54,5 @@
     time: <fmt:formatDate value="${r5}" type="time"/><br>
     both: <fmt:formatDate value="${r6}" type="both"/><br>
     both: <fmt:formatDate value="${r7}" type="both"/><br>
-
+    
 </tck:test>

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueNullEmptyTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/positiveSetTimezoneValueTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueNullEmptyTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Contributors to the Eclipse Foundation
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at

--- a/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
+++ b/jstl/src/main/resources/com/sun/ts/tests/jstl/spec/fmt/format/timezone/positiveTimezoneValueTest.jsp
@@ -1,6 +1,7 @@
 <%--
 
-    Copyright (c) 2003 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2003, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2024 Contributors to the Eclipse Foundation
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at


### PR DESCRIPTION
**Fixes Issue**
This is a clean up PR for: https://github.com/jakartaee/platform-tck/pull/1329

**Related Issue(s)**
N/A

**Describe the change**
1) Many of these updates / files were copied from : https://github.com/jakartaee/platform-tck/pull/1320 as such I'm preserving the copyrights. 

Some Oracle copyrights were modified from `Copyright (c) 2003, 20xx Oracle and/or its affiliates. All rights reserved.` to `Copyright (c) 2003 Contributors to the Eclipse Foundation` which is incorrect and the following should just be added: `Copyright (c) 2024 Contributors to the Eclipse Foundation` The Oracle copyrights should be preserved.

The new JSPs that were added as part of the original PR I made are copies of the existing JSPs with minor updates, as such the original Oracle copyright should be maintained, so I've added that back as well.


Eclipse copyright policy: https://www.eclipse.org/projects/handbook/#legaldoc-faq

2) Some of the space characters in the new JSPs were incorrect. I updated these.

3) I updated all the files that were different from the original PR to ensure consistent content between the JSP files.

**Additional context**

CC @alwin-joseph @scottmarlow 
