### PR TITLE
Restore the BaseUrlClient extending the EETest class and isolate the …

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -104,5 +104,20 @@
                 </excludes>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar-no-fork</goal>
+                        </goals>
+                        <phase>verify</phase>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 </project>

--- a/jsp/src/main/java/ee/jakarta/tck/pages/common/client/AbstractUrlClient.java
+++ b/jsp/src/main/java/ee/jakarta/tck/pages/common/client/AbstractUrlClient.java
@@ -16,7 +16,6 @@
 
 package ee.jakarta.tck.pages.common.client;
 
-import com.sun.ts.tests.common.webclient.BaseUrlClient;
 import com.sun.ts.tests.common.webclient.WebTestCase;
 import com.sun.ts.tests.common.webclient.http.HttpRequest;
 

--- a/jsp/src/main/java/ee/jakarta/tck/pages/common/client/BaseUrlClient.java
+++ b/jsp/src/main/java/ee/jakarta/tck/pages/common/client/BaseUrlClient.java
@@ -18,18 +18,17 @@
  * $Id$
  */
 
-package com.sun.ts.tests.common.webclient;
+package ee.jakarta.tck.pages.common.client;
+
+import com.sun.ts.tests.common.webclient.TestFailureException;
+import com.sun.ts.tests.common.webclient.WebTestCase;
+import com.sun.ts.tests.common.webclient.http.HttpRequest;
+import org.apache.commons.httpclient.HttpState;
 
 import java.util.Enumeration;
 import java.util.Properties;
-import java.util.logging.Logger;
 import java.util.logging.Level;
-
-import com.sun.ts.lib.harness.EETest;
-import com.sun.ts.lib.util.TestUtil;
-import org.apache.commons.httpclient.HttpState;
-
-import com.sun.ts.tests.common.webclient.http.HttpRequest;
+import java.util.logging.Logger;
 
 /**
  * <PRE>
@@ -40,7 +39,8 @@ import com.sun.ts.tests.common.webclient.http.HttpRequest;
  * that particular technology.
  * </PRE>
  */
-public abstract class BaseUrlClient extends EETest {
+public abstract class BaseUrlClient {
+
   private static final Logger LOGGER = Logger.getLogger(BaseUrlClient.class.getName());
 
   /**
@@ -370,7 +370,7 @@ public abstract class BaseUrlClient extends EETest {
 
   /**
    * Sets the goldenfile directory
-   * 
+   *
    * @param goldenDir
    *          goldenfile directory based off test directory
    */
@@ -396,24 +396,24 @@ public abstract class BaseUrlClient extends EETest {
       _hostname = hostname;
     } else {
       throw new Exception(
-          "[BaseUrlClient] 'webServerHost' was not set in the" + " ts.jte.");
+              "[BaseUrlClient] 'webServerHost' was not set in the" + " ts.jte.");
     }
 
     if (!isNullOrEmpty(portnum)) {
       _port = Integer.parseInt(portnum);
     } else {
       throw new Exception(
-          "[BaseUrlClient] 'webServerPort' was not set in the" + " ts.jte.");
+              "[BaseUrlClient] 'webServerPort' was not set in the" + " ts.jte.");
     }
 
     if (!isNullOrEmpty(tshome)) {
       _tsHome = tshome;
     } else {
       throw new Exception(
-          "[BaseUrlClient] 'tshome' was not set in the " + " ts.jte.");
+              "[BaseUrlClient] 'tshome' was not set in the " + " ts.jte.");
     }
 
-    TestUtil.logMsg("[BaseUrlClient] Test setup OK");
+    LOGGER.log(Level.INFO,"[BaseUrlClient] Test setup OK");
   }
 
   /**
@@ -422,7 +422,7 @@ public abstract class BaseUrlClient extends EETest {
    *
    */
   public void cleanup() throws Exception {
-    TestUtil.logMsg( "[BaseUrlClient] Test cleanup OK");
+    LOGGER.log(Level.INFO, "[BaseUrlClient] Test cleanup OK");
   }
 
   /*
@@ -433,8 +433,8 @@ public abstract class BaseUrlClient extends EETest {
   /**
    * <PRE>
    * Invokes a test based on the properties
-    * stored in TEST_PROPS.  Once the test has completed,
-    * the properties in TEST_PROPS will be cleared.
+   * stored in TEST_PROPS.  Once the test has completed,
+   * the properties in TEST_PROPS will be cleared.
    * </PRE>
    *
    * @throws Exception
@@ -444,29 +444,25 @@ public abstract class BaseUrlClient extends EETest {
     try {
       _testCase = new WebTestCase();
       setTestProperties(_testCase);
-      TestUtil.logTrace("[BaseUrlClient] EXECUTING");
       LOGGER.fine("[BaseUrlClient] EXECUTING");
       if (_useSavedState && _state != null) {
         _testCase.getRequest().setState(_state);
       }
       if (_redirect != false) {
-        TestUtil.logTrace("##########Call setFollowRedirects");
         LOGGER.fine("##########Call setFollowRedirects");
         _testCase.getRequest().setFollowRedirects(_redirect);
       }
       _testCase.execute();
-      TestUtil.logMsg(_testCase.getResponse().getResponseBodyAsString());
       if (_saveState) {
         _state = _testCase.getResponse().getState();
       }
     } catch (TestFailureException tfe) {
       Throwable t = tfe.getRootCause();
       if (t != null) {
-        TestUtil.logErr("Root cause of Failure: " + t.getMessage(), t);
         LOGGER.log(Level.WARNING, "Root cause of Failure: " + t.getMessage(), t);
       }
       throw new Exception("[BaseUrlClient] " + _testName
-          + " failed!  Check output for cause of failure.", tfe);
+              + " failed!  Check output for cause of failure.", tfe);
     } finally {
       _useSavedState = false;
       _saveState = false;
@@ -478,7 +474,7 @@ public abstract class BaseUrlClient extends EETest {
   /**
    * <PRE>
    * Sets the appropriate test properties based
-    * on the values stored in TEST_PROPS
+   * on the values stored in TEST_PROPS
    * </PRE>
    */
   protected void setTestProperties(WebTestCase testCase) {
@@ -491,9 +487,9 @@ public abstract class BaseUrlClient extends EETest {
       String request = TEST_PROPS.getProperty(REQUEST);
 
       if (request.startsWith("GET") || request.startsWith("POST")
-          || request.startsWith("OPTIONS") || request.startsWith("PUT")
-          || request.startsWith("DELETE") || request.startsWith("HEAD")
-          || request.endsWith(HTTP10) || request.endsWith(HTTP11)) {
+              || request.startsWith("OPTIONS") || request.startsWith("PUT")
+              || request.startsWith("DELETE") || request.startsWith("HEAD")
+              || request.endsWith(HTTP10) || request.endsWith(HTTP11)) {
         // user has overriden default request behavior
         req = new HttpRequest(request, _hostname, _port);
         testCase.setRequest(req);
@@ -559,13 +555,13 @@ public abstract class BaseUrlClient extends EETest {
         LOGGER.fine("##########Found redirect Property");
         _redirect = true;
       } else if (key.equals(BASIC_AUTH_USER) || key.equals(BASIC_AUTH_PASSWD)
-          || key.equals(BASIC_AUTH_REALM)) {
+              || key.equals(BASIC_AUTH_REALM)) {
 
         String user = TEST_PROPS.getProperty(BASIC_AUTH_USER);
         String password = TEST_PROPS.getProperty(BASIC_AUTH_PASSWD);
         String realm = TEST_PROPS.getProperty(BASIC_AUTH_REALM);
         req.setAuthenticationCredentials(user, password,
-            HttpRequest.BASIC_AUTHENTICATION, realm);
+                HttpRequest.BASIC_AUTHENTICATION, realm);
       }
     }
   }

--- a/jsp/src/main/java/ee/jakarta/tck/pages/common/client/ServletAbstractUrlClient.java
+++ b/jsp/src/main/java/ee/jakarta/tck/pages/common/client/ServletAbstractUrlClient.java
@@ -16,7 +16,6 @@
 
 package ee.jakarta.tck.pages.common.client;
 
-import com.sun.ts.tests.common.webclient.BaseUrlClient;
 import com.sun.ts.tests.common.webclient.http.HttpRequest;
 import com.sun.ts.tests.common.webclient.WebTestCase;
 import com.sun.ts.tests.servlet.common.util.Data;

--- a/jsp/src/main/java/ee/jakarta/tck/pages/spec/security/secbasic/SecBasicClient.java
+++ b/jsp/src/main/java/ee/jakarta/tck/pages/spec/security/secbasic/SecBasicClient.java
@@ -17,18 +17,13 @@
 
 package ee.jakarta.tck.pages.spec.security.secbasic;
 
-import java.util.Properties;
 import java.net.URL;
-import com.sun.ts.tests.common.webclient.BaseUrlClient;
-import ee.jakarta.tck.pages.common.client.AbstractUrlClient;
 
+import ee.jakarta.tck.pages.common.client.BaseUrlClient;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.TestInfo;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import com.sun.ts.tests.common.webclient.BaseUrlClient;
 import java.lang.System.Logger;
 
 public class SecBasicClient extends BaseUrlClient {

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
@@ -35,7 +35,6 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
 
-import com.sun.ts.tests.common.webclient.BaseUrlClient;
 import com.sun.ts.tests.common.webclient.WebTestCase;
 import com.sun.ts.tests.common.webclient.http.HttpRequest;
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/common/client/BaseUrlClient.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/common/client/BaseUrlClient.java
@@ -18,15 +18,16 @@
  * $Id$
  */
 
-package com.sun.ts.tests.common.webclient;
+package com.sun.ts.tests.jstl.common.client;
 
+import java.io.PrintWriter;
 import java.util.Enumeration;
 import java.util.Properties;
 import java.util.logging.Logger;
 import java.util.logging.Level;
 
-import com.sun.ts.lib.harness.EETest;
-import com.sun.ts.lib.util.TestUtil;
+import com.sun.ts.tests.common.webclient.TestFailureException;
+import com.sun.ts.tests.common.webclient.WebTestCase;
 import org.apache.commons.httpclient.HttpState;
 
 import com.sun.ts.tests.common.webclient.http.HttpRequest;
@@ -40,7 +41,8 @@ import com.sun.ts.tests.common.webclient.http.HttpRequest;
  * that particular technology.
  * </PRE>
  */
-public abstract class BaseUrlClient extends EETest {
+public abstract class BaseUrlClient {
+
   private static final Logger LOGGER = Logger.getLogger(BaseUrlClient.class.getName());
 
   /**
@@ -370,7 +372,7 @@ public abstract class BaseUrlClient extends EETest {
 
   /**
    * Sets the goldenfile directory
-   * 
+   *
    * @param goldenDir
    *          goldenfile directory based off test directory
    */
@@ -396,24 +398,24 @@ public abstract class BaseUrlClient extends EETest {
       _hostname = hostname;
     } else {
       throw new Exception(
-          "[BaseUrlClient] 'webServerHost' was not set in the" + " ts.jte.");
+              "[BaseUrlClient] 'webServerHost' was not set in the" + " ts.jte.");
     }
 
     if (!isNullOrEmpty(portnum)) {
       _port = Integer.parseInt(portnum);
     } else {
       throw new Exception(
-          "[BaseUrlClient] 'webServerPort' was not set in the" + " ts.jte.");
+              "[BaseUrlClient] 'webServerPort' was not set in the" + " ts.jte.");
     }
 
     if (!isNullOrEmpty(tshome)) {
       _tsHome = tshome;
     } else {
       throw new Exception(
-          "[BaseUrlClient] 'tshome' was not set in the " + " ts.jte.");
+              "[BaseUrlClient] 'tshome' was not set in the " + " ts.jte.");
     }
 
-    TestUtil.logMsg("[BaseUrlClient] Test setup OK");
+    LOGGER.log(Level.INFO,"[BaseUrlClient] Test setup OK");
   }
 
   /**
@@ -422,7 +424,7 @@ public abstract class BaseUrlClient extends EETest {
    *
    */
   public void cleanup() throws Exception {
-    TestUtil.logMsg( "[BaseUrlClient] Test cleanup OK");
+    LOGGER.log(Level.INFO, "[BaseUrlClient] Test cleanup OK");
   }
 
   /*
@@ -433,8 +435,8 @@ public abstract class BaseUrlClient extends EETest {
   /**
    * <PRE>
    * Invokes a test based on the properties
-    * stored in TEST_PROPS.  Once the test has completed,
-    * the properties in TEST_PROPS will be cleared.
+   * stored in TEST_PROPS.  Once the test has completed,
+   * the properties in TEST_PROPS will be cleared.
    * </PRE>
    *
    * @throws Exception
@@ -444,29 +446,25 @@ public abstract class BaseUrlClient extends EETest {
     try {
       _testCase = new WebTestCase();
       setTestProperties(_testCase);
-      TestUtil.logTrace("[BaseUrlClient] EXECUTING");
       LOGGER.fine("[BaseUrlClient] EXECUTING");
       if (_useSavedState && _state != null) {
         _testCase.getRequest().setState(_state);
       }
       if (_redirect != false) {
-        TestUtil.logTrace("##########Call setFollowRedirects");
         LOGGER.fine("##########Call setFollowRedirects");
         _testCase.getRequest().setFollowRedirects(_redirect);
       }
       _testCase.execute();
-      TestUtil.logMsg(_testCase.getResponse().getResponseBodyAsString());
       if (_saveState) {
         _state = _testCase.getResponse().getState();
       }
     } catch (TestFailureException tfe) {
       Throwable t = tfe.getRootCause();
       if (t != null) {
-        TestUtil.logErr("Root cause of Failure: " + t.getMessage(), t);
         LOGGER.log(Level.WARNING, "Root cause of Failure: " + t.getMessage(), t);
       }
       throw new Exception("[BaseUrlClient] " + _testName
-          + " failed!  Check output for cause of failure.", tfe);
+              + " failed!  Check output for cause of failure.", tfe);
     } finally {
       _useSavedState = false;
       _saveState = false;
@@ -478,7 +476,7 @@ public abstract class BaseUrlClient extends EETest {
   /**
    * <PRE>
    * Sets the appropriate test properties based
-    * on the values stored in TEST_PROPS
+   * on the values stored in TEST_PROPS
    * </PRE>
    */
   protected void setTestProperties(WebTestCase testCase) {
@@ -491,9 +489,9 @@ public abstract class BaseUrlClient extends EETest {
       String request = TEST_PROPS.getProperty(REQUEST);
 
       if (request.startsWith("GET") || request.startsWith("POST")
-          || request.startsWith("OPTIONS") || request.startsWith("PUT")
-          || request.startsWith("DELETE") || request.startsWith("HEAD")
-          || request.endsWith(HTTP10) || request.endsWith(HTTP11)) {
+              || request.startsWith("OPTIONS") || request.startsWith("PUT")
+              || request.startsWith("DELETE") || request.startsWith("HEAD")
+              || request.endsWith(HTTP10) || request.endsWith(HTTP11)) {
         // user has overriden default request behavior
         req = new HttpRequest(request, _hostname, _port);
         testCase.setRequest(req);
@@ -559,13 +557,13 @@ public abstract class BaseUrlClient extends EETest {
         LOGGER.fine("##########Found redirect Property");
         _redirect = true;
       } else if (key.equals(BASIC_AUTH_USER) || key.equals(BASIC_AUTH_PASSWD)
-          || key.equals(BASIC_AUTH_REALM)) {
+              || key.equals(BASIC_AUTH_REALM)) {
 
         String user = TEST_PROPS.getProperty(BASIC_AUTH_USER);
         String password = TEST_PROPS.getProperty(BASIC_AUTH_PASSWD);
         String realm = TEST_PROPS.getProperty(BASIC_AUTH_REALM);
         req.setAuthenticationCredentials(user, password,
-            HttpRequest.BASIC_AUTHENTICATION, realm);
+                HttpRequest.BASIC_AUTHENTICATION, realm);
       }
     }
   }

--- a/pom.xml
+++ b/pom.xml
@@ -729,6 +729,11 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.3.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-resources-plugin</artifactId>
                     <version>3.3.1</version>
                 </plugin>


### PR DESCRIPTION
…pages and tags tck usage.

Note that this is ignore the servlet module as I believe we are just deleting that code since it has moved to its own tck.

**Fixes Issue**
Fixes #1404 

**Related Issue(s)**
#1404 

**Describe the change**
This has restored the EETest base class to com.sun.ts.tests.common.webclient.BaseUrlClient and created separate versions without the EETest base class in the pages and tags tck modules.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
