### PR TITLE
Updated CDI TCK - platform used 4.0.7 while latest is 4.0.13

### DIFF
--- a/glassfish-runner/cdi-tck/pom.xml
+++ b/glassfish-runner/cdi-tck/pom.xml
@@ -30,7 +30,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <cdi.tck-4-0.version>4.0.7</cdi.tck-4-0.version>
+        <cdi.tck-4-0.version>4.0.13</cdi.tck-4-0.version>
 
         <!-- This matches the htmlunit version in TCK -->
         <htmlunit.version>2.50.0</htmlunit.version>
@@ -261,7 +261,7 @@
             <scope>test</scope>
         </dependency>
 
-  
+
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
@@ -274,7 +274,7 @@
             <artifactId>testng</artifactId>
             <version>7.4.0</version>
         </dependency>
-        
+
         <!--  Signature Test Plugin  -->
         <dependency>
             <groupId>org.netbeans.tools</groupId>


### PR DESCRIPTION
**Fixes Issue**
* https://github.com/jakartaee/cdi-tck/pull/444 vs. https://ci.eclipse.org/jakartaee-tck/view/EFTL-Certification-Jobs-10/job/10/job/jakarta-cdi-tck-glassfish/120/
* https://github.com/jakartaee/cdi-tck/tags

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
