### PR TITLE
comment out the maven.yml build of GlassFish Runner

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -68,8 +68,8 @@ jobs:
       - name: Build TCK
         run: ./mvnw -e -B -U clean install -Dmaven.test.failure.ignore=true -Pstaging
 
-      - name: Run Glassfish Runner
-        run: cd glassfish-runner; ../mvnw -e -B -U test -Pglassfish-runner -Pstaging
+#      - name: Run Glassfish Runner
+#        run: cd glassfish-runner; ../mvnw -e -B -U test -Pglassfish-runner -Pstaging
 
 #      - name: Publish Test Report
 #        uses: ScaCap/action-surefire-report@v1.7.0


### PR DESCRIPTION
Currently, the GlassFish runner fails to build as per https://github.com/jakartaee/platform-tck/issues/1368.  This change disables the build of the GlassFish runner which can later be enabled when https://github.com/jakartaee/platform-tck/issues/1368 is addressed.