### PR TITLE
Fix jaxws build

### DIFF
--- a/jaxws-common/pom.xml
+++ b/jaxws-common/pom.xml
@@ -53,6 +53,9 @@
         <!-- Include the container descriptors in the output artifact -->
         <resources>
             <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+            <resource>
                 <directory>src/main/java</directory>
                 <includes>
                     <include>**/*.xml</include>


### PR DESCRIPTION
Fix the jaxws build by adding back the standard src/main/resources dir to the jaxws-common module

**Fixes Issue**
jaxws module build was failing

**Related Issue(s)**

**Describe the change**
The change to include the source tree descriptors had dropped the standard jaxws-common/src/main/resources path from the build. This has been added back.

**Additional context**
Add any other context about the problem here.

