### PR TITLE
Include vehicle *.xhtml resources in artifact

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -98,6 +98,7 @@
                     <include>**/*.properties</include>
                     <include>**/*.jsp</include>
                     <include>**/client.html</include>
+                    <include>**/*.xhtml</include>
                 </includes>
                 <excludes>
                     <exclude>**/build.xml</exclude>


### PR DESCRIPTION
Fixes #1366

another missing resource type used in the test artifacts.