### PR TITLE
Make the sigtest classs public for use in the arquillian test artifacts

### DIFF
--- a/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/PackageList.java
+++ b/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/PackageList.java
@@ -62,7 +62,7 @@ import java.util.TreeSet;
  * and returning any package name that starts with the parent package name and a
  * trailing period character.
  */
-class PackageList {
+public class PackageList {
 
   // Any line in the packageFile starting with this character is a comment
   private static final char COMMENT_CHAR = '#';

--- a/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestData.java
+++ b/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestData.java
@@ -31,6 +31,9 @@ public class SigTestData {
 
   private Properties props;
 
+  public SigTestData(Properties props) {
+    this.props = props;
+  }
   public SigTestData() {
     this.props = System.getProperties();
   }

--- a/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestEE.java
+++ b/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestEE.java
@@ -203,15 +203,23 @@ public abstract class SigTestEE extends ServiceEETest {
    *           When an error occurs reading or saving the state information
    *           processed by this method.
    */
-  public void setup() throws Exception {
+  public void setup(String[] args, Properties p) throws Exception {
     try {
       TestUtil.logMsg("$$$ SigTestEE.setup() called");
-      this.testInfo = new SigTestData();
+      this.testInfo = new SigTestData(p);
       TestUtil.logMsg("$$$ SigTestEE.setup() complete");
     } catch (Exception e) {
       logErr("Unexpected exception " + e.getMessage());
       throw new Exception("setup failed!", e);
     }
+  }
+
+  /**
+   * calls {@link #setup(String[], Properties)} with null and System.getProperties()
+   * @throws Exception
+   */
+  public void setup() throws Exception {
+    setup(null, System.getProperties());
   }
 
   /**

--- a/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SignatureTestDriver.java
+++ b/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SignatureTestDriver.java
@@ -640,7 +640,7 @@ public abstract class SignatureTestDriver {
    * A simple data structure containing the fully qualified path to the
    * signature file as well as the version being tested.
    */
-  protected static class SignatureFileInfo {
+  public static class SignatureFileInfo {
 
     private String file;
 

--- a/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java
+++ b/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java
@@ -96,7 +96,7 @@ public class JavaEESigTest extends SigTestEE {
           "jaxws", "jaxb", "jms", "javamail", "jacc", "jaspic",
           "wsmd"));
 
-  enum Containers {
+  public enum Containers {
     ejb, servlet, jsp, appclient 
   };
 


### PR DESCRIPTION
Fixes #1365
Improves #1366

**Fixes Issue**
#1365 

**Related Issue(s)**
#1366 

**Describe the change**
Makes package classes public and adds back the setup(String[], Properties) method and has the setup() delegate to it passing in System.getProperties()

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
