### PR TITLE
On branch edburns-msft-1410-arquillian-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ el/bundle
 jakartaeetck-bundles/
 /tck-env.cfg
 .DS_Store
+wip-find.txt

--- a/cdi-ee-tck/pom.xml
+++ b/cdi-ee-tck/pom.xml
@@ -18,7 +18,7 @@
         <maven.compiler.release>17</maven.compiler.release>
         <testng.version>7.9.0</testng.version>
         <jboss.test.audit.version>2.0.0.Final</jboss.test.audit.version>
-        <arquillian.version>1.8.0.Final</arquillian.version>
+        <arquillian.version>1.9.1.Final</arquillian.version>
         <arquillian.container.se.api.version>1.0.2.Final</arquillian.container.se.api.version>
         <apache.httpclient.version>3.1</apache.httpclient.version>
         <htmlunit.version>2.50.0</htmlunit.version>
@@ -168,6 +168,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+            <version>2.0.0</version>
         </dependency>
 
         <dependency>

--- a/core-profile-tck/pom.xml
+++ b/core-profile-tck/pom.xml
@@ -79,7 +79,7 @@
         <!-- Jakarta EE APIs Core -->
         <annotations.api.version>2.1.1</annotations.api.version>
         <apache.httpclient.version>3.1</apache.httpclient.version>
-        <arquillian.container.se.api.version>1.0.1.Final</arquillian.container.se.api.version>
+
         <cdi.api.version>4.0.0</cdi.api.version>
         <cdi.tck.version>4.0.6</cdi.tck.version>
         <!-- Required for distribution build, should be overriden for each build -->

--- a/glassfish-runner/cdi-model-tck/pom.xml
+++ b/glassfish-runner/cdi-model-tck/pom.xml
@@ -66,7 +66,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
-            <version>1.7.0.Alpha10</version>
             <scope>test</scope>
         </dependency>
 

--- a/glassfish-runner/cdi-tck/pom.xml
+++ b/glassfish-runner/cdi-tck/pom.xml
@@ -50,19 +50,20 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>1.8.0.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
 
             <dependency>
                 <groupId>jakarta.enterprise</groupId>
                 <artifactId>jakarta.enterprise.cdi-api</artifactId>
                 <version>4.1.0</version>
             </dependency>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+                <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
+                <version>2.0.0</version>
+            </dependency>
+
+
         </dependencies>
     </dependencyManagement>
 
@@ -264,7 +265,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.testng</groupId>
             <artifactId>arquillian-testng-container</artifactId>
-            <version>1.8.0.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/glassfish-runner/concurrency-tck/pom.xml
+++ b/glassfish-runner/concurrency-tck/pom.xml
@@ -40,18 +40,6 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>1.8.0.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
     <dependencies>
         <!-- Jakarta EE APIs -->
         <dependency>

--- a/glassfish-runner/javaee-module-tck/pom.xml
+++ b/glassfish-runner/javaee-module-tck/pom.xml
@@ -20,7 +20,6 @@
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.javaee-module-tck</artifactId>
@@ -53,7 +52,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>1.7.0.Alpha10</version>
         </dependency>
         <dependency>
             <groupId>jakarta.platform</groupId>
@@ -69,7 +67,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-spi</artifactId>
-            <version>1.7.0.Alpha10</version>
         </dependency>
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>

--- a/glassfish-runner/jaxrs-platform-tck/pom.xml
+++ b/glassfish-runner/jaxrs-platform-tck/pom.xml
@@ -64,17 +64,14 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>1.7.0.Final</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>1.7.0.Final</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-spi</artifactId>
-            <version>1.7.0.Alpha10</version>
         </dependency>
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>

--- a/glassfish-runner/jsonb-platform-tck/pom.xml
+++ b/glassfish-runner/jsonb-platform-tck/pom.xml
@@ -20,7 +20,6 @@
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsonb-platform-tck</artifactId>
@@ -28,7 +27,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
         <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version>
         <!-- Use JDK21 to run with GF 8.0.0-M5 -->
@@ -77,7 +75,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-spi</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>
@@ -87,12 +84,10 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>

--- a/glassfish-runner/jsonp-platform-tck/pom.xml
+++ b/glassfish-runner/jsonp-platform-tck/pom.xml
@@ -20,7 +20,6 @@
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsonp-platform-tck</artifactId>
@@ -28,7 +27,6 @@
     <packaging>jar</packaging>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
         <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version>
         <!-- Use JDK21 to run with GF 8.0.0-M5 -->
@@ -77,7 +75,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-spi</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>
@@ -87,12 +84,10 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>

--- a/glassfish-runner/jsp-platform-tck/pom.xml
+++ b/glassfish-runner/jsp-platform-tck/pom.xml
@@ -20,7 +20,6 @@
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsp-tck</artifactId>
@@ -84,7 +83,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>1.7.0.Alpha10</version>
         </dependency>
         <dependency>
             <groupId>jakarta.platform</groupId>
@@ -105,7 +103,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-spi</artifactId>
-            <version>1.7.0.Alpha10</version>
         </dependency>
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>

--- a/glassfish-runner/jstl-tck/pom.xml
+++ b/glassfish-runner/jstl-tck/pom.xml
@@ -20,7 +20,6 @@
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jstl-tck</artifactId>
@@ -68,7 +67,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>1.7.0.Alpha10</version>
         </dependency>
         <dependency>
             <groupId>jakarta.platform</groupId>
@@ -89,7 +87,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-test-spi</artifactId>
-            <version>1.7.0.Alpha10</version>
         </dependency>
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>

--- a/glassfish-runner/pages-tck/pages-tck-run/pom.xml
+++ b/glassfish-runner/pages-tck/pages-tck-run/pom.xml
@@ -46,10 +46,15 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.8.0.Final</version>
+                <version>1.9.1.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13.2</version>
+        </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/glassfish-runner/pom.xml
+++ b/glassfish-runner/pom.xml
@@ -45,23 +45,28 @@
 
     <properties>
         <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-
         <glassfish.container.version>7.0.0</glassfish.container.version>
         <glassfish.toplevel.dir>glassfish7</glassfish.toplevel.dir>
         <jakarta.rest.version>3.1.0</jakarta.rest.version>
-        <jakarta.rest.version>3.1.0</jakarta.rest.version>
         <json.tck.version>2.1.0</json.tck.version>
-        <json.tck.version>2.1.0</json.tck.version>
-
         <jsonb.tck.version>3.0.0</jsonb.tck.version>
-
-        <jsonb.tck.version>3.0.0</jsonb.tck.version>
-
         <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
         <tck.artifactId>jakarta-restful-ws-tck</tck.artifactId>
-        <tck.artifactId>jakarta-restful-ws-tck</tck.artifactId>
+        <arquillian.version>1.9.1.Final</arquillian.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+            
 
     <repositories>
         <repository>

--- a/glassfish-runner/rest-tck/pom.xml
+++ b/glassfish-runner/rest-tck/pom.xml
@@ -73,13 +73,6 @@ mvn clean install -Dgroups=security
     <dependencyManagement>
         <dependencies>
             <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>1.8.0.Final</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
                 <version>5.10.2</version>

--- a/glassfish-runner/servlet-tck/servlet-tck-run/pom.xml
+++ b/glassfish-runner/servlet-tck/servlet-tck-run/pom.xml
@@ -51,11 +51,25 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.8.0.Final</version>
+                <version>1.9.1.Final</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+                <version>3.3.0</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-impl-maven-archive</artifactId>
+                <version>3.3.0</version>
+            </dependency>
+
         </dependencies>
+        
     </dependencyManagement>
 
     <dependencies>
@@ -126,6 +140,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
+            <version>4.13.2</version>
             <scope>test</scope>
         </dependency>
 

--- a/glassfish-runner/websocket-tck/websocket-tck-run/pom.xml
+++ b/glassfish-runner/websocket-tck/websocket-tck-run/pom.xml
@@ -30,6 +30,7 @@
     <packaging>jar</packaging>
 
     <properties>
+        <arquillian.version>1.9.1.Final</arquillian.version>
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
 
@@ -46,7 +47,7 @@
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
-                <version>1.8.0.Final</version>
+                <version>${arquillian.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -87,7 +88,6 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>1.8.0.Final</version>
             <scope>test</scope>
         </dependency>
 

--- a/javaee/pom.xml
+++ b/javaee/pom.xml
@@ -34,7 +34,6 @@
     <description>javaee</description>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
@@ -74,12 +73,10 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
     </dependencies>
     <build>

--- a/jms-tck/pom.xml
+++ b/jms-tck/pom.xml
@@ -33,7 +33,6 @@
     <description>JMS Standalone TCK tests</description>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -77,12 +76,10 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
     </dependencies>
     <build>

--- a/jpa/bin/pom.xml
+++ b/jpa/bin/pom.xml
@@ -66,7 +66,7 @@
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <jakarta.ee.version>11.0.0-M1</jakarta.ee.version>
         <persistence.tck.version>3.2.0</persistence.tck.version>
-        <arquillian.junit5.version>1.7.0.Alpha14</arquillian.junit5.version>
+        <arquillian.junit5.version>1.9.1.Final</arquillian.junit5.version>
         <el.version>5.0.0-M1</el.version>
         <hibernate.version>8.0.1.Final</hibernate.version>
         <javadb.lib>${glassfish.toplevel.dir}/javadb/lib</javadb.lib>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -39,7 +39,7 @@
         <module>tck-dist</module>
     </modules>
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
+        <arquillian.junit>1.9.1.Final</arquillian.junit>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.version>${project.version}</tck.version>
         <jakarta.ee.version>11.0.0-M1</jakarta.ee.version>

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -33,7 +33,6 @@
     <description>JSONB</description>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
@@ -78,12 +77,10 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
     </dependencies>
     <build>

--- a/jsonp/pom.xml
+++ b/jsonp/pom.xml
@@ -33,7 +33,6 @@
     <description>JSONP</description>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
@@ -78,12 +77,10 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
     </dependencies>
     <build>

--- a/jsp/pom.xml
+++ b/jsp/pom.xml
@@ -34,7 +34,6 @@
     <description>JSP Tests for Jakarta EE Platform</description>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <jakarta.annotation-api.version>3.0.0-M1</jakarta.annotation-api.version>
         <jakarta.el-api.version>6.0.0-RC1</jakarta.el-api.version>
         <jakarta.mail-api.version>2.1.2</jakarta.mail-api.version>
@@ -112,12 +111,10 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
     </dependencies>
 

--- a/jstl/pom.xml
+++ b/jstl/pom.xml
@@ -34,7 +34,6 @@
     <description>JSTL TCK</description>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <jakarta.servlet.api.version>6.1.0-M2</jakarta.servlet.api.version>
         <jakarta.servlet.jsp-api.version>4.0.0-M2</jakarta.servlet.jsp-api.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
@@ -88,12 +87,10 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,8 @@
 
     <properties>
         <ant.version>1.10.11</ant.version>
-        <arquillian.version>1.7.0.Alpha10</arquillian.version>
+        <arquillian.version>1.9.1.Final</arquillian.version>
+        <arquillian.container.se.api.version>1.0.2.Final</arquillian.container.se.api.version>
         <!-- CDI -->
         <cdi-api.version>4.0.0</cdi-api.version>
         <!-- Jakarta Concurrency -->
@@ -131,6 +132,8 @@
         <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <shrinkwrap.version>3.3.0</shrinkwrap.version>
+        <shrinkwrap.api.version>2.0.0-beta-1</shrinkwrap.api.version>
         <slf4j.version>2.0.0</slf4j.version>
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
         <!-- Jakarta WebSocket -->
@@ -389,6 +392,30 @@
             </dependency>
 
             <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>container-se-api</artifactId>
+                <version>${arquillian.container.se.api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-depchain</artifactId>
+                <version>${shrinkwrap.version}</version>
+                <type>pom</type>
+            </dependency>
+ 
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-api</artifactId>
+                <version>${shrinkwrap.api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+                <version>${shrinkwrap.version}</version>
+            </dependency>
+
+            <dependency>
                 <groupId>jakarta.activation</groupId>
                 <artifactId>jakarta.activation-api</artifactId>
                 <version>${jakarta.activation-api.version}</version>
@@ -633,12 +660,6 @@
                     <groupId>org.netbeans.tools</groupId>
                     <artifactId>sigtest-maven-plugin</artifactId>
                     <version>1.5</version>
-                </plugin>
-                <!-- Plugin versions since ee4j parent no longer declares them-->
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-source-plugin</artifactId>
-                    <version>3.2.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/saaj/pom.xml
+++ b/saaj/pom.xml
@@ -33,7 +33,6 @@
     <description>saaj</description>
 
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
@@ -69,12 +68,10 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
-            <version>${arquillian.junit}</version>
         </dependency>
     </dependencies>
     <build>

--- a/websocket/pom.xml
+++ b/websocket/pom.xml
@@ -19,6 +19,7 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+    <!-- Why does this not list the top level POM as a parent, as many other modules do? -->
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
@@ -38,7 +39,7 @@
         <module>tck-dist</module>
     </modules>
     <properties>
-        <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
+        <arquillian.junit>1.9.1.Final</arquillian.junit>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.version>${project.version}</tck.version>
         <jakarta.ee.version>11.0.0-M1</jakarta.ee.version>


### PR DESCRIPTION
WIP: Intended to fix #1410 .

modified:   pom.xml

- Add shrinkwrap, container-se-api to dependencyManagement.

- Update arquillian version.

- Remove duplicate maven-source-plugin dependency.

modified:   .gitignore

- Add scratch file.

modified:   core-profile-tck/pom.xml

- Remove arquillian.container.se.api.version property. Pull arquillian version from parent via dependencyManagement.

modified:   glassfish-runner/websocket-tck/websocket-tck-run/pom.xml
modified:   websocket/pom.xml

- Does not use an internal parent POM, therefore must include the arquillian version inline here.

modified:   javaee/pom.xml
modified:   jms-tck/pom.xml
modified:   jstl/pom.xml

- Pull arquillian version from parent via dependencyManagement.

**Fixes Issue**

 #1410 

**Related Issue(s)**

https://github.com/jakartaee/batch-tck/pull/82

**Describe the change**

Upgrade arquillian version as requested in #1410.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
