### PR TITLE
Pages TCK was failing since javatest was not installed correctly

### DIFF
--- a/glassfish-runner/pages-tck/pages-tck-install/pom.xml
+++ b/glassfish-runner/pages-tck/pages-tck-install/pom.xml
@@ -73,6 +73,7 @@
                             <artifactId>javatest</artifactId>
                             <version>5.0</version>
                             <packaging>jar</packaging>
+                            <generatePom>true</generatePom>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Added pom generation. 

Note; it's strange that the refactored Pages TCK still depends on javatest. This seems like an oversight.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
