### PR TITLE
use local snapshot build of tck-rewrite OpenRewrite recipe

### DIFF
--- a/ejb30/pom.xml
+++ b/ejb30/pom.xml
@@ -190,6 +190,62 @@
                     </execution>
                 </executions>
             </plugin>
+            
+            <plugin>
+                <!--  Run with: mvn -Drewrite.exclusions="$PWD/annotations,$PWD/appclient,$PWD/assembly,$PWD/bin,$PWD/common,$PWD/connector,$PWD/core-profile-tck,$PWD/docker,$PWD/docker-images,$PWD/ejb,$PWD/ejb30,$PWD/ejb30-ws,$PWD/ejb32,$PWD/el,$PWD/glassfish-runner,$PWD/glassfishtck,$PWD/install,$PWD/integration,$PWD/internal,$PWD/jacc,$PWD/javaee,$PWD/javamail,$PWD/jaxrs,$PWD/jaxws,$PWD/jaxws-common,$PWD/jdbc,$PWD/jdbc_extras,$PWD/jms,$PWD/jsonb,$PWD/jsonp,$PWD/jsp,$PWD/jstl,$PWD/jta,$PWD/jws,$PWD/jws,$PWD/common,$PWD/lib,$PWD/libutil,$PWD/notes,$PWD/release,$PWD/runtime,$PWD/saaj,$PWD/samples,$PWD/servlet,$PWD/signaturetest,$PWD/sql,$PWD/src,$PWD/user_guides,$PWD/webartifacts,$PWD/webservices12,$PWD/webservices13,$PWD/websocket,$PWD/xa" org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
+                -->
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>5.32.1</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
+                    </activeRecipes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>tck.jakarta.platform</groupId>
+                        <artifactId>tck-rewrite-tools</artifactId>
+                        <version>11.0.0-SNAPSHOT</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-core</artifactId>
+                        <version>8.24.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>2.3.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-testing-frameworks</artifactId>
+                        <version>2.6.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-github-actions</artifactId>
+                        <version>2.1.7</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-17</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/ejb30/pom.xml
+++ b/ejb30/pom.xml
@@ -247,7 +247,7 @@
                     <dependency>
                         <groupId>tck.jakarta.platform</groupId>
                         <artifactId>tck-rewrite-tools</artifactId>
-                        <version>11.0.0-SNAPSHOT</version>
+                        <version>1.0-SNAPSHOT</version>
                     </dependency>
                     <dependency>
                         <groupId>org.openrewrite</groupId>

--- a/ejb30/pom.xml
+++ b/ejb30/pom.xml
@@ -190,7 +190,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <!--  Run with: mvn -Drewrite.exclusions="$PWD/annotations,$PWD/appclient,$PWD/assembly,$PWD/bin,$PWD/common,$PWD/connector,$PWD/core-profile-tck,$PWD/docker,$PWD/docker-images,$PWD/ejb,$PWD/ejb30,$PWD/ejb30-ws,$PWD/ejb32,$PWD/el,$PWD/glassfish-runner,$PWD/glassfishtck,$PWD/install,$PWD/integration,$PWD/internal,$PWD/jacc,$PWD/javaee,$PWD/javamail,$PWD/jaxrs,$PWD/jaxws,$PWD/jaxws-common,$PWD/jdbc,$PWD/jdbc_extras,$PWD/jms,$PWD/jsonb,$PWD/jsonp,$PWD/jsp,$PWD/jstl,$PWD/jta,$PWD/jws,$PWD/jws,$PWD/common,$PWD/lib,$PWD/libutil,$PWD/notes,$PWD/release,$PWD/runtime,$PWD/saaj,$PWD/samples,$PWD/servlet,$PWD/signaturetest,$PWD/sql,$PWD/src,$PWD/user_guides,$PWD/webartifacts,$PWD/webservices12,$PWD/webservices13,$PWD/websocket,$PWD/xa" org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
                 -->

--- a/ejb30/pom.xml
+++ b/ejb30/pom.xml
@@ -34,6 +34,7 @@
 
     <properties>
         <jaxwsStaleDirectory>${project.build.directory}/jaxws/stale</jaxwsStaleDirectory>
+        <junit.jupiter.version>5.9.1</junit.jupiter.version>
     </properties>
 
     <dependencies>
@@ -57,6 +58,11 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>
@@ -106,6 +112,41 @@
             <groupId>jakarta.servlet.jsp</groupId>
             <artifactId>jakarta.servlet.jsp-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-api</artifactId>
+            <version>1.8.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+            <version>1.2.6</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-depchain</artifactId>
+            <version>3.1.4</version>
+            <type>pom</type>
+        </dependency>
+        <dependency>
+            <groupId>tck.jakarta.platform</groupId>
+            <artifactId>tck-rewrite-ant</artifactId>
+            <version>11.0.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-common</artifactId>
+            <version>1.0.0-SNAPSHOT</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/ejb30/pom.xml
+++ b/ejb30/pom.xml
@@ -237,7 +237,7 @@
                 -->
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
-                <version>5.32.1</version>
+                <version>${version.openrewrite.maven-plugin}</version>
                 <configuration>
                     <activeRecipes>
                         <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
@@ -252,7 +252,7 @@
                     <dependency>
                         <groupId>org.openrewrite</groupId>
                         <artifactId>rewrite-core</artifactId>
-                        <version>8.24.0</version>
+                        <version>${version.openrewrite}</version>
                     </dependency>
                     <dependency>
                         <groupId>jakarta.xml.bind</groupId>

--- a/ejb30/pom.xml
+++ b/ejb30/pom.xml
@@ -233,7 +233,7 @@
             </plugin>
 
             <plugin>
-                <!--  Run with: mvn -Drewrite.exclusions="$PWD/annotations,$PWD/appclient,$PWD/assembly,$PWD/bin,$PWD/common,$PWD/connector,$PWD/core-profile-tck,$PWD/docker,$PWD/docker-images,$PWD/ejb,$PWD/ejb30,$PWD/ejb30-ws,$PWD/ejb32,$PWD/el,$PWD/glassfish-runner,$PWD/glassfishtck,$PWD/install,$PWD/integration,$PWD/internal,$PWD/jacc,$PWD/javaee,$PWD/javamail,$PWD/jaxrs,$PWD/jaxws,$PWD/jaxws-common,$PWD/jdbc,$PWD/jdbc_extras,$PWD/jms,$PWD/jsonb,$PWD/jsonp,$PWD/jsp,$PWD/jstl,$PWD/jta,$PWD/jws,$PWD/jws,$PWD/common,$PWD/lib,$PWD/libutil,$PWD/notes,$PWD/release,$PWD/runtime,$PWD/saaj,$PWD/samples,$PWD/servlet,$PWD/signaturetest,$PWD/sql,$PWD/src,$PWD/user_guides,$PWD/webartifacts,$PWD/webservices12,$PWD/webservices13,$PWD/websocket,$PWD/xa" org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
+                <!--  Run with: mvn -Dtcktestgroup=ejb30 -Dtcksourcepath=src/main/java  -Dts.home=/home/smarlow/tck/tck10/jakartaeetck org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log 
                 -->
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>

--- a/ejb32/pom.xml
+++ b/ejb32/pom.xml
@@ -84,6 +84,61 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <!--  Run with: mvn -Dtcktestgroup=ejb32 -Dtcksourcepath=src/main/java  -Dts.home=/home/smarlow/tck/tck10/jakartaeetck org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
+                -->
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>5.32.1</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
+                    </activeRecipes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>tck.jakarta.platform</groupId>
+                        <artifactId>tck-rewrite-tools</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-core</artifactId>
+                        <version>8.24.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>2.3.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-testing-frameworks</artifactId>
+                        <version>2.6.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-github-actions</artifactId>
+                        <version>2.1.7</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-17</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/ejb32/pom.xml
+++ b/ejb32/pom.xml
@@ -89,7 +89,7 @@
                 -->
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
-                <version>5.32.1</version>
+                <version>${version.openrewrite.maven-plugin}</version>
                 <configuration>
                     <activeRecipes>
                         <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
@@ -104,7 +104,7 @@
                     <dependency>
                         <groupId>org.openrewrite</groupId>
                         <artifactId>rewrite-core</artifactId>
-                        <version>8.24.0</version>
+                        <version>${version.openrewrite}</version>
                     </dependency>
                     <dependency>
                         <groupId>jakarta.xml.bind</groupId>

--- a/jpa/bin/pom.xml
+++ b/jpa/bin/pom.xml
@@ -18,7 +18,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <groupId>jakarta.tck</groupId>
     <artifactId>persistence-tck-runner</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <modelVersion>4.0.0</modelVersion>
     <parent>

--- a/jpa/common/pom.xml
+++ b/jpa/common/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>persistence-tck</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>persistence-tck-common</artifactId>
     <packaging>jar</packaging>

--- a/jpa/docs/userguide/pom.xml
+++ b/jpa/docs/userguide/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.persistence</groupId>
     <artifactId>jakarta.persistence-tck-user-guide</artifactId>
-    <version>3.2.0-SNAPSHOT</version>
+    <version>3.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta Persistence for Jakarta EE, Release 3.2 ${project.version}</name>
 

--- a/jpa/platform-tests/pom.xml
+++ b/jpa/platform-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>persistence-tck</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>persistence-tck-platform-tests</artifactId>
     <packaging>jar</packaging>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -147,7 +147,7 @@
                 -->
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
-                <version>5.32.1</version>
+                <version>${version.openrewrite.maven-plugin}</version>
                 <configuration>
                     <activeRecipes>
                         <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
@@ -162,7 +162,7 @@
                     <dependency>
                         <groupId>org.openrewrite</groupId>
                         <artifactId>rewrite-core</artifactId>
-                        <version>8.24.0</version>
+                        <version>${version.openrewrite}</version>
                     </dependency>
                     <dependency>
                         <groupId>jakarta.xml.bind</groupId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -143,7 +143,7 @@
                 </executions>
             </plugin>
             <plugin>
-                <!--  Run with: mvn -Drewrite.exclusions="$PWD/annotations,$PWD/appclient,$PWD/assembly,$PWD/bin,$PWD/common,$PWD/connector,$PWD/core-profile-tck,$PWD/docker,$PWD/docker-images,$PWD/ejb,$PWD/ejb30,$PWD/ejb30-ws,$PWD/ejb32,$PWD/el,$PWD/glassfish-runner,$PWD/glassfishtck,$PWD/install,$PWD/integration,$PWD/internal,$PWD/jacc,$PWD/javaee,$PWD/javamail,$PWD/jaxrs,$PWD/jaxws,$PWD/jaxws-common,$PWD/jdbc,$PWD/jdbc_extras,$PWD/jms,$PWD/jsonb,$PWD/jsonp,$PWD/jsp,$PWD/jstl,$PWD/jta,$PWD/jws,$PWD/jws,$PWD/common,$PWD/lib,$PWD/libutil,$PWD/notes,$PWD/release,$PWD/runtime,$PWD/saaj,$PWD/samples,$PWD/servlet,$PWD/signaturetest,$PWD/sql,$PWD/src,$PWD/user_guides,$PWD/webartifacts,$PWD/webservices12,$PWD/webservices13,$PWD/websocket,$PWD/xa" org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
+                <!--  Run with: mvn -Dtcktestgroup=jpa -Dtcksourcepath=src/main/java  -Dts.home=/home/smarlow/tck/tck10/jakartaeetck org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
                 -->
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -142,6 +142,61 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <!--  Run with: mvn -Drewrite.exclusions="$PWD/annotations,$PWD/appclient,$PWD/assembly,$PWD/bin,$PWD/common,$PWD/connector,$PWD/core-profile-tck,$PWD/docker,$PWD/docker-images,$PWD/ejb,$PWD/ejb30,$PWD/ejb30-ws,$PWD/ejb32,$PWD/el,$PWD/glassfish-runner,$PWD/glassfishtck,$PWD/install,$PWD/integration,$PWD/internal,$PWD/jacc,$PWD/javaee,$PWD/javamail,$PWD/jaxrs,$PWD/jaxws,$PWD/jaxws-common,$PWD/jdbc,$PWD/jdbc_extras,$PWD/jms,$PWD/jsonb,$PWD/jsonp,$PWD/jsp,$PWD/jstl,$PWD/jta,$PWD/jws,$PWD/jws,$PWD/common,$PWD/lib,$PWD/libutil,$PWD/notes,$PWD/release,$PWD/runtime,$PWD/saaj,$PWD/samples,$PWD/servlet,$PWD/signaturetest,$PWD/sql,$PWD/src,$PWD/user_guides,$PWD/webartifacts,$PWD/webservices12,$PWD/webservices13,$PWD/websocket,$PWD/xa" org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
+                -->
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>5.32.1</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
+                    </activeRecipes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>tck.jakarta.platform</groupId>
+                        <artifactId>tck-rewrite-tools</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-core</artifactId>
+                        <version>8.24.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>2.3.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-testing-frameworks</artifactId>
+                        <version>2.6.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-github-actions</artifactId>
+                        <version>2.1.7</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-17</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -20,13 +20,13 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
+        <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
     <groupId>jakarta.tck</groupId>
     <artifactId>persistence-tck</artifactId>
-    <version>3.2.0</version>
+    <version>3.2.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>persistence</name>
     <description>persistence tck tests</description>
@@ -39,11 +39,10 @@
         <module>tck-dist</module>
     </modules>
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
-        <junit.jupiter.version>5.9.1</junit.jupiter.version>
-        <tck.version>${project.version}</tck.version>
         <jakarta.ee.version>11.0.0-M1</jakarta.ee.version>
+        <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <maven.compiler.release>17</maven.compiler.release>
+        <tck.version>${project.version}</tck.version>
     </properties>
     <dependencies>
         <dependency>
@@ -69,7 +68,7 @@
         <dependency>
             <groupId>jakarta.persistence</groupId>
             <artifactId>jakarta.persistence-api</artifactId>
-            <version>${project.version}</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>jakarta.annotation</groupId>
@@ -90,6 +89,19 @@
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${junit.jupiter.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-api</artifactId>
+            <version>1.8.0.Final</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-container</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>

--- a/jpa/procedures/pom.xml
+++ b/jpa/procedures/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>persistence-tck</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>dbprocedures</artifactId>
     <name>Persistence</name>

--- a/jpa/spec-tests/pom.xml
+++ b/jpa/spec-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>persistence-tck</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
     </parent>
     <artifactId>persistence-tck-spec-tests</artifactId>
     <packaging>jar</packaging>
@@ -31,6 +31,11 @@
             <groupId>${project.groupId}</groupId>
             <artifactId>persistence-tck-common</artifactId>
             <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-api</artifactId>
+            <version>1.8.0.Final</version>
         </dependency>
     </dependencies>
     <build>

--- a/jpa/tck-dist/pom.xml
+++ b/jpa/tck-dist/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>persistence-tck</artifactId>
-        <version>3.2.0</version>
+        <version>3.2.1-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <artifactId>persistence-tck-dist</artifactId>

--- a/jta/pom.xml
+++ b/jta/pom.xml
@@ -92,6 +92,61 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
+            <plugin>
+                <!--  Run with: mvn -Dtcktestgroup=jta -Dtcksourcepath=src/main/java  -Dts.home=/home/smarlow/tck/tck10/jakartaeetck org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
+                -->
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>5.32.1</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
+                    </activeRecipes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>tck.jakarta.platform</groupId>
+                        <artifactId>tck-rewrite-tools</artifactId>
+                        <version>1.0-SNAPSHOT</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-core</artifactId>
+                        <version>8.24.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>2.3.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-testing-frameworks</artifactId>
+                        <version>2.6.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-github-actions</artifactId>
+                        <version>2.1.7</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-17</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
         </plugins>
     </build>
 </project>

--- a/jta/pom.xml
+++ b/jta/pom.xml
@@ -97,7 +97,7 @@
                 -->
                 <groupId>org.openrewrite.maven</groupId>
                 <artifactId>rewrite-maven-plugin</artifactId>
-                <version>5.32.1</version>
+                <version>${version.openrewrite.maven-plugin}</version>
                 <configuration>
                     <activeRecipes>
                         <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
@@ -112,7 +112,7 @@
                     <dependency>
                         <groupId>org.openrewrite</groupId>
                         <artifactId>rewrite-core</artifactId>
-                        <version>8.24.0</version>
+                        <version>${version.openrewrite}</version>
                     </dependency>
                     <dependency>
                         <groupId>jakarta.xml.bind</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,7 +80,8 @@
 
     <properties>
         <ant.version>1.10.11</ant.version>
-        <arquillian.version>1.7.0.Alpha10</arquillian.version>
+        <arquillian.version>1.8.0.Final</arquillian.version>
+
         <!-- CDI -->
         <cdi-api.version>4.0.0</cdi-api.version>
         <!-- Jakarta Concurrency -->
@@ -132,6 +133,12 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <slf4j.version>2.0.0</slf4j.version>
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
+        <version.openrewrite>8.24.0</version.openrewrite>
+        <version.org.jboss.arquillian.core>1.7.2.Final</version.org.jboss.arquillian.core>
+        <webservices-api-osgi.version>3.0.0</webservices-api-osgi.version>
+        <webservices-api.version>3.0.0</webservices-api.version>
+        <webservices-osgi.version>3.0.0</webservices-osgi.version>
+        <webservices-tools.version>3.0.0</webservices-tools.version>
         <!-- Jakarta WebSocket -->
         <websocket-api.version>2.2.0</websocket-api.version>
         <websocket-client-api.version>2.2.0</websocket-client-api.version>
@@ -388,6 +395,18 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-container-test-spi</artifactId>
+                <version>${arquillian.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.arquillian.junit</groupId>
+                <artifactId>arquillian-junit-container</artifactId>
+                <version>${version.org.jboss.arquillian.core}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
                 <version>${jakarta.activation-api.version}</version>
@@ -562,7 +581,11 @@
                 <artifactId>jboss-rmi-api_1.0_spec</artifactId>
                 <version>1.0.6.Final</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-container-test-api</artifactId>
+                <version>1.8.0.Final</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -757,6 +780,61 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <!--  Run with: mvn -Drewrite.exclusions="$PWD/annotations,$PWD/appclient,$PWD/assembly,$PWD/bin,$PWD/common,$PWD/connector,$PWD/core-profile-tck,$PWD/docker,$PWD/docker-images,$PWD/ejb,$PWD/ejb30,$PWD/ejb30-ws,$PWD/ejb32,$PWD/el,$PWD/glassfish-runner,$PWD/glassfishtck,$PWD/install,$PWD/integration,$PWD/internal,$PWD/jacc,$PWD/javaee,$PWD/javamail,$PWD/jaxrs,$PWD/jaxws,$PWD/jaxws-common,$PWD/jdbc,$PWD/jdbc_extras,$PWD/jms,$PWD/jsonb,$PWD/jsonp,$PWD/jsp,$PWD/jstl,$PWD/jta,$PWD/jws,$PWD/jws,$PWD/common,$PWD/lib,$PWD/libutil,$PWD/notes,$PWD/release,$PWD/runtime,$PWD/saaj,$PWD/samples,$PWD/servlet,$PWD/signaturetest,$PWD/sql,$PWD/src,$PWD/user_guides,$PWD/webartifacts,$PWD/webservices12,$PWD/webservices13,$PWD/websocket,$PWD/xa" org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
+                -->
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>5.32.1</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
+                    </activeRecipes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>tck.jakarta.platform</groupId>
+                        <artifactId>tck-rewrite-tools</artifactId>
+                        <version>11.0.0-SNAPSHOT</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-core</artifactId>
+                        <version>8.24.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>2.3.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-testing-frameworks</artifactId>
+                        <version>2.6.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-github-actions</artifactId>
+                        <version>2.1.7</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-17</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -780,61 +780,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <!--  Run with: mvn -Drewrite.exclusions="$PWD/annotations,$PWD/appclient,$PWD/assembly,$PWD/bin,$PWD/common,$PWD/connector,$PWD/core-profile-tck,$PWD/docker,$PWD/docker-images,$PWD/ejb,$PWD/ejb30,$PWD/ejb30-ws,$PWD/ejb32,$PWD/el,$PWD/glassfish-runner,$PWD/glassfishtck,$PWD/install,$PWD/integration,$PWD/internal,$PWD/jacc,$PWD/javaee,$PWD/javamail,$PWD/jaxrs,$PWD/jaxws,$PWD/jaxws-common,$PWD/jdbc,$PWD/jdbc_extras,$PWD/jms,$PWD/jsonb,$PWD/jsonp,$PWD/jsp,$PWD/jstl,$PWD/jta,$PWD/jws,$PWD/jws,$PWD/common,$PWD/lib,$PWD/libutil,$PWD/notes,$PWD/release,$PWD/runtime,$PWD/saaj,$PWD/samples,$PWD/servlet,$PWD/signaturetest,$PWD/sql,$PWD/src,$PWD/user_guides,$PWD/webartifacts,$PWD/webservices12,$PWD/webservices13,$PWD/websocket,$PWD/xa" org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
-                -->
-                <groupId>org.openrewrite.maven</groupId>
-                <artifactId>rewrite-maven-plugin</artifactId>
-                <version>5.32.1</version>
-                <configuration>
-                    <activeRecipes>
-                        <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
-                    </activeRecipes>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>tck.jakarta.platform</groupId>
-                        <artifactId>tck-rewrite-tools</artifactId>
-                        <version>11.0.0-SNAPSHOT</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.openrewrite</groupId>
-                        <artifactId>rewrite-core</artifactId>
-                        <version>8.24.0</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>jakarta.xml.bind</groupId>
-                        <artifactId>jakarta.xml.bind-api</artifactId>
-                        <version>2.3.2</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.openrewrite.recipe</groupId>
-                        <artifactId>rewrite-testing-frameworks</artifactId>
-                        <version>2.6.0</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.openrewrite.recipe</groupId>
-                        <artifactId>rewrite-github-actions</artifactId>
-                        <version>2.1.7</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.openrewrite</groupId>
-                        <artifactId>rewrite-java-17</artifactId>
-                        <version>${version.openrewrite}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.openrewrite</groupId>
-                        <artifactId>rewrite-test</artifactId>
-                        <version>${version.openrewrite}</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.openrewrite</groupId>
-                        <artifactId>rewrite-java-test</artifactId>
-                        <version>${version.openrewrite}</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-
         </plugins>
     </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,7 @@
         <slf4j.version>2.0.0</slf4j.version>
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
         <version.openrewrite>8.24.0</version.openrewrite>
+        <version.openrewrite.maven-plugin>5.32.1</version.openrewrite.maven-plugin>
         <version.org.jboss.arquillian.core>1.7.2.Final</version.org.jboss.arquillian.core>
         <webservices-api-osgi.version>3.0.0</webservices-api-osgi.version>
         <webservices-api.version>3.0.0</webservices-api.version>

--- a/rewrite_readme.txt
+++ b/rewrite_readme.txt
@@ -1,1 +1,1 @@
-mvn -Djar2shrinkwrap.technology=com.sun.ts.tests.jpa org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee tckrewrite.log
+mvn -Dtcktestgroup=jpa -Dts.home=/home/smarlow/tck/tck10/jakartaeetck org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log

--- a/rewrite_readme.txt
+++ b/rewrite_readme.txt
@@ -1,0 +1,1 @@
+mvn -Djar2shrinkwrap.technology=com.sun.ts.tests.jpa org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee tckrewrite.log

--- a/servlet/pom.xml
+++ b/servlet/pom.xml
@@ -79,6 +79,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.directory.studio</groupId>
+            <artifactId>org.apache.commons.io</artifactId>
+            <version>2.4</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>


### PR DESCRIPTION
Add support for running the OpenRewrite Maven plugin with local build of the https://github.com/scottmarlow/jakartaee-tck-tools/tree/tck-rewrite-ant branch

Steps to try:

- in your local jakartaee-tck-tools repo `git fetch https://github.com/scottmarlow/jakartaee-tck-tools tck-rewrite-ant:tck-rewrite-ant` 
- git checkout tck-rewrite-ant
- (compile with Java 17) cd tools/tck-rewrite-ant;mvn clean install
- (compile with Java 21) cd ../tck-rewrite-fx;mvn clean install
- (compile with Java 17) cd ../tck-rewrite;mvn clean install -DskipTests=true

Build this branch:
- In your https://github.com/jakartaee/platform-tck repo `git fetch  https://github.com/scottmarlow/jakartaee-tck new_rewritejpa2:new_rewritejpa2
- git checkout new_rewritejpa2
- (compile with Java 17) mvn clean install

Try running the rewrite-maven-plugin command (make sure you commit any other changes first).
- cd jta
- mvn -Dtcksourcepath=src/main/java  -Dts.home=/home/you/jakartaee10tckFolder org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log

You can also run the last ^ maven command in the ejb30/ejb32/jpa folders as well.

After running the org.openrewrite.maven:rewrite-maven-plugin command, try to build the TCK and consider further changes to address build failures.  

To save the generated java sources do `git add *.java`.  

To delete the generated java sources do something like `git status | grep .java | xargs rm`