### PR TITLE
Initial transform of the ejb32 tests to arquillian/junit5

### DIFF
--- a/ejb32/pom.xml
+++ b/ejb32/pom.xml
@@ -32,6 +32,10 @@
     <name>EJB32</name>
     <description>EJB32</description>
 
+    <properties>
+        <version.jakarta.tck.arquillian>1.0.0-SNAPSHOT</version.jakarta.tck.arquillian>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
@@ -60,6 +64,30 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
+        </dependency>
+        <!-- Junit5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-appclient</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-javatest</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>tck-porting-lib</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
         </dependency>
     </dependencies>
     <build>

--- a/ejb32/rewrite-pom.xml
+++ b/ejb32/rewrite-pom.xml
@@ -1,0 +1,774 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2022, 2024  Contributors to the Eclipse Foundation
+    All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.7</version>
+    </parent>
+
+    <groupId>jakarta.tck</groupId>
+    <artifactId>ejb32-rewrite</artifactId>
+    <version>11.0.0-SNAPSHOT</version>
+    <packaging>pom</packaging>
+    <name>project</name>
+    <description>project</description>
+
+    <properties>
+        <ant.version>1.10.11</ant.version>
+        <arquillian.version>1.8.0.Final</arquillian.version>
+
+        <!-- CDI -->
+        <cdi-api.version>4.0.0</cdi-api.version>
+        <!-- Jakarta Concurrency -->
+        <concurrent-api.version>2.0.0</concurrent-api.version>
+        <!-- Jakarta Persistence -->
+        <jakarta-persistence-api.version>3.2.0-M2</jakarta-persistence-api.version>
+        <jakarta.activation-api.version>2.0.0</jakarta.activation-api.version>
+
+        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
+        <jakarta.authentication-api.version>2.0.0</jakarta.authentication-api.version>
+        <jakarta.authorization-api.version>2.1.0</jakarta.authorization-api.version>
+        <!-- Jakarta Batch -->
+        <jakarta.batch-api.version>2.0.0</jakarta.batch-api.version>
+        <!-- Jakarta Enterprise beans -->
+        <jakarta.ejb-api.version>4.0.0</jakarta.ejb-api.version>
+        <jakarta.el-api.version>6.0.0-M1</jakarta.el-api.version>
+        <jakarta.faces-api.version>3.0.0</jakarta.faces-api.version>
+        <jakarta.inject-api.version>2.0.1</jakarta.inject-api.version>
+        <!-- Jakarta Interceptors -->
+        <jakarta.interceptor-api.version>2.1.0</jakarta.interceptor-api.version>
+        <jakarta.jws-api.version>3.0.0</jakarta.jws-api.version>
+        <jakarta.mail-api.version>2.0.0</jakarta.mail-api.version>
+        <!-- Jakarta Connectors -->
+        <jakarta.resource-api.version>2.0.0</jakarta.resource-api.version>
+        <!-- Jakarta EE Security + Authentication/Authorization -->
+        <jakarta.security.enterprise-api.version>2.0.0</jakarta.security.enterprise-api.version>
+        <jakarta.servlet-api.version>6.0.0</jakarta.servlet-api.version>
+        <!-- Jakarta Transactions -->
+        <jakarta.transaction-api.version>2.0.0</jakarta.transaction-api.version>
+        <jakarta.validation-api.version>3.0.0</jakarta.validation-api.version>
+
+        <jakarta.ws.rs-api.version>3.1.0</jakarta.ws.rs-api.version>
+        <jakarta.xml.bind-api.version>3.0.0</jakarta.xml.bind-api.version>
+        <jakarta.xml.soap-api.version>3.0.0</jakarta.xml.soap-api.version>
+        <jakarta.xml.ws-api.version>4.0.0</jakarta.xml.ws-api.version>
+        <javatest.version>5.0</javatest.version>
+        <jaxb-osgi.version>3.0.0</jaxb-osgi.version>
+        <!-- Jakarta Messaging -->
+        <jms-api.version>3.1.0</jms-api.version>
+        <json.bind-api.version>3.0.0</json.bind-api.version>
+        <!-- Jakarta JSON -->
+        <jsonp-api.version>2.1.1</jsonp-api.version>
+        <!-- Jakarta Server Pages -->
+        <jsp-api.version>3.1.0</jsp-api.version>
+        <!-- Jakarta Standard Tag Library -->
+        <jstl-api.version>2.0.0</jstl-api.version>
+        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <slf4j.version>2.0.0</slf4j.version>
+        <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
+        <version.openrewrite>8.24.0</version.openrewrite>
+        <version.org.jboss.arquillian.core>1.7.2.Final</version.org.jboss.arquillian.core>
+        <webservices-api-osgi.version>3.0.0</webservices-api-osgi.version>
+        <webservices-api.version>3.0.0</webservices-api.version>
+        <webservices-osgi.version>3.0.0</webservices-osgi.version>
+        <webservices-tools.version>3.0.0</webservices-tools.version>
+        <!-- Jakarta WebSocket -->
+        <websocket-api.version>2.2.0</websocket-api.version>
+        <websocket-client-api.version>2.2.0</websocket-client-api.version>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>appclient</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>runtime</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>assembly</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>ejb30</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>ejb30-ws</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>ejb32</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>ejb</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>concurrency</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>connector</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>el</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>integration</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>internal</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>javaee</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>javamail</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jaxrs-platform-tck</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jaxws</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jaxws-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jdbc</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jms</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jpa</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jsf</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jsonb</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jsonp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jsp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jstl</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jta</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jws</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>jws-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>libutil</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>saaj</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>samples</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>servlet</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>signaturetest</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>webservices12</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>webservices13</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>websocket</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>xa</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-httpclient</groupId>
+                <artifactId>commons-httpclient</artifactId>
+                <version>3.1</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-api</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>slf4j-simple</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jcl-over-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.slf4j</groupId>
+                <artifactId>jul-to-slf4j</artifactId>
+                <version>${slf4j.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>javatest</groupId>
+                <artifactId>javatest</artifactId>
+                <version>${javatest.version}</version>
+                <scope>compile</scope>
+                <optional>true</optional>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>web-servlet</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>web-jsp</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>5.9.1</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${arquillian.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-container-test-spi</artifactId>
+                <version>${arquillian.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.arquillian.junit</groupId>
+                <artifactId>arquillian-junit-container</artifactId>
+                <version>${version.org.jboss.arquillian.core}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.activation</groupId>
+                <artifactId>jakarta.activation-api</artifactId>
+                <version>${jakarta.activation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.annotation</groupId>
+                <artifactId>jakarta.annotation-api</artifactId>
+                <version>${jakarta.annotation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.ant</groupId>
+                <artifactId>ant</artifactId>
+                <version>${ant.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>2.10.0</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>3.9</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.authentication</groupId>
+                <artifactId>jakarta.authentication-api</artifactId>
+                <version>${jakarta.authentication-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.authorization</groupId>
+                <artifactId>jakarta.authorization-api</artifactId>
+                <version>${jakarta.authorization-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.batch</groupId>
+                <artifactId>jakarta.batch-api</artifactId>
+                <version>${jakarta.batch-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ejb</groupId>
+                <artifactId>jakarta.ejb-api</artifactId>
+                <version>${jakarta.ejb-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.el</groupId>
+                <artifactId>jakarta.el-api</artifactId>
+                <version>${jakarta.el-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise</groupId>
+                <artifactId>jakarta.enterprise.cdi-api</artifactId>
+                <version>${cdi-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.enterprise.concurrent</groupId>
+                <artifactId>jakarta.enterprise.concurrent-api</artifactId>
+                <version>${concurrent-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.faces</groupId>
+                <artifactId>jakarta.faces-api</artifactId>
+                <version>${jakarta.faces-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.inject</groupId>
+                <artifactId>jakarta.inject-api</artifactId>
+                <version>${jakarta.inject-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.jws</groupId>
+                <artifactId>jakarta.jws-api</artifactId>
+                <version>${jakarta.jws-api.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>jakarta.interceptor</groupId>
+                <artifactId>jakarta.interceptor-api</artifactId>
+                <version>${jakarta.interceptor-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.jms</groupId>
+                <artifactId>jakarta.jms-api</artifactId>
+                <version>${jms-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json.bind</groupId>
+                <artifactId>jakarta.json.bind-api</artifactId>
+                <version>${json.bind-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.json</groupId>
+                <artifactId>jakarta.json-api</artifactId>
+                <version>${jsonp-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.mail</groupId>
+                <artifactId>jakarta.mail-api</artifactId>
+                <version>${jakarta.mail-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.persistence</groupId>
+                <artifactId>jakarta.persistence-api</artifactId>
+                <version>${jakarta-persistence-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.resource</groupId>
+                <artifactId>jakarta.resource-api</artifactId>
+                <version>${jakarta.resource-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.security.enterprise</groupId>
+                <artifactId>jakarta.security.enterprise-api</artifactId>
+                <version>${jakarta.security.enterprise-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>${jakarta.servlet-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet.jsp</groupId>
+                <artifactId>jakarta.servlet.jsp-api</artifactId>
+                <version>${jsp-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.servlet.jsp.jstl</groupId>
+                <artifactId>jakarta.servlet.jsp.jstl-api</artifactId>
+                <version>${jstl-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.transaction</groupId>
+                <artifactId>jakarta.transaction-api</artifactId>
+                <version>${jakarta.transaction-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.validation</groupId>
+                <artifactId>jakarta.validation-api</artifactId>
+                <version>${jakarta.validation-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-client-api</artifactId>
+                <version>${websocket-client-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.websocket</groupId>
+                <artifactId>jakarta.websocket-api</artifactId>
+                <version>${websocket-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.ws.rs</groupId>
+                <artifactId>jakarta.ws.rs-api</artifactId>
+                <version>${jakarta.ws.rs-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.soap</groupId>
+                <artifactId>jakarta.xml.soap-api</artifactId>
+                <version>${jakarta.xml.soap-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.ws</groupId>
+                <artifactId>jakarta.xml.ws-api</artifactId>
+                <version>${jakarta.xml.ws-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.xml.bind</groupId>
+                <artifactId>jakarta.xml.bind-api</artifactId>
+                <version>${jakarta.xml.bind-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-osgi</artifactId>
+                <version>${jaxb-osgi.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.spec.javax.rmi</groupId>
+                <artifactId>jboss-rmi-api_1.0_spec</artifactId>
+                <version>1.0.6.Final</version>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-container-test-api</artifactId>
+                <version>1.8.0.Final</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+    </dependencies>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+            <id>oss.sonatype.org</id>
+            <name>Jetty Snapshot Repository</name>
+            <url>https://oss.sonatype.org/content/repositories/jetty-snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
+
+    <build>
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.12.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.sun.xml.ws</groupId>
+                    <artifactId>jaxws-maven-plugin</artifactId>
+                    <version>4.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>2.5.3</version>
+                    <configuration>
+                        <mavenExecutorId>forked-path</mavenExecutorId>
+                        <preparationGoals>clean install</preparationGoals>
+                        <arguments>-Drelease -Dtck-audit</arguments>
+                    </configuration>
+                </plugin>
+                <!-- Plugin versions since ee4j parent no longer declares them-->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.2.1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.1.1</version>
+                    <configuration>
+                        <doclint>none</doclint>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>exec-maven-plugin</artifactId>
+                    <version>3.2.0</version>
+                    <configuration>
+                        <environmentVariables>
+                            <AS_JAVA>${java.home}</AS_JAVA>
+                            <JAVA_HOME>${java.home}</JAVA_HOME>
+                        </environmentVariables>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>2.8.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.2</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+            </plugins>
+        </pluginManagement>
+
+        <plugins>
+            <plugin>
+                <!--  Run with: mvn -Drewrite.exclusions="$PWD/annotations,$PWD/appclient,$PWD/assembly,$PWD/bin,$PWD/common,$PWD/connector,$PWD/core-profile-tck,$PWD/docker,$PWD/docker-images,$PWD/ejb,$PWD/ejb30,$PWD/ejb30-ws,$PWD/ejb32,$PWD/el,$PWD/glassfish-runner,$PWD/glassfishtck,$PWD/install,$PWD/integration,$PWD/internal,$PWD/jacc,$PWD/javaee,$PWD/javamail,$PWD/jaxrs,$PWD/jaxws,$PWD/jaxws-common,$PWD/jdbc,$PWD/jdbc_extras,$PWD/jms,$PWD/jsonb,$PWD/jsonp,$PWD/jsp,$PWD/jstl,$PWD/jta,$PWD/jws,$PWD/jws,$PWD/common,$PWD/lib,$PWD/libutil,$PWD/notes,$PWD/release,$PWD/runtime,$PWD/saaj,$PWD/samples,$PWD/servlet,$PWD/signaturetest,$PWD/sql,$PWD/src,$PWD/user_guides,$PWD/webartifacts,$PWD/webservices12,$PWD/webservices13,$PWD/websocket,$PWD/xa" org.openrewrite.maven:rewrite-maven-plugin:runNoFork  2>&1 | tee /tmp/tck.log
+                -->
+                <groupId>org.openrewrite.maven</groupId>
+                <artifactId>rewrite-maven-plugin</artifactId>
+                <version>5.32.1</version>
+                <configuration>
+                    <activeRecipes>
+                        <recipe>tck.jakarta.platform.rewrite.GenerateNewTestClassRecipe</recipe>
+                    </activeRecipes>
+                </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>jakarta.tck</groupId>
+                        <artifactId>tck-rewrite-tools</artifactId>
+                        <version>1.0.0-SNAPSHOT</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-core</artifactId>
+                        <version>8.24.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>jakarta.xml.bind</groupId>
+                        <artifactId>jakarta.xml.bind-api</artifactId>
+                        <version>2.3.2</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-testing-frameworks</artifactId>
+                        <version>2.6.0</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite.recipe</groupId>
+                        <artifactId>rewrite-github-actions</artifactId>
+                        <version>2.1.7</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-17</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>org.openrewrite</groupId>
+                        <artifactId>rewrite-java-test</artifactId>
+                        <version>${version.openrewrite}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/ClientEjblitejsfTest.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.concurrency;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.WriteSingletonTimerBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.TimerIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.LockSingletonTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.ReadSingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void lookupTimerService() throws java.lang.InterruptedException, java.util.concurrent.ExecutionException {
+            super.lookupTimerService();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void writeLockTimeout() {
+            super.writeLockTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/ClientEjblitejspTest.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.concurrency;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.WriteSingletonTimerBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.TimerIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.LockSingletonTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.ReadSingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void lookupTimerService() throws java.lang.InterruptedException, java.util.concurrent.ExecutionException {
+            super.lookupTimerService();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void writeLockTimeout() {
+            super.writeLockTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/ClientEjbliteservlet2Test.java
@@ -1,0 +1,117 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.concurrency;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.WriteSingletonTimerBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.TimerIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.LockSingletonTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.ReadSingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void lookupTimerService() throws java.lang.InterruptedException, java.util.concurrent.ExecutionException {
+            super.lookupTimerService();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void writeLockTimeout() {
+            super.writeLockTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/ClientEjbliteservletTest.java
@@ -1,0 +1,114 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.concurrency;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.WriteSingletonTimerBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.TimerIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.LockSingletonTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.ReadSingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void lookupTimerService() throws java.lang.InterruptedException, java.util.concurrent.ExecutionException {
+            super.lookupTimerService();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void writeLockTimeout() {
+            super.writeLockTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/JsfClientEjblitejsfTest.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.concurrency;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.WriteSingletonTimerBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.TimerIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.LockSingletonTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.ReadSingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void lookupTimerService() throws java.lang.InterruptedException, java.util.concurrent.ExecutionException {
+            super.lookupTimerService();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void writeLockTimeout() {
+            super.writeLockTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/JsfClientEjblitejspTest.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.concurrency;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.WriteSingletonTimerBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.TimerIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.LockSingletonTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.ReadSingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void lookupTimerService() throws java.lang.InterruptedException, java.util.concurrent.ExecutionException {
+            super.lookupTimerService();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void writeLockTimeout() {
+            super.writeLockTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,117 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.concurrency;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.WriteSingletonTimerBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.TimerIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.LockSingletonTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.ReadSingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void lookupTimerService() throws java.lang.InterruptedException, java.util.concurrent.ExecutionException {
+            super.lookupTimerService();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void writeLockTimeout() {
+            super.writeLockTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/concurrency/JsfClientEjbliteservletTest.java
@@ -1,0 +1,114 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.concurrency;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_concurrency_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.WriteSingletonTimerBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.TimerIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.LockSingletonTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.ReadSingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_basic_concurrency_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void lookupTimerService() throws java.lang.InterruptedException, java.util.concurrent.ExecutionException {
+            super.lookupTimerService();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void writeLockTimeout() {
+            super.writeLockTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/ClientEjblitejsfTest.java
@@ -1,0 +1,149 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.sharing;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.StatelessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SharingTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.TimerIF.class
+            );
+            ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client$1.class");
+            ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient$1.class");
+
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerRollbackStateless() {
+            super.createTimerRollbackStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerRollbackSingleton() {
+            super.createTimerRollbackSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createVerifyRecurringTimerStateless() {
+            super.createVerifyRecurringTimerStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createVerifyRecurringTimerSingleton() {
+            super.createVerifyRecurringTimerSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void accessTimersStateless() {
+            super.accessTimersStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void accessTimersSingleton() {
+            super.accessTimersSingleton();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/ClientEjblitejspTest.java
@@ -1,0 +1,149 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.sharing;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.StatelessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SharingTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.TimerIF.class
+            );
+            ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client$1.class");
+            ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient$1.class");
+
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerRollbackStateless() {
+            super.createTimerRollbackStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerRollbackSingleton() {
+            super.createTimerRollbackSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createVerifyRecurringTimerStateless() {
+            super.createVerifyRecurringTimerStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createVerifyRecurringTimerSingleton() {
+            super.createVerifyRecurringTimerSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void accessTimersStateless() {
+            super.accessTimersStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void accessTimersSingleton() {
+            super.accessTimersSingleton();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/ClientEjbliteservlet2Test.java
@@ -1,0 +1,150 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.sharing;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.StatelessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SharingTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.TimerIF.class
+            );
+            ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client$1.class");
+            ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient$1.class");
+
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerRollbackStateless() {
+            super.createTimerRollbackStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerRollbackSingleton() {
+            super.createTimerRollbackSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createVerifyRecurringTimerStateless() {
+            super.createVerifyRecurringTimerStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createVerifyRecurringTimerSingleton() {
+            super.createVerifyRecurringTimerSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void accessTimersStateless() {
+            super.accessTimersStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void accessTimersSingleton() {
+            super.accessTimersSingleton();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/ClientEjbliteservletTest.java
@@ -1,0 +1,147 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.sharing;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.StatelessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SharingTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.TimerIF.class
+            );
+            ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client$1.class");
+            ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient$1.class");
+
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerRollbackStateless() {
+            super.createTimerRollbackStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerRollbackSingleton() {
+            super.createTimerRollbackSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createVerifyRecurringTimerStateless() {
+            super.createVerifyRecurringTimerStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createVerifyRecurringTimerSingleton() {
+            super.createVerifyRecurringTimerSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void accessTimersStateless() {
+            super.accessTimersStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void accessTimersSingleton() {
+            super.accessTimersSingleton();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/JsfClientEjblitejsfTest.java
@@ -1,0 +1,149 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.sharing;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.StatelessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SharingTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.TimerIF.class
+            );
+            ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client$1.class");
+            ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient$1.class");
+
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerRollbackStateless() {
+            super.createTimerRollbackStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerRollbackSingleton() {
+            super.createTimerRollbackSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createVerifyRecurringTimerStateless() {
+            super.createVerifyRecurringTimerStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createVerifyRecurringTimerSingleton() {
+            super.createVerifyRecurringTimerSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void accessTimersStateless() {
+            super.accessTimersStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void accessTimersSingleton() {
+            super.accessTimersSingleton();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/JsfClientEjblitejspTest.java
@@ -1,0 +1,149 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.sharing;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.StatelessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SharingTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.TimerIF.class
+            );
+            ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client$1.class");
+            ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient$1.class");
+
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerRollbackStateless() {
+            super.createTimerRollbackStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerRollbackSingleton() {
+            super.createTimerRollbackSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createVerifyRecurringTimerStateless() {
+            super.createVerifyRecurringTimerStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createVerifyRecurringTimerSingleton() {
+            super.createVerifyRecurringTimerSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void accessTimersStateless() {
+            super.accessTimersStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void accessTimersSingleton() {
+            super.accessTimersSingleton();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,150 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.sharing;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.StatelessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SharingTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.TimerIF.class
+            );
+            ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client$1.class");
+            ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient$1.class");
+
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerRollbackStateless() {
+            super.createTimerRollbackStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerRollbackSingleton() {
+            super.createTimerRollbackSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createVerifyRecurringTimerStateless() {
+            super.createVerifyRecurringTimerStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createVerifyRecurringTimerSingleton() {
+            super.createVerifyRecurringTimerSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void accessTimersStateless() {
+            super.accessTimersStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void accessTimersSingleton() {
+            super.accessTimersSingleton();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/sharing/JsfClientEjbliteservletTest.java
@@ -1,0 +1,147 @@
+package com.sun.ts.tests.ejb32.lite.timer.basic.sharing;
+
+import com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_basic_sharing_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_basic_sharing_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.StatelessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SingletonTimerBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.SharingTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.basic.sharing.TimerIF.class
+            );
+            ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.Client$1.class");
+            ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addClass("com.sun.ts.tests.ejb32.lite.timer.basic.sharing.JsfClient$1.class");
+
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_basic_sharing_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerRollbackStateless() {
+            super.createTimerRollbackStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerRollbackSingleton() {
+            super.createTimerRollbackSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createVerifyRecurringTimerStateless() {
+            super.createVerifyRecurringTimerStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createVerifyRecurringTimerSingleton() {
+            super.createVerifyRecurringTimerSingleton();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void accessTimersStateless() {
+            super.accessTimersStateless();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void accessTimersSingleton() {
+            super.accessTimersSingleton();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/ClientEjblitejsfTest.java
@@ -1,0 +1,179 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor4.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutExceptionBean.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor6.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor1.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.MethodOverrideBeanBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutIF.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor5.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutComplementBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverride2Bean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutExceptionBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.InvocationContextMethodsBean.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundTimeoutExceptionAsBusinessMethod() throws java.lang.Exception {
+            super.aroundTimeoutExceptionAsBusinessMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allInterceptors() {
+            super.allInterceptors();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allInterceptorsOverride() {
+            super.allInterceptorsOverride();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allInterceptorsComplement() {
+            super.allInterceptorsComplement();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundTimeoutMethod() {
+            super.aroundTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundTimeoutMethod2() {
+            super.aroundTimeoutMethod2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundTimeoutException() {
+            super.aroundTimeoutException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invocationContextMethods() {
+            super.invocationContextMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/ClientEjblitejspTest.java
@@ -1,0 +1,179 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor4.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutExceptionBean.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor6.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor1.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.MethodOverrideBeanBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutIF.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor5.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutComplementBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverride2Bean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutExceptionBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.InvocationContextMethodsBean.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundTimeoutExceptionAsBusinessMethod() throws java.lang.Exception {
+            super.aroundTimeoutExceptionAsBusinessMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allInterceptors() {
+            super.allInterceptors();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allInterceptorsOverride() {
+            super.allInterceptorsOverride();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allInterceptorsComplement() {
+            super.allInterceptorsComplement();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundTimeoutMethod() {
+            super.aroundTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundTimeoutMethod2() {
+            super.aroundTimeoutMethod2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundTimeoutException() {
+            super.aroundTimeoutException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invocationContextMethods() {
+            super.invocationContextMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/ClientEjbliteservlet2Test.java
@@ -1,0 +1,180 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor4.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutExceptionBean.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor6.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor1.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.MethodOverrideBeanBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutIF.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor5.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutComplementBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverride2Bean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutExceptionBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.InvocationContextMethodsBean.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundTimeoutExceptionAsBusinessMethod() throws java.lang.Exception {
+            super.aroundTimeoutExceptionAsBusinessMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allInterceptors() {
+            super.allInterceptors();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allInterceptorsOverride() {
+            super.allInterceptorsOverride();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allInterceptorsComplement() {
+            super.allInterceptorsComplement();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundTimeoutMethod() {
+            super.aroundTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundTimeoutMethod2() {
+            super.aroundTimeoutMethod2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundTimeoutException() {
+            super.aroundTimeoutException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invocationContextMethods() {
+            super.invocationContextMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/ClientEjbliteservletTest.java
@@ -1,0 +1,177 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor4.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutExceptionBean.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor6.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor1.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.MethodOverrideBeanBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutIF.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor5.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutComplementBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverride2Bean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutExceptionBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.InvocationContextMethodsBean.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundTimeoutExceptionAsBusinessMethod() throws java.lang.Exception {
+            super.aroundTimeoutExceptionAsBusinessMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allInterceptors() {
+            super.allInterceptors();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allInterceptorsOverride() {
+            super.allInterceptorsOverride();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allInterceptorsComplement() {
+            super.allInterceptorsComplement();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundTimeoutMethod() {
+            super.aroundTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundTimeoutMethod2() {
+            super.aroundTimeoutMethod2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundTimeoutException() {
+            super.aroundTimeoutException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invocationContextMethods() {
+            super.invocationContextMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/JsfClientEjblitejsfTest.java
@@ -1,0 +1,179 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor4.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutExceptionBean.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor6.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor1.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.MethodOverrideBeanBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutIF.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor5.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutComplementBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverride2Bean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutExceptionBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.InvocationContextMethodsBean.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundTimeoutExceptionAsBusinessMethod() throws java.lang.Exception {
+            super.aroundTimeoutExceptionAsBusinessMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allInterceptors() {
+            super.allInterceptors();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allInterceptorsOverride() {
+            super.allInterceptorsOverride();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allInterceptorsComplement() {
+            super.allInterceptorsComplement();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundTimeoutMethod() {
+            super.aroundTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundTimeoutMethod2() {
+            super.aroundTimeoutMethod2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundTimeoutException() {
+            super.aroundTimeoutException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invocationContextMethods() {
+            super.invocationContextMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/JsfClientEjblitejspTest.java
@@ -1,0 +1,179 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor4.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutExceptionBean.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor6.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor1.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.MethodOverrideBeanBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutIF.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor5.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutComplementBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverride2Bean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutExceptionBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.InvocationContextMethodsBean.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundTimeoutExceptionAsBusinessMethod() throws java.lang.Exception {
+            super.aroundTimeoutExceptionAsBusinessMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allInterceptors() {
+            super.allInterceptors();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allInterceptorsOverride() {
+            super.allInterceptorsOverride();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allInterceptorsComplement() {
+            super.allInterceptorsComplement();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundTimeoutMethod() {
+            super.aroundTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundTimeoutMethod2() {
+            super.aroundTimeoutMethod2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundTimeoutException() {
+            super.aroundTimeoutException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invocationContextMethods() {
+            super.invocationContextMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,180 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor4.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutExceptionBean.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor6.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor1.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.MethodOverrideBeanBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutIF.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor5.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutComplementBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverride2Bean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutExceptionBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.InvocationContextMethodsBean.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundTimeoutExceptionAsBusinessMethod() throws java.lang.Exception {
+            super.aroundTimeoutExceptionAsBusinessMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allInterceptors() {
+            super.allInterceptors();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allInterceptorsOverride() {
+            super.allInterceptorsOverride();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allInterceptorsComplement() {
+            super.allInterceptorsComplement();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundTimeoutMethod() {
+            super.aroundTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundTimeoutMethod2() {
+            super.aroundTimeoutMethod2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundTimeoutException() {
+            super.aroundTimeoutException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invocationContextMethods() {
+            super.invocationContextMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/annotated/JsfClientEjbliteservletTest.java
@@ -1,0 +1,177 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor4.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutExceptionBean.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor6.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor1.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.MethodOverrideBeanBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutIF.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor5.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.Interceptor3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutOverrideBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.AroundTimeoutComplementBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.MethodOverride2Bean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.Client.class,
+            com.sun.ts.tests.ejb30.timer.interceptor.aroundtimeout.common.AroundTimeoutExceptionBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.annotated.InvocationContextMethodsBean.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_annotated_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundTimeoutExceptionAsBusinessMethod() throws java.lang.Exception {
+            super.aroundTimeoutExceptionAsBusinessMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allInterceptors() {
+            super.allInterceptors();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allInterceptorsOverride() {
+            super.allInterceptorsOverride();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allInterceptorsComplement() {
+            super.allInterceptorsComplement();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundTimeoutMethod() {
+            super.aroundTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundTimeoutMethod2() {
+            super.aroundTimeoutMethod2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundTimeoutException() {
+            super.aroundTimeoutException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invocationContextMethods() {
+            super.invocationContextMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/ClientEjblitejsfTest.java
@@ -1,0 +1,119 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Interceptor1.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void asBusiness() {
+            super.asBusiness();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void asTimeout() {
+            super.asTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/ClientEjblitejspTest.java
@@ -1,0 +1,119 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Interceptor1.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void asBusiness() {
+            super.asBusiness();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void asTimeout() {
+            super.asTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/ClientEjbliteservlet2Test.java
@@ -1,0 +1,120 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Interceptor1.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void asBusiness() {
+            super.asBusiness();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void asTimeout() {
+            super.asTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/ClientEjbliteservletTest.java
@@ -1,0 +1,117 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Interceptor1.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void asBusiness() {
+            super.asBusiness();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void asTimeout() {
+            super.asTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/JsfClientEjblitejsfTest.java
@@ -1,0 +1,119 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Interceptor1.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void asBusiness() {
+            super.asBusiness();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void asTimeout() {
+            super.asTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/JsfClientEjblitejspTest.java
@@ -1,0 +1,119 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Interceptor1.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void asBusiness() {
+            super.asBusiness();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void asTimeout() {
+            super.asTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,120 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Interceptor1.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void asBusiness() {
+            super.asBusiness();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void asTimeout() {
+            super.asTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/aroundtimeout/singleton/dual/JsfClientEjbliteservletTest.java
@@ -1,0 +1,117 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.Interceptor1.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.aroundtimeout.singleton.dual.AroundTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.common.helper.ServiceLocator.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_aroundtimeout_singleton_dual_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void asBusiness() {
+            super.asBusiness();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void asTimeout() {
+            super.asTimeout();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/ClientEjblitejsfTest.java
@@ -1,0 +1,115 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.BusinessTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/ClientEjblitejspTest.java
@@ -1,0 +1,115 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.BusinessTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/ClientEjbliteservlet2Test.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.BusinessTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/ClientEjbliteservletTest.java
@@ -1,0 +1,113 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.BusinessTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/JsfClientEjblitejsfTest.java
@@ -1,0 +1,115 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.BusinessTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/JsfClientEjblitejspTest.java
@@ -1,0 +1,115 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.BusinessTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.BusinessTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/singleton/JsfClientEjbliteservletTest.java
@@ -1,0 +1,113 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.BusinessTimerBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.singleton.JsfClient.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_singleton_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/ClientEjblitejsfTest.java
@@ -1,0 +1,115 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.BusinessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/ClientEjblitejspTest.java
@@ -1,0 +1,115 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.EJBLiteJSPTag.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.BusinessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/ClientEjbliteservlet2Test.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.BusinessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/ClientEjbliteservletTest.java
@@ -1,0 +1,113 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.BusinessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/JsfClientEjblitejsfTest.java
@@ -1,0 +1,115 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.BusinessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/JsfClientEjblitejspTest.java
@@ -1,0 +1,115 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.EJBLiteJSPTag.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.BusinessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.BusinessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/business/stateless/JsfClientEjbliteservletTest.java
@@ -1,0 +1,113 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.InterceptorBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.BusinessTimerBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor1.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor3.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.Interceptor2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.business.common.BusinessTimerBeanBase.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_business_stateless_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundInvokeMethods() {
+            super.aroundInvokeMethods();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/ClientEjblitejsfTest.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void postConstructInBeanClass() {
+            super.postConstructInBeanClass();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void postConstructInInterceptorClasses() {
+            super.postConstructInInterceptorClasses();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundConstructInBeanClass() {
+            super.aroundConstructInBeanClass();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/ClientEjblitejspTest.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void postConstructInBeanClass() {
+            super.postConstructInBeanClass();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void postConstructInInterceptorClasses() {
+            super.postConstructInInterceptorClasses();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundConstructInBeanClass() {
+            super.aroundConstructInBeanClass();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/ClientEjbliteservlet2Test.java
@@ -1,0 +1,117 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void postConstructInBeanClass() {
+            super.postConstructInBeanClass();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void postConstructInInterceptorClasses() {
+            super.postConstructInInterceptorClasses();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundConstructInBeanClass() {
+            super.aroundConstructInBeanClass();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/ClientEjbliteservletTest.java
@@ -1,0 +1,114 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.EJBLiteServletVehicle.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void postConstructInBeanClass() {
+            super.postConstructInBeanClass();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void postConstructInInterceptorClasses() {
+            super.postConstructInInterceptorClasses();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundConstructInBeanClass() {
+            super.aroundConstructInBeanClass();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/JsfClientEjblitejsfTest.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void postConstructInBeanClass() {
+            super.postConstructInBeanClass();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void postConstructInInterceptorClasses() {
+            super.postConstructInInterceptorClasses();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void aroundConstructInBeanClass() {
+            super.aroundConstructInBeanClass();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/JsfClientEjblitejspTest.java
@@ -1,0 +1,116 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void postConstructInBeanClass() {
+            super.postConstructInBeanClass();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void postConstructInInterceptorClasses() {
+            super.postConstructInInterceptorClasses();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void aroundConstructInBeanClass() {
+            super.aroundConstructInBeanClass();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,117 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void postConstructInBeanClass() {
+            super.postConstructInBeanClass();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void postConstructInInterceptorClasses() {
+            super.postConstructInInterceptorClasses();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void aroundConstructInBeanClass() {
+            super.aroundConstructInBeanClass();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/interceptor/lifecycle/singleton/JsfClientEjbliteservletTest.java
@@ -1,0 +1,114 @@
+package com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.EJBLiteServletVehicle.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.interceptor.lifecycle.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_interceptor_lifecycle_singleton_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void postConstructInBeanClass() {
+            super.postConstructInBeanClass();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void postConstructInInterceptorClasses() {
+            super.postConstructInInterceptorClasses();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void aroundConstructInBeanClass() {
+            super.aroundConstructInBeanClass();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/ClientEjblitejsfTest.java
@@ -1,0 +1,141 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void postConstruct() {
+            super.postConstruct();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/ClientEjblitejspTest.java
@@ -1,0 +1,141 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void postConstruct() {
+            super.postConstruct();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/ClientEjbliteservlet2Test.java
@@ -1,0 +1,142 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void postConstruct() {
+            super.postConstruct();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/ClientEjbliteservletTest.java
@@ -1,0 +1,139 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void postConstruct() {
+            super.postConstruct();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/JsfClientEjblitejsfTest.java
@@ -1,0 +1,141 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void postConstruct() {
+            super.postConstruct();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/JsfClientEjblitejspTest.java
@@ -1,0 +1,141 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void postConstruct() {
+            super.postConstruct();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,142 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void postConstruct() {
+            super.postConstruct();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/singleton/JsfClientEjbliteservletTest.java
@@ -1,0 +1,139 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_singleton_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void postConstruct() {
+            super.postConstruct();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/ClientEjblitejsfTest.java
@@ -1,0 +1,133 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/ClientEjblitejspTest.java
@@ -1,0 +1,133 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/ClientEjbliteservlet2Test.java
@@ -1,0 +1,134 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/ClientEjbliteservletTest.java
@@ -1,0 +1,131 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/JsfClientEjblitejsfTest.java
@@ -1,0 +1,133 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/JsfClientEjblitejspTest.java
@@ -1,0 +1,133 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,134 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/auto/attr/stateless/JsfClientEjbliteservletTest.java
@@ -1,0 +1,131 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase2.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.ScheduleBeanBase3.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.auto.attr.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_auto_attr_stateless_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerInSuperClassNoParam() {
+            super.autoTimerInSuperClassNoParam();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerNonPersistent() {
+            super.autoTimerNonPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerWithInfo() {
+            super.autoTimerWithInfo();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoTimerWithoutInfo() {
+            super.autoTimerWithoutInfo();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/ClientEjblitejsfTest.java
@@ -1,0 +1,134 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EmptyParamTimeoutBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.WithParamTimeoutBean.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.NoParamTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.timer.schedule.descriptor.common.TimeoutParamIF.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void programmatic() {
+            super.programmatic();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoNoParamTimeoutBean() {
+            super.autoNoParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoEmptyParamTimeoutBean() {
+            super.autoEmptyParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoWithParamTimeoutBean() {
+            super.autoWithParamTimeoutBean();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/ClientEjblitejspTest.java
@@ -1,0 +1,134 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EmptyParamTimeoutBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.WithParamTimeoutBean.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.NoParamTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.timer.schedule.descriptor.common.TimeoutParamIF.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void programmatic() {
+            super.programmatic();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoNoParamTimeoutBean() {
+            super.autoNoParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoEmptyParamTimeoutBean() {
+            super.autoEmptyParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoWithParamTimeoutBean() {
+            super.autoWithParamTimeoutBean();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/ClientEjbliteservlet2Test.java
@@ -1,0 +1,135 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EmptyParamTimeoutBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.WithParamTimeoutBean.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.NoParamTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.timer.schedule.descriptor.common.TimeoutParamIF.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void programmatic() {
+            super.programmatic();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoNoParamTimeoutBean() {
+            super.autoNoParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoEmptyParamTimeoutBean() {
+            super.autoEmptyParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoWithParamTimeoutBean() {
+            super.autoWithParamTimeoutBean();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/ClientEjbliteservletTest.java
@@ -1,0 +1,132 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EmptyParamTimeoutBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.WithParamTimeoutBean.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.NoParamTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.timer.schedule.descriptor.common.TimeoutParamIF.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void programmatic() {
+            super.programmatic();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoNoParamTimeoutBean() {
+            super.autoNoParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoEmptyParamTimeoutBean() {
+            super.autoEmptyParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoWithParamTimeoutBean() {
+            super.autoWithParamTimeoutBean();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/JsfClientEjblitejsfTest.java
@@ -1,0 +1,134 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EmptyParamTimeoutBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.WithParamTimeoutBean.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.NoParamTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.timer.schedule.descriptor.common.TimeoutParamIF.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void programmatic() {
+            super.programmatic();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoNoParamTimeoutBean() {
+            super.autoNoParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoEmptyParamTimeoutBean() {
+            super.autoEmptyParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void autoWithParamTimeoutBean() {
+            super.autoWithParamTimeoutBean();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/JsfClientEjblitejspTest.java
@@ -1,0 +1,134 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EmptyParamTimeoutBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.WithParamTimeoutBean.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.NoParamTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.timer.schedule.descriptor.common.TimeoutParamIF.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void programmatic() {
+            super.programmatic();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoNoParamTimeoutBean() {
+            super.autoNoParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoEmptyParamTimeoutBean() {
+            super.autoEmptyParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void autoWithParamTimeoutBean() {
+            super.autoWithParamTimeoutBean();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,135 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EmptyParamTimeoutBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.WithParamTimeoutBean.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.NoParamTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.timer.schedule.descriptor.common.TimeoutParamIF.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void programmatic() {
+            super.programmatic();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoNoParamTimeoutBean() {
+            super.autoNoParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoEmptyParamTimeoutBean() {
+            super.autoEmptyParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void autoWithParamTimeoutBean() {
+            super.autoWithParamTimeoutBean();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/descriptor/stateless/JsfClientEjbliteservletTest.java
@@ -1,0 +1,132 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EmptyParamTimeoutBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.WithParamTimeoutBean.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.NoParamTimeoutBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.descriptor.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb30.timer.schedule.descriptor.common.TimeoutParamIF.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_descriptor_stateless_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void programmatic() {
+            super.programmatic();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoNoParamTimeoutBean() {
+            super.autoNoParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoEmptyParamTimeoutBean() {
+            super.autoEmptyParamTimeoutBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void autoWithParamTimeoutBean() {
+            super.autoWithParamTimeoutBean();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejsfTest.java
@@ -1,0 +1,383 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expire;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startNeverExpires() {
+            super.startNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void endNeverExpires() {
+            super.endNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void endBeforeActualValues() {
+            super.endBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startBeforeActualValues() {
+            super.startBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startInTheFuture() {
+            super.startInTheFuture();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startAfterActualValues() {
+            super.startAfterActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startAfterActualValues2() {
+            super.startAfterActualValues2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allDefaults() {
+            super.allDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timerAccessInTimeoutMethod() {
+            super.timerAccessInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelInTimeoutMethod() {
+            super.cancelInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void leapYears() {
+            super.leapYears();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonth() {
+            super.dayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthNegative() {
+            super.dayOfMonthNegative();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthNthDayFeb() {
+            super.dayOfMonthNthDayFeb();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthNthDayJan() {
+            super.dayOfMonthNthDayJan();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekAll() {
+            super.dayOfWeekAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekSunday() {
+            super.dayOfWeekSunday();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekSunday0To7() {
+            super.dayOfWeekSunday0To7();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekSunday2() {
+            super.dayOfWeekSunday2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekNow() {
+            super.dayOfWeekNow();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekList() {
+            super.dayOfWeekList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekListComplex() {
+            super.dayOfWeekListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekListOverlap() {
+            super.dayOfWeekListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekRange() {
+            super.dayOfWeekRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthList() {
+            super.monthList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthRange() {
+            super.monthRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthListComplex() {
+            super.monthListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthListOverlap() {
+            super.monthListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthAll() {
+            super.monthAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void yearList() {
+            super.yearList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void yearRange() {
+            super.yearRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void yearListComplex() {
+            super.yearListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void yearListOverlap() {
+            super.yearListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementSecond1() {
+            super.incrementSecond1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementSecond2() {
+            super.incrementSecond2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementSecond3() {
+            super.incrementSecond3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementMinute1() {
+            super.incrementMinute1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementMinute2() {
+            super.incrementMinute2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementHour1() {
+            super.incrementHour1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementHour2() {
+            super.incrementHour2();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejspTest.java
@@ -1,0 +1,383 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expire;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.EJBLiteJSPTag.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startNeverExpires() {
+            super.startNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void endNeverExpires() {
+            super.endNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void endBeforeActualValues() {
+            super.endBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startBeforeActualValues() {
+            super.startBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startInTheFuture() {
+            super.startInTheFuture();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startAfterActualValues() {
+            super.startAfterActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startAfterActualValues2() {
+            super.startAfterActualValues2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allDefaults() {
+            super.allDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timerAccessInTimeoutMethod() {
+            super.timerAccessInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelInTimeoutMethod() {
+            super.cancelInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void leapYears() {
+            super.leapYears();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonth() {
+            super.dayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthNegative() {
+            super.dayOfMonthNegative();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthNthDayFeb() {
+            super.dayOfMonthNthDayFeb();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthNthDayJan() {
+            super.dayOfMonthNthDayJan();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekAll() {
+            super.dayOfWeekAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekSunday() {
+            super.dayOfWeekSunday();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekSunday0To7() {
+            super.dayOfWeekSunday0To7();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekSunday2() {
+            super.dayOfWeekSunday2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekNow() {
+            super.dayOfWeekNow();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekList() {
+            super.dayOfWeekList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekListComplex() {
+            super.dayOfWeekListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekListOverlap() {
+            super.dayOfWeekListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekRange() {
+            super.dayOfWeekRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthList() {
+            super.monthList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthRange() {
+            super.monthRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthListComplex() {
+            super.monthListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthListOverlap() {
+            super.monthListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthAll() {
+            super.monthAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void yearList() {
+            super.yearList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void yearRange() {
+            super.yearRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void yearListComplex() {
+            super.yearListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void yearListOverlap() {
+            super.yearListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementSecond1() {
+            super.incrementSecond1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementSecond2() {
+            super.incrementSecond2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementSecond3() {
+            super.incrementSecond3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementMinute1() {
+            super.incrementMinute1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementMinute2() {
+            super.incrementMinute2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementHour1() {
+            super.incrementHour1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementHour2() {
+            super.incrementHour2();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservlet2Test.java
@@ -1,0 +1,384 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expire;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startNeverExpires() {
+            super.startNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void endNeverExpires() {
+            super.endNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void endBeforeActualValues() {
+            super.endBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startBeforeActualValues() {
+            super.startBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startInTheFuture() {
+            super.startInTheFuture();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startAfterActualValues() {
+            super.startAfterActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startAfterActualValues2() {
+            super.startAfterActualValues2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allDefaults() {
+            super.allDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timerAccessInTimeoutMethod() {
+            super.timerAccessInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelInTimeoutMethod() {
+            super.cancelInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void leapYears() {
+            super.leapYears();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonth() {
+            super.dayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthNegative() {
+            super.dayOfMonthNegative();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthNthDayFeb() {
+            super.dayOfMonthNthDayFeb();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthNthDayJan() {
+            super.dayOfMonthNthDayJan();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekAll() {
+            super.dayOfWeekAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekSunday() {
+            super.dayOfWeekSunday();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekSunday0To7() {
+            super.dayOfWeekSunday0To7();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekSunday2() {
+            super.dayOfWeekSunday2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekNow() {
+            super.dayOfWeekNow();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekList() {
+            super.dayOfWeekList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekListComplex() {
+            super.dayOfWeekListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekListOverlap() {
+            super.dayOfWeekListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekRange() {
+            super.dayOfWeekRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthList() {
+            super.monthList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthRange() {
+            super.monthRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthListComplex() {
+            super.monthListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthListOverlap() {
+            super.monthListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthAll() {
+            super.monthAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void yearList() {
+            super.yearList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void yearRange() {
+            super.yearRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void yearListComplex() {
+            super.yearListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void yearListOverlap() {
+            super.yearListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementSecond1() {
+            super.incrementSecond1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementSecond2() {
+            super.incrementSecond2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementSecond3() {
+            super.incrementSecond3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementMinute1() {
+            super.incrementMinute1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementMinute2() {
+            super.incrementMinute2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementHour1() {
+            super.incrementHour1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementHour2() {
+            super.incrementHour2();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservletTest.java
@@ -1,0 +1,381 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expire;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startNeverExpires() {
+            super.startNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void endNeverExpires() {
+            super.endNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void endBeforeActualValues() {
+            super.endBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startBeforeActualValues() {
+            super.startBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startInTheFuture() {
+            super.startInTheFuture();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startAfterActualValues() {
+            super.startAfterActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startAfterActualValues2() {
+            super.startAfterActualValues2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allDefaults() {
+            super.allDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timerAccessInTimeoutMethod() {
+            super.timerAccessInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelInTimeoutMethod() {
+            super.cancelInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void leapYears() {
+            super.leapYears();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonth() {
+            super.dayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthNegative() {
+            super.dayOfMonthNegative();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthNthDayFeb() {
+            super.dayOfMonthNthDayFeb();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthNthDayJan() {
+            super.dayOfMonthNthDayJan();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekAll() {
+            super.dayOfWeekAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekSunday() {
+            super.dayOfWeekSunday();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekSunday0To7() {
+            super.dayOfWeekSunday0To7();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekSunday2() {
+            super.dayOfWeekSunday2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekNow() {
+            super.dayOfWeekNow();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekList() {
+            super.dayOfWeekList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekListComplex() {
+            super.dayOfWeekListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekListOverlap() {
+            super.dayOfWeekListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekRange() {
+            super.dayOfWeekRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthList() {
+            super.monthList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthRange() {
+            super.monthRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthListComplex() {
+            super.monthListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthListOverlap() {
+            super.monthListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthAll() {
+            super.monthAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void yearList() {
+            super.yearList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void yearRange() {
+            super.yearRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void yearListComplex() {
+            super.yearListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void yearListOverlap() {
+            super.yearListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementSecond1() {
+            super.incrementSecond1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementSecond2() {
+            super.incrementSecond2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementSecond3() {
+            super.incrementSecond3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementMinute1() {
+            super.incrementMinute1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementMinute2() {
+            super.incrementMinute2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementHour1() {
+            super.incrementHour1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementHour2() {
+            super.incrementHour2();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejsfTest.java
@@ -1,0 +1,383 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expire;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startNeverExpires() {
+            super.startNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void endNeverExpires() {
+            super.endNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void endBeforeActualValues() {
+            super.endBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startBeforeActualValues() {
+            super.startBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startInTheFuture() {
+            super.startInTheFuture();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startAfterActualValues() {
+            super.startAfterActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void startAfterActualValues2() {
+            super.startAfterActualValues2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allDefaults() {
+            super.allDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timerAccessInTimeoutMethod() {
+            super.timerAccessInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelInTimeoutMethod() {
+            super.cancelInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void leapYears() {
+            super.leapYears();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonth() {
+            super.dayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthNegative() {
+            super.dayOfMonthNegative();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthNthDayFeb() {
+            super.dayOfMonthNthDayFeb();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthNthDayJan() {
+            super.dayOfMonthNthDayJan();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekAll() {
+            super.dayOfWeekAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekSunday() {
+            super.dayOfWeekSunday();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekSunday0To7() {
+            super.dayOfWeekSunday0To7();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekSunday2() {
+            super.dayOfWeekSunday2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekNow() {
+            super.dayOfWeekNow();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekList() {
+            super.dayOfWeekList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekListComplex() {
+            super.dayOfWeekListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekListOverlap() {
+            super.dayOfWeekListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekRange() {
+            super.dayOfWeekRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthList() {
+            super.monthList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthRange() {
+            super.monthRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthListComplex() {
+            super.monthListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthListOverlap() {
+            super.monthListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void monthAll() {
+            super.monthAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void yearList() {
+            super.yearList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void yearRange() {
+            super.yearRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void yearListComplex() {
+            super.yearListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void yearListOverlap() {
+            super.yearListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementSecond1() {
+            super.incrementSecond1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementSecond2() {
+            super.incrementSecond2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementSecond3() {
+            super.incrementSecond3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementMinute1() {
+            super.incrementMinute1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementMinute2() {
+            super.incrementMinute2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementHour1() {
+            super.incrementHour1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void incrementHour2() {
+            super.incrementHour2();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejspTest.java
@@ -1,0 +1,383 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expire;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.EJBLiteJSPTag.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startNeverExpires() {
+            super.startNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void endNeverExpires() {
+            super.endNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void endBeforeActualValues() {
+            super.endBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startBeforeActualValues() {
+            super.startBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startInTheFuture() {
+            super.startInTheFuture();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startAfterActualValues() {
+            super.startAfterActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void startAfterActualValues2() {
+            super.startAfterActualValues2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allDefaults() {
+            super.allDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timerAccessInTimeoutMethod() {
+            super.timerAccessInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelInTimeoutMethod() {
+            super.cancelInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void leapYears() {
+            super.leapYears();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonth() {
+            super.dayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthNegative() {
+            super.dayOfMonthNegative();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthNthDayFeb() {
+            super.dayOfMonthNthDayFeb();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthNthDayJan() {
+            super.dayOfMonthNthDayJan();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekAll() {
+            super.dayOfWeekAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekSunday() {
+            super.dayOfWeekSunday();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekSunday0To7() {
+            super.dayOfWeekSunday0To7();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekSunday2() {
+            super.dayOfWeekSunday2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekNow() {
+            super.dayOfWeekNow();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekList() {
+            super.dayOfWeekList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekListComplex() {
+            super.dayOfWeekListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekListOverlap() {
+            super.dayOfWeekListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekRange() {
+            super.dayOfWeekRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthList() {
+            super.monthList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthRange() {
+            super.monthRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthListComplex() {
+            super.monthListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthListOverlap() {
+            super.monthListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void monthAll() {
+            super.monthAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void yearList() {
+            super.yearList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void yearRange() {
+            super.yearRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void yearListComplex() {
+            super.yearListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void yearListOverlap() {
+            super.yearListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementSecond1() {
+            super.incrementSecond1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementSecond2() {
+            super.incrementSecond2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementSecond3() {
+            super.incrementSecond3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementMinute1() {
+            super.incrementMinute1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementMinute2() {
+            super.incrementMinute2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementHour1() {
+            super.incrementHour1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void incrementHour2() {
+            super.incrementHour2();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,384 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expire;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startNeverExpires() {
+            super.startNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void endNeverExpires() {
+            super.endNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void endBeforeActualValues() {
+            super.endBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startBeforeActualValues() {
+            super.startBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startInTheFuture() {
+            super.startInTheFuture();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startAfterActualValues() {
+            super.startAfterActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void startAfterActualValues2() {
+            super.startAfterActualValues2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allDefaults() {
+            super.allDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timerAccessInTimeoutMethod() {
+            super.timerAccessInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelInTimeoutMethod() {
+            super.cancelInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void leapYears() {
+            super.leapYears();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonth() {
+            super.dayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthNegative() {
+            super.dayOfMonthNegative();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthNthDayFeb() {
+            super.dayOfMonthNthDayFeb();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthNthDayJan() {
+            super.dayOfMonthNthDayJan();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekAll() {
+            super.dayOfWeekAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekSunday() {
+            super.dayOfWeekSunday();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekSunday0To7() {
+            super.dayOfWeekSunday0To7();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekSunday2() {
+            super.dayOfWeekSunday2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekNow() {
+            super.dayOfWeekNow();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekList() {
+            super.dayOfWeekList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekListComplex() {
+            super.dayOfWeekListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekListOverlap() {
+            super.dayOfWeekListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekRange() {
+            super.dayOfWeekRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthList() {
+            super.monthList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthRange() {
+            super.monthRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthListComplex() {
+            super.monthListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthListOverlap() {
+            super.monthListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void monthAll() {
+            super.monthAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void yearList() {
+            super.yearList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void yearRange() {
+            super.yearRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void yearListComplex() {
+            super.yearListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void yearListOverlap() {
+            super.yearListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementSecond1() {
+            super.incrementSecond1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementSecond2() {
+            super.incrementSecond2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementSecond3() {
+            super.incrementSecond3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementMinute1() {
+            super.incrementMinute1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementMinute2() {
+            super.incrementMinute2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementHour1() {
+            super.incrementHour1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void incrementHour2() {
+            super.incrementHour2();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjbliteservletTest.java
@@ -1,0 +1,381 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expire;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startNeverExpires() {
+            super.startNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void endNeverExpires() {
+            super.endNeverExpires();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void endBeforeActualValues() {
+            super.endBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startBeforeActualValues() {
+            super.startBeforeActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startInTheFuture() {
+            super.startInTheFuture();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startAfterActualValues() {
+            super.startAfterActualValues();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void startAfterActualValues2() {
+            super.startAfterActualValues2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allDefaults() {
+            super.allDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timerAccessInTimeoutMethod() {
+            super.timerAccessInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelInTimeoutMethod() {
+            super.cancelInTimeoutMethod();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void leapYears() {
+            super.leapYears();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonth() {
+            super.dayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthNegative() {
+            super.dayOfMonthNegative();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthNthDayFeb() {
+            super.dayOfMonthNthDayFeb();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthNthDayJan() {
+            super.dayOfMonthNthDayJan();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekAll() {
+            super.dayOfWeekAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekSunday() {
+            super.dayOfWeekSunday();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekSunday0To7() {
+            super.dayOfWeekSunday0To7();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekSunday2() {
+            super.dayOfWeekSunday2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekNow() {
+            super.dayOfWeekNow();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekList() {
+            super.dayOfWeekList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekListComplex() {
+            super.dayOfWeekListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekListOverlap() {
+            super.dayOfWeekListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekRange() {
+            super.dayOfWeekRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthList() {
+            super.monthList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthRange() {
+            super.monthRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthListComplex() {
+            super.monthListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthListOverlap() {
+            super.monthListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void monthAll() {
+            super.monthAll();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void yearList() {
+            super.yearList();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void yearRange() {
+            super.yearRange();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void yearListComplex() {
+            super.yearListComplex();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void yearListOverlap() {
+            super.yearListOverlap();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementSecond1() {
+            super.incrementSecond1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementSecond2() {
+            super.incrementSecond2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementSecond3() {
+            super.incrementSecond3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementMinute1() {
+            super.incrementMinute1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementMinute2() {
+            super.incrementMinute2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementHour1() {
+            super.incrementHour1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void incrementHour2() {
+            super.incrementHour2();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ClientEjblitejsfTest.java
@@ -1,0 +1,362 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validSecondValuesInt() {
+            super.validSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validSecondValuesString() {
+            super.validSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validMinuteValuesInt() {
+            super.validMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validMinuteValuesString() {
+            super.validMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validHourValuesInt() {
+            super.validHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validHourValuesString() {
+            super.validHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validMonthValuesInt() {
+            super.validMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validMonthValuesString() {
+            super.validMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validYearValuesInt() {
+            super.validYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validYearValuesString() {
+            super.validYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validDayOfMonthValuesInt() {
+            super.validDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validDayOfMonthValuesString() {
+            super.validDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validDayOfWeekValuesInt() {
+            super.validDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validDayOfWeekValuesString() {
+            super.validDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidSecondValuesInt() {
+            super.invalidSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidSecondValuesString() {
+            super.invalidSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidMinuteValuesInt() {
+            super.invalidMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidMinuteValuesString() {
+            super.invalidMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidHourValuesInt() {
+            super.invalidHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidHourValuesString() {
+            super.invalidHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidMonthValuesInt() {
+            super.invalidMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidMonthValuesString() {
+            super.invalidMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidYearValuesInt() {
+            super.invalidYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidYearValuesString() {
+            super.invalidYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidDayOfMonthValuesInt() {
+            super.invalidDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidDayOfMonthValuesString() {
+            super.invalidDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidDayOfWeekValuesInt() {
+            super.invalidDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidDayOfWeekValuesString() {
+            super.invalidDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void leapYear() {
+            super.leapYear();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void attributeDefaults() {
+            super.attributeDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthOverDayOfWeek() {
+            super.dayOfMonthOverDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekOverDayOfMonth() {
+            super.dayOfWeekOverDayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthAndDayOfWeek() {
+            super.dayOfMonthAndDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validStart() {
+            super.validStart();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validEnd() {
+            super.validEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validStartEnd() {
+            super.validStartEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validTimeZone() {
+            super.validTimeZone();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ClientEjblitejspTest.java
@@ -1,0 +1,362 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validSecondValuesInt() {
+            super.validSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validSecondValuesString() {
+            super.validSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validMinuteValuesInt() {
+            super.validMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validMinuteValuesString() {
+            super.validMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validHourValuesInt() {
+            super.validHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validHourValuesString() {
+            super.validHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validMonthValuesInt() {
+            super.validMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validMonthValuesString() {
+            super.validMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validYearValuesInt() {
+            super.validYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validYearValuesString() {
+            super.validYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validDayOfMonthValuesInt() {
+            super.validDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validDayOfMonthValuesString() {
+            super.validDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validDayOfWeekValuesInt() {
+            super.validDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validDayOfWeekValuesString() {
+            super.validDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidSecondValuesInt() {
+            super.invalidSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidSecondValuesString() {
+            super.invalidSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidMinuteValuesInt() {
+            super.invalidMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidMinuteValuesString() {
+            super.invalidMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidHourValuesInt() {
+            super.invalidHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidHourValuesString() {
+            super.invalidHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidMonthValuesInt() {
+            super.invalidMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidMonthValuesString() {
+            super.invalidMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidYearValuesInt() {
+            super.invalidYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidYearValuesString() {
+            super.invalidYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidDayOfMonthValuesInt() {
+            super.invalidDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidDayOfMonthValuesString() {
+            super.invalidDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidDayOfWeekValuesInt() {
+            super.invalidDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidDayOfWeekValuesString() {
+            super.invalidDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void leapYear() {
+            super.leapYear();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void attributeDefaults() {
+            super.attributeDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthOverDayOfWeek() {
+            super.dayOfMonthOverDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekOverDayOfMonth() {
+            super.dayOfWeekOverDayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthAndDayOfWeek() {
+            super.dayOfMonthAndDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validStart() {
+            super.validStart();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validEnd() {
+            super.validEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validStartEnd() {
+            super.validStartEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validTimeZone() {
+            super.validTimeZone();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ClientEjbliteservlet2Test.java
@@ -1,0 +1,363 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validSecondValuesInt() {
+            super.validSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validSecondValuesString() {
+            super.validSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validMinuteValuesInt() {
+            super.validMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validMinuteValuesString() {
+            super.validMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validHourValuesInt() {
+            super.validHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validHourValuesString() {
+            super.validHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validMonthValuesInt() {
+            super.validMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validMonthValuesString() {
+            super.validMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validYearValuesInt() {
+            super.validYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validYearValuesString() {
+            super.validYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validDayOfMonthValuesInt() {
+            super.validDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validDayOfMonthValuesString() {
+            super.validDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validDayOfWeekValuesInt() {
+            super.validDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validDayOfWeekValuesString() {
+            super.validDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidSecondValuesInt() {
+            super.invalidSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidSecondValuesString() {
+            super.invalidSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidMinuteValuesInt() {
+            super.invalidMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidMinuteValuesString() {
+            super.invalidMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidHourValuesInt() {
+            super.invalidHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidHourValuesString() {
+            super.invalidHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidMonthValuesInt() {
+            super.invalidMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidMonthValuesString() {
+            super.invalidMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidYearValuesInt() {
+            super.invalidYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidYearValuesString() {
+            super.invalidYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidDayOfMonthValuesInt() {
+            super.invalidDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidDayOfMonthValuesString() {
+            super.invalidDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidDayOfWeekValuesInt() {
+            super.invalidDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidDayOfWeekValuesString() {
+            super.invalidDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void leapYear() {
+            super.leapYear();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void attributeDefaults() {
+            super.attributeDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthOverDayOfWeek() {
+            super.dayOfMonthOverDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekOverDayOfMonth() {
+            super.dayOfWeekOverDayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthAndDayOfWeek() {
+            super.dayOfMonthAndDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validStart() {
+            super.validStart();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validEnd() {
+            super.validEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validStartEnd() {
+            super.validStartEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validTimeZone() {
+            super.validTimeZone();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ClientEjbliteservletTest.java
@@ -1,0 +1,360 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validSecondValuesInt() {
+            super.validSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validSecondValuesString() {
+            super.validSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validMinuteValuesInt() {
+            super.validMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validMinuteValuesString() {
+            super.validMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validHourValuesInt() {
+            super.validHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validHourValuesString() {
+            super.validHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validMonthValuesInt() {
+            super.validMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validMonthValuesString() {
+            super.validMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validYearValuesInt() {
+            super.validYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validYearValuesString() {
+            super.validYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validDayOfMonthValuesInt() {
+            super.validDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validDayOfMonthValuesString() {
+            super.validDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validDayOfWeekValuesInt() {
+            super.validDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validDayOfWeekValuesString() {
+            super.validDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidSecondValuesInt() {
+            super.invalidSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidSecondValuesString() {
+            super.invalidSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidMinuteValuesInt() {
+            super.invalidMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidMinuteValuesString() {
+            super.invalidMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidHourValuesInt() {
+            super.invalidHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidHourValuesString() {
+            super.invalidHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidMonthValuesInt() {
+            super.invalidMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidMonthValuesString() {
+            super.invalidMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidYearValuesInt() {
+            super.invalidYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidYearValuesString() {
+            super.invalidYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidDayOfMonthValuesInt() {
+            super.invalidDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidDayOfMonthValuesString() {
+            super.invalidDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidDayOfWeekValuesInt() {
+            super.invalidDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidDayOfWeekValuesString() {
+            super.invalidDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void leapYear() {
+            super.leapYear();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void attributeDefaults() {
+            super.attributeDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthOverDayOfWeek() {
+            super.dayOfMonthOverDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekOverDayOfMonth() {
+            super.dayOfWeekOverDayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthAndDayOfWeek() {
+            super.dayOfMonthAndDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validStart() {
+            super.validStart();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validEnd() {
+            super.validEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validStartEnd() {
+            super.validStartEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validTimeZone() {
+            super.validTimeZone();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/JsfClientEjblitejsfTest.java
@@ -1,0 +1,362 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validSecondValuesInt() {
+            super.validSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validSecondValuesString() {
+            super.validSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validMinuteValuesInt() {
+            super.validMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validMinuteValuesString() {
+            super.validMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validHourValuesInt() {
+            super.validHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validHourValuesString() {
+            super.validHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validMonthValuesInt() {
+            super.validMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validMonthValuesString() {
+            super.validMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validYearValuesInt() {
+            super.validYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validYearValuesString() {
+            super.validYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validDayOfMonthValuesInt() {
+            super.validDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validDayOfMonthValuesString() {
+            super.validDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validDayOfWeekValuesInt() {
+            super.validDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validDayOfWeekValuesString() {
+            super.validDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidSecondValuesInt() {
+            super.invalidSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidSecondValuesString() {
+            super.invalidSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidMinuteValuesInt() {
+            super.invalidMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidMinuteValuesString() {
+            super.invalidMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidHourValuesInt() {
+            super.invalidHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidHourValuesString() {
+            super.invalidHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidMonthValuesInt() {
+            super.invalidMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidMonthValuesString() {
+            super.invalidMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidYearValuesInt() {
+            super.invalidYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidYearValuesString() {
+            super.invalidYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidDayOfMonthValuesInt() {
+            super.invalidDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidDayOfMonthValuesString() {
+            super.invalidDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidDayOfWeekValuesInt() {
+            super.invalidDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void invalidDayOfWeekValuesString() {
+            super.invalidDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void leapYear() {
+            super.leapYear();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void attributeDefaults() {
+            super.attributeDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthOverDayOfWeek() {
+            super.dayOfMonthOverDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfWeekOverDayOfMonth() {
+            super.dayOfWeekOverDayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void dayOfMonthAndDayOfWeek() {
+            super.dayOfMonthAndDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validStart() {
+            super.validStart();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validEnd() {
+            super.validEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validStartEnd() {
+            super.validStartEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void validTimeZone() {
+            super.validTimeZone();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/JsfClientEjblitejspTest.java
@@ -1,0 +1,362 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validSecondValuesInt() {
+            super.validSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validSecondValuesString() {
+            super.validSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validMinuteValuesInt() {
+            super.validMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validMinuteValuesString() {
+            super.validMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validHourValuesInt() {
+            super.validHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validHourValuesString() {
+            super.validHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validMonthValuesInt() {
+            super.validMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validMonthValuesString() {
+            super.validMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validYearValuesInt() {
+            super.validYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validYearValuesString() {
+            super.validYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validDayOfMonthValuesInt() {
+            super.validDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validDayOfMonthValuesString() {
+            super.validDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validDayOfWeekValuesInt() {
+            super.validDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validDayOfWeekValuesString() {
+            super.validDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidSecondValuesInt() {
+            super.invalidSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidSecondValuesString() {
+            super.invalidSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidMinuteValuesInt() {
+            super.invalidMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidMinuteValuesString() {
+            super.invalidMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidHourValuesInt() {
+            super.invalidHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidHourValuesString() {
+            super.invalidHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidMonthValuesInt() {
+            super.invalidMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidMonthValuesString() {
+            super.invalidMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidYearValuesInt() {
+            super.invalidYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidYearValuesString() {
+            super.invalidYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidDayOfMonthValuesInt() {
+            super.invalidDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidDayOfMonthValuesString() {
+            super.invalidDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidDayOfWeekValuesInt() {
+            super.invalidDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void invalidDayOfWeekValuesString() {
+            super.invalidDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void leapYear() {
+            super.leapYear();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void attributeDefaults() {
+            super.attributeDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthOverDayOfWeek() {
+            super.dayOfMonthOverDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfWeekOverDayOfMonth() {
+            super.dayOfWeekOverDayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void dayOfMonthAndDayOfWeek() {
+            super.dayOfMonthAndDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validStart() {
+            super.validStart();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validEnd() {
+            super.validEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validStartEnd() {
+            super.validStartEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void validTimeZone() {
+            super.validTimeZone();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,363 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validSecondValuesInt() {
+            super.validSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validSecondValuesString() {
+            super.validSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validMinuteValuesInt() {
+            super.validMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validMinuteValuesString() {
+            super.validMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validHourValuesInt() {
+            super.validHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validHourValuesString() {
+            super.validHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validMonthValuesInt() {
+            super.validMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validMonthValuesString() {
+            super.validMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validYearValuesInt() {
+            super.validYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validYearValuesString() {
+            super.validYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validDayOfMonthValuesInt() {
+            super.validDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validDayOfMonthValuesString() {
+            super.validDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validDayOfWeekValuesInt() {
+            super.validDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validDayOfWeekValuesString() {
+            super.validDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidSecondValuesInt() {
+            super.invalidSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidSecondValuesString() {
+            super.invalidSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidMinuteValuesInt() {
+            super.invalidMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidMinuteValuesString() {
+            super.invalidMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidHourValuesInt() {
+            super.invalidHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidHourValuesString() {
+            super.invalidHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidMonthValuesInt() {
+            super.invalidMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidMonthValuesString() {
+            super.invalidMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidYearValuesInt() {
+            super.invalidYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidYearValuesString() {
+            super.invalidYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidDayOfMonthValuesInt() {
+            super.invalidDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidDayOfMonthValuesString() {
+            super.invalidDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidDayOfWeekValuesInt() {
+            super.invalidDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void invalidDayOfWeekValuesString() {
+            super.invalidDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void leapYear() {
+            super.leapYear();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void attributeDefaults() {
+            super.attributeDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthOverDayOfWeek() {
+            super.dayOfMonthOverDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfWeekOverDayOfMonth() {
+            super.dayOfWeekOverDayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void dayOfMonthAndDayOfWeek() {
+            super.dayOfMonthAndDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validStart() {
+            super.validStart();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validEnd() {
+            super.validEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validStartEnd() {
+            super.validStartEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void validTimeZone() {
+            super.validTimeZone();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/JsfClientEjbliteservletTest.java
@@ -1,0 +1,360 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.Client.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.annotated.ScheduleBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_annotated_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validSecondValuesInt() {
+            super.validSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validSecondValuesString() {
+            super.validSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validMinuteValuesInt() {
+            super.validMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validMinuteValuesString() {
+            super.validMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validHourValuesInt() {
+            super.validHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validHourValuesString() {
+            super.validHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validMonthValuesInt() {
+            super.validMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validMonthValuesString() {
+            super.validMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validYearValuesInt() {
+            super.validYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validYearValuesString() {
+            super.validYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validDayOfMonthValuesInt() {
+            super.validDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validDayOfMonthValuesString() {
+            super.validDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validDayOfWeekValuesInt() {
+            super.validDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validDayOfWeekValuesString() {
+            super.validDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidSecondValuesInt() {
+            super.invalidSecondValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidSecondValuesString() {
+            super.invalidSecondValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidMinuteValuesInt() {
+            super.invalidMinuteValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidMinuteValuesString() {
+            super.invalidMinuteValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidHourValuesInt() {
+            super.invalidHourValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidHourValuesString() {
+            super.invalidHourValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidMonthValuesInt() {
+            super.invalidMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidMonthValuesString() {
+            super.invalidMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidYearValuesInt() {
+            super.invalidYearValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidYearValuesString() {
+            super.invalidYearValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidDayOfMonthValuesInt() {
+            super.invalidDayOfMonthValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidDayOfMonthValuesString() {
+            super.invalidDayOfMonthValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidDayOfWeekValuesInt() {
+            super.invalidDayOfWeekValuesInt();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void invalidDayOfWeekValuesString() {
+            super.invalidDayOfWeekValuesString();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void leapYear() {
+            super.leapYear();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void attributeDefaults() {
+            super.attributeDefaults();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthOverDayOfWeek() {
+            super.dayOfMonthOverDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfWeekOverDayOfMonth() {
+            super.dayOfWeekOverDayOfMonth();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void dayOfMonthAndDayOfWeek() {
+            super.dayOfMonthAndDayOfWeek();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validStart() {
+            super.validStart();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validEnd() {
+            super.validEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validStartEnd() {
+            super.validStartEnd();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void validTimeZone() {
+            super.validTimeZone();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/ClientEjblitejsfTest.java
@@ -1,0 +1,138 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.ScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void defaultSchedule() {
+            super.defaultSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void schedule1() {
+            super.schedule1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void schedule2() {
+            super.schedule2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void schedule3() {
+            super.schedule3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void schedule4() {
+            super.schedule4();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/ClientEjblitejspTest.java
@@ -1,0 +1,138 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.ScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void defaultSchedule() {
+            super.defaultSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void schedule1() {
+            super.schedule1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void schedule2() {
+            super.schedule2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void schedule3() {
+            super.schedule3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void schedule4() {
+            super.schedule4();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/ClientEjbliteservlet2Test.java
@@ -1,0 +1,139 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.ScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.EJBLiteServlet2Filter.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void defaultSchedule() {
+            super.defaultSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void schedule1() {
+            super.schedule1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void schedule2() {
+            super.schedule2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void schedule3() {
+            super.schedule3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void schedule4() {
+            super.schedule4();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/ClientEjbliteservletTest.java
@@ -1,0 +1,136 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.ScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void defaultSchedule() {
+            super.defaultSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void schedule1() {
+            super.schedule1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void schedule2() {
+            super.schedule2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void schedule3() {
+            super.schedule3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void schedule4() {
+            super.schedule4();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/JsfClientEjblitejsfTest.java
@@ -1,0 +1,138 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.ScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void defaultSchedule() {
+            super.defaultSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void schedule1() {
+            super.schedule1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void schedule2() {
+            super.schedule2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void schedule3() {
+            super.schedule3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void schedule4() {
+            super.schedule4();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/JsfClientEjblitejspTest.java
@@ -1,0 +1,138 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.ScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void defaultSchedule() {
+            super.defaultSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void schedule1() {
+            super.schedule1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void schedule2() {
+            super.schedule2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void schedule3() {
+            super.schedule3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void schedule4() {
+            super.schedule4();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,139 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.ScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.EJBLiteServlet2Filter.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void defaultSchedule() {
+            super.defaultSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void schedule1() {
+            super.schedule1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void schedule2() {
+            super.schedule2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void schedule3() {
+            super.schedule3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void schedule4() {
+            super.schedule4();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/descriptor/JsfClientEjbliteservletTest.java
@@ -1,0 +1,136 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.ScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.expression.descriptor.Client.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_expression_descriptor_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void defaultSchedule() {
+            super.defaultSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void schedule1() {
+            super.schedule1();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void schedule2() {
+            super.schedule2();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void schedule3() {
+            super.schedule3();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void schedule4() {
+            super.schedule4();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjblitejsfTest.java
@@ -1,0 +1,159 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timerHandle() throws java.io.IOException, java.lang.ClassNotFoundException {
+            super.timerHandle();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timerHandleIllegalStateException() {
+            super.timerHandleIllegalStateException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void isCalendarTimerAndGetSchedule() {
+            super.isCalendarTimerAndGetSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timerEquals() {
+            super.timerEquals();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createAndComplete() {
+            super.createAndComplete();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void completeAndNoSuchObjectLocalException() {
+            super.completeAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelAndNoSuchObjectLocalException() {
+            super.cancelAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelWithTxAndNoSuchObjectLocalException() {
+            super.cancelWithTxAndNoSuchObjectLocalException();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjblitejspTest.java
@@ -1,0 +1,159 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timerHandle() throws java.io.IOException, java.lang.ClassNotFoundException {
+            super.timerHandle();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timerHandleIllegalStateException() {
+            super.timerHandleIllegalStateException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void isCalendarTimerAndGetSchedule() {
+            super.isCalendarTimerAndGetSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timerEquals() {
+            super.timerEquals();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createAndComplete() {
+            super.createAndComplete();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void completeAndNoSuchObjectLocalException() {
+            super.completeAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelAndNoSuchObjectLocalException() {
+            super.cancelAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelWithTxAndNoSuchObjectLocalException() {
+            super.cancelWithTxAndNoSuchObjectLocalException();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjbliteservlet2Test.java
@@ -1,0 +1,160 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timerHandle() throws java.io.IOException, java.lang.ClassNotFoundException {
+            super.timerHandle();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timerHandleIllegalStateException() {
+            super.timerHandleIllegalStateException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void isCalendarTimerAndGetSchedule() {
+            super.isCalendarTimerAndGetSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timerEquals() {
+            super.timerEquals();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createAndComplete() {
+            super.createAndComplete();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void completeAndNoSuchObjectLocalException() {
+            super.completeAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelAndNoSuchObjectLocalException() {
+            super.cancelAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelWithTxAndNoSuchObjectLocalException() {
+            super.cancelWithTxAndNoSuchObjectLocalException();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjbliteservletTest.java
@@ -1,0 +1,157 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timerHandle() throws java.io.IOException, java.lang.ClassNotFoundException {
+            super.timerHandle();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timerHandleIllegalStateException() {
+            super.timerHandleIllegalStateException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void isCalendarTimerAndGetSchedule() {
+            super.isCalendarTimerAndGetSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timerEquals() {
+            super.timerEquals();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createAndComplete() {
+            super.createAndComplete();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void completeAndNoSuchObjectLocalException() {
+            super.completeAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelAndNoSuchObjectLocalException() {
+            super.cancelAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelWithTxAndNoSuchObjectLocalException() {
+            super.cancelWithTxAndNoSuchObjectLocalException();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjblitejsfTest.java
@@ -1,0 +1,159 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timerHandle() throws java.io.IOException, java.lang.ClassNotFoundException {
+            super.timerHandle();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timerHandleIllegalStateException() {
+            super.timerHandleIllegalStateException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void isCalendarTimerAndGetSchedule() {
+            super.isCalendarTimerAndGetSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timerEquals() {
+            super.timerEquals();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createAndComplete() {
+            super.createAndComplete();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void completeAndNoSuchObjectLocalException() {
+            super.completeAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelAndNoSuchObjectLocalException() {
+            super.cancelAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelWithTxAndNoSuchObjectLocalException() {
+            super.cancelWithTxAndNoSuchObjectLocalException();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjblitejspTest.java
@@ -1,0 +1,159 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timerHandle() throws java.io.IOException, java.lang.ClassNotFoundException {
+            super.timerHandle();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timerHandleIllegalStateException() {
+            super.timerHandleIllegalStateException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void isCalendarTimerAndGetSchedule() {
+            super.isCalendarTimerAndGetSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timerEquals() {
+            super.timerEquals();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createAndComplete() {
+            super.createAndComplete();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void completeAndNoSuchObjectLocalException() {
+            super.completeAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelAndNoSuchObjectLocalException() {
+            super.cancelAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelWithTxAndNoSuchObjectLocalException() {
+            super.cancelWithTxAndNoSuchObjectLocalException();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,160 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timerHandle() throws java.io.IOException, java.lang.ClassNotFoundException {
+            super.timerHandle();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timerHandleIllegalStateException() {
+            super.timerHandleIllegalStateException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void isCalendarTimerAndGetSchedule() {
+            super.isCalendarTimerAndGetSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timerEquals() {
+            super.timerEquals();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createAndComplete() {
+            super.createAndComplete();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void completeAndNoSuchObjectLocalException() {
+            super.completeAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelAndNoSuchObjectLocalException() {
+            super.cancelAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelWithTxAndNoSuchObjectLocalException() {
+            super.cancelWithTxAndNoSuchObjectLocalException();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjbliteservletTest.java
@@ -1,0 +1,157 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("javaee_web_profile_optional")
+@Tag("ejb_persistent_timer_optional")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.lifecycle.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timerHandle() throws java.io.IOException, java.lang.ClassNotFoundException {
+            super.timerHandle();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timerHandleIllegalStateException() {
+            super.timerHandleIllegalStateException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void isCalendarTimerAndGetSchedule() {
+            super.isCalendarTimerAndGetSchedule();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timerEquals() {
+            super.timerEquals();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createAndComplete() {
+            super.createAndComplete();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void completeAndNoSuchObjectLocalException() {
+            super.completeAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelAndNoSuchObjectLocalException() {
+            super.cancelAndNoSuchObjectLocalException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelWithTxAndNoSuchObjectLocalException() {
+            super.cancelWithTxAndNoSuchObjectLocalException();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/ClientEjblitejsfTest.java
@@ -1,0 +1,202 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tx;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/ClientEjblitejspTest.java
@@ -1,0 +1,202 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tx;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/ClientEjbliteservlet2Test.java
@@ -1,0 +1,203 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tx;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/ClientEjbliteservletTest.java
@@ -1,0 +1,200 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tx;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/JsfClientEjblitejsfTest.java
@@ -1,0 +1,202 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tx;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/JsfClientEjblitejspTest.java
@@ -1,0 +1,202 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tx;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,203 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tx;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tx/JsfClientEjbliteservletTest.java
@@ -1,0 +1,200 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tx;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tx_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tx_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClient.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tx_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/ClientEjblitejsfTest.java
@@ -1,0 +1,200 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/ClientEjblitejspTest.java
@@ -1,0 +1,200 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.EJBLiteJSPTag.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/ClientEjbliteservlet2Test.java
@@ -1,0 +1,201 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/ClientEjbliteservletTest.java
@@ -1,0 +1,198 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/JsfClientEjblitejsfTest.java
@@ -1,0 +1,200 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/JsfClientEjblitejspTest.java
@@ -1,0 +1,200 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.EJBLiteJSPTag.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,201 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/txnonpersistent/JsfClientEjbliteservletTest.java
@@ -1,0 +1,198 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.JsfClient.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleTxBeanBase.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.Client.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBMTBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ClientBase.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.txnonpersistent.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleValues.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tx.ScheduleBean.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ScheduleAttributeType.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_txnonpersistent_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollback() {
+            super.createRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackBMT() {
+            super.createRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackTxPropagation() throws java.lang.Exception {
+            super.createRollbackTxPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createRollbackTxPropagationBMT() throws java.lang.Exception {
+            super.createRollbackTxPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollback() {
+            super.cancelRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackBMT() {
+            super.cancelRollbackBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackPropagation() throws java.lang.Exception {
+            super.cancelRollbackPropagation();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void cancelRollbackPropagationBMT() throws java.lang.Exception {
+            super.cancelRollbackPropagationBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutRollback() {
+            super.timeoutRollback();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutSystemException() {
+            super.timeoutSystemException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void timeoutSystemExceptionBMT() {
+            super.timeoutSystemExceptionBMT();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithoutTx() {
+            super.createTimerWithoutTx();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithoutTxHavingClientTx() throws java.lang.Exception {
+            super.createTimerWithoutTxHavingClientTx();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjblitejsfTest.java
@@ -1,0 +1,136 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tz;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBareBean.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void defaultTZ() {
+            super.defaultTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void shanghaiAndArgentinaTZ() {
+            super.shanghaiAndArgentinaTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void onlyForTZScheduleBareBean() {
+            super.onlyForTZScheduleBareBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allTZ() {
+            super.allTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void expireInLaterTZ() {
+            super.expireInLaterTZ();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjblitejspTest.java
@@ -1,0 +1,136 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tz;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBareBean.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void defaultTZ() {
+            super.defaultTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void shanghaiAndArgentinaTZ() {
+            super.shanghaiAndArgentinaTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void onlyForTZScheduleBareBean() {
+            super.onlyForTZScheduleBareBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allTZ() {
+            super.allTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void expireInLaterTZ() {
+            super.expireInLaterTZ();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjbliteservlet2Test.java
@@ -1,0 +1,137 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tz;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBareBean.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void defaultTZ() {
+            super.defaultTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void shanghaiAndArgentinaTZ() {
+            super.shanghaiAndArgentinaTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void onlyForTZScheduleBareBean() {
+            super.onlyForTZScheduleBareBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allTZ() {
+            super.allTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void expireInLaterTZ() {
+            super.expireInLaterTZ();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjbliteservletTest.java
@@ -1,0 +1,134 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tz;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.EJBLiteServletVehicle.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBareBean.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void defaultTZ() {
+            super.defaultTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void shanghaiAndArgentinaTZ() {
+            super.shanghaiAndArgentinaTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void onlyForTZScheduleBareBean() {
+            super.onlyForTZScheduleBareBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allTZ() {
+            super.allTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void expireInLaterTZ() {
+            super.expireInLaterTZ();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjblitejsfTest.java
@@ -1,0 +1,136 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tz;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBareBean.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void defaultTZ() {
+            super.defaultTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void shanghaiAndArgentinaTZ() {
+            super.shanghaiAndArgentinaTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void onlyForTZScheduleBareBean() {
+            super.onlyForTZScheduleBareBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void allTZ() {
+            super.allTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void expireInLaterTZ() {
+            super.expireInLaterTZ();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjblitejspTest.java
@@ -1,0 +1,136 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tz;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBareBean.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void defaultTZ() {
+            super.defaultTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void shanghaiAndArgentinaTZ() {
+            super.shanghaiAndArgentinaTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void onlyForTZScheduleBareBean() {
+            super.onlyForTZScheduleBareBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void allTZ() {
+            super.allTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void expireInLaterTZ() {
+            super.expireInLaterTZ();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,137 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tz;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBareBean.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.EJBLiteServlet2Filter.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void defaultTZ() {
+            super.defaultTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void shanghaiAndArgentinaTZ() {
+            super.shanghaiAndArgentinaTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void onlyForTZScheduleBareBean() {
+            super.onlyForTZScheduleBareBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void allTZ() {
+            super.allTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void expireInLaterTZ() {
+            super.expireInLaterTZ();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjbliteservletTest.java
@@ -1,0 +1,134 @@
+package com.sun.ts.tests.ejb32.lite.timer.schedule.tz;
+
+import com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web: WEB-INF/ejb-jar.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+        ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web: WEB-INF/ejb-jar.xml,WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.EJBLiteServletVehicle.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBareBean.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.TZScheduleBean.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void defaultTZ() {
+            super.defaultTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void shanghaiAndArgentinaTZ() {
+            super.shanghaiAndArgentinaTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void onlyForTZScheduleBareBean() {
+            super.onlyForTZScheduleBareBean();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void allTZ() {
+            super.allTZ();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void expireInLaterTZ() {
+            super.expireInLaterTZ();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/ClientEjblitejsfTest.java
@@ -1,0 +1,112 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_singleton_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/ClientEjblitejspTest.java
@@ -1,0 +1,112 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_singleton_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/ClientEjbliteservlet2Test.java
@@ -1,0 +1,113 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.EJBLiteServlet2Filter.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/ClientEjbliteservletTest.java
@@ -1,0 +1,110 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/JsfClientEjblitejsfTest.java
@@ -1,0 +1,112 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_singleton_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/JsfClientEjblitejspTest.java
@@ -1,0 +1,112 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_singleton_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,113 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.EJBLiteServlet2Filter.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/singleton/JsfClientEjbliteservletTest.java
@@ -1,0 +1,110 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.singleton;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_singleton_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_singleton_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.JsfClient.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.singleton.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_service_singleton_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/ClientEjblitejsfTest.java
@@ -1,0 +1,112 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_stateless_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/ClientEjblitejspTest.java
@@ -1,0 +1,112 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_stateless_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.EJBLiteJSPTag.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/ClientEjbliteservlet2Test.java
@@ -1,0 +1,113 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.EJBLiteServlet2Filter.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/ClientEjbliteservletTest.java
@@ -1,0 +1,110 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/JsfClientEjblitejsfTest.java
@@ -1,0 +1,112 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_stateless_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/JsfClientEjblitejspTest.java
@@ -1,0 +1,112 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_stateless_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.EJBLiteJSPTag.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,113 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.EJBLiteServlet2Filter.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/service/stateless/JsfClientEjbliteservletTest.java
@@ -1,0 +1,110 @@
+package com.sun.ts.tests.ejb32.lite.timer.service.stateless;
+
+import com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_service_stateless_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_service_stateless_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.JsfClient.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.Client.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.NonPersistentTimerServiceBeanBase.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.stateless.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.JsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.tests.ejb32.lite.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_service_stateless_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/ClientEjblitejsfTest.java
@@ -1,0 +1,164 @@
+package com.sun.ts.tests.ejb32.lite.timer.timerconfig;
+
+import com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_timerconfig_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void isPersistent() {
+            super.isPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void gettersSetters() {
+            super.gettersSetters();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void illegalArgumentException() {
+            super.illegalArgumentException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void resetTimerConfig() {
+            super.resetTimerConfig();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithLong() {
+            super.createTimerWithLong();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithLongRecurring() {
+            super.createTimerWithLongRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithDate() {
+            super.createTimerWithDate();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithDateRecurring() {
+            super.createTimerWithDateRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithSchedule() {
+            super.createTimerWithSchedule();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/ClientEjblitejspTest.java
@@ -1,0 +1,164 @@
+package com.sun.ts.tests.ejb32.lite.timer.timerconfig;
+
+import com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_timerconfig_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void isPersistent() {
+            super.isPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void gettersSetters() {
+            super.gettersSetters();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void illegalArgumentException() {
+            super.illegalArgumentException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void resetTimerConfig() {
+            super.resetTimerConfig();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithLong() {
+            super.createTimerWithLong();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithLongRecurring() {
+            super.createTimerWithLongRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithDate() {
+            super.createTimerWithDate();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithDateRecurring() {
+            super.createTimerWithDateRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithSchedule() {
+            super.createTimerWithSchedule();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/ClientEjbliteservlet2Test.java
@@ -1,0 +1,165 @@
+package com.sun.ts.tests.ejb32.lite.timer.timerconfig;
+
+import com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.EJBLiteServlet2Filter.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void isPersistent() {
+            super.isPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void gettersSetters() {
+            super.gettersSetters();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void illegalArgumentException() {
+            super.illegalArgumentException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void resetTimerConfig() {
+            super.resetTimerConfig();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithLong() {
+            super.createTimerWithLong();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithLongRecurring() {
+            super.createTimerWithLongRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithDate() {
+            super.createTimerWithDate();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithDateRecurring() {
+            super.createTimerWithDateRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithSchedule() {
+            super.createTimerWithSchedule();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/ClientEjbliteservletTest.java
@@ -1,0 +1,162 @@
+package com.sun.ts.tests.ejb32.lite.timer.timerconfig;
+
+import com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void isPersistent() {
+            super.isPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void gettersSetters() {
+            super.gettersSetters();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void illegalArgumentException() {
+            super.illegalArgumentException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void resetTimerConfig() {
+            super.resetTimerConfig();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithLong() {
+            super.createTimerWithLong();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithLongRecurring() {
+            super.createTimerWithLongRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithDate() {
+            super.createTimerWithDate();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithDateRecurring() {
+            super.createTimerWithDateRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithSchedule() {
+            super.createTimerWithSchedule();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/JsfClientEjblitejsfTest.java
@@ -1,0 +1,164 @@
+package com.sun.ts.tests.ejb32.lite.timer.timerconfig;
+
+import com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_timerconfig_ejblitejsf_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle.xhtml");
+            ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void isPersistent() {
+            super.isPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void gettersSetters() {
+            super.gettersSetters();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void illegalArgumentException() {
+            super.illegalArgumentException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void resetTimerConfig() {
+            super.resetTimerConfig();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithLong() {
+            super.createTimerWithLong();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithLongRecurring() {
+            super.createTimerWithLongRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithDate() {
+            super.createTimerWithDate();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithDateRecurring() {
+            super.createTimerWithDateRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsf")
+        public void createTimerWithSchedule() {
+            super.createTimerWithSchedule();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/JsfClientEjblitejspTest.java
@@ -1,0 +1,164 @@
+package com.sun.ts.tests.ejb32.lite.timer.timerconfig;
+
+import com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_timerconfig_ejblitejsp_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.EJBLiteJSPTag.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("//vehicle/ejblitejsp/ejblitejsp_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsp/ejblitejsp_vehicle.jsp");
+            ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void isPersistent() {
+            super.isPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void gettersSetters() {
+            super.gettersSetters();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void illegalArgumentException() {
+            super.illegalArgumentException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void resetTimerConfig() {
+            super.resetTimerConfig();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithLong() {
+            super.createTimerWithLong();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithLongRecurring() {
+            super.createTimerWithLongRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithDate() {
+            super.createTimerWithDate();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithDateRecurring() {
+            super.createTimerWithDateRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejblitejsp")
+        public void createTimerWithSchedule() {
+            super.createTimerWithSchedule();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/JsfClientEjbliteservlet2Test.java
@@ -1,0 +1,165 @@
+package com.sun.ts.tests.ejb32.lite.timer.timerconfig;
+
+import com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.EJBLiteServlet2Filter.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet2_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
+            ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
+
+           archiveProcessor.processWebArchive(ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void isPersistent() {
+            super.isPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void gettersSetters() {
+            super.gettersSetters();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void illegalArgumentException() {
+            super.illegalArgumentException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void resetTimerConfig() {
+            super.resetTimerConfig();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithLong() {
+            super.createTimerWithLong();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithLongRecurring() {
+            super.createTimerWithLongRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithDate() {
+            super.createTimerWithDate();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithDateRecurring() {
+            super.createTimerWithDateRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet2")
+        public void createTimerWithSchedule() {
+            super.createTimerWithSchedule();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/timerconfig/JsfClientEjbliteservletTest.java
@@ -1,0 +1,162 @@
+package com.sun.ts.tests.ejb32.lite.timer.timerconfig;
+
+import com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_web_profile")
+@Tag("javaee_web_profile")
+
+public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient {
+    static final String VEHICLE_ARCHIVE = "ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_lite_timer_timerconfig_ejblitejsf_vehicle_web: WEB-INF/beans.xml,WEB-INF/faces-config.xml,WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejblitejsp_vehicle_web: 
+        ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+        ejb32_lite_timer_timerconfig_ejbliteservlet2_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.Client.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.JsfClientBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigBean.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.JsfClient.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.TimerConfigIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.lite.timer.timerconfig.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = JsfClient.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);
+
+        return ejb32_lite_timer_timerconfig_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void isPersistent() {
+            super.isPersistent();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void gettersSetters() {
+            super.gettersSetters();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void illegalArgumentException() {
+            super.illegalArgumentException();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void resetTimerConfig() {
+            super.resetTimerConfig();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithLong() {
+            super.createTimerWithLong();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithLongRecurring() {
+            super.createTimerWithLongRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithDate() {
+            super.createTimerWithDate();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithDateRecurring() {
+            super.createTimerWithDateRecurring();
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void createTimerWithSchedule() {
+            super.createTimerWithSchedule();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/mdb/modernconnector/ClientTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/mdb/modernconnector/ClientTest.java
@@ -1,0 +1,156 @@
+package com.sun.ts.tests.ejb32.mdb.modernconnector;
+
+import com.sun.ts.tests.ejb32.mdb.modernconnector.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("javaee")
+@Tag("ejb_mdb_optional")
+
+public class ClientTest extends com.sun.ts.tests.ejb32.mdb.modernconnector.Client {
+    /**
+        EE10 Deployment Descriptors:
+        ejb32_mdb_modernconnector: 
+        ejb32_mdb_modernconnector_client: 
+        ejb32_mdb_modernconnector_ejb: 
+        ejb32_mdb_modernconnector_ra: META-INF/ra.xml
+
+        Found Descriptors:
+        Client:
+
+        Ejb:
+
+        Rar:
+
+        Ear:
+
+        */
+        @TargetsContainer("tck-appclient")
+        @OverProtocol("appclient")
+        @Deployment(name = "ejb32_mdb_modernconnector", order = 2)
+        public static EnterpriseArchive createDeployment(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        // Client
+            // the jar with the correct archive name
+            JavaArchive ejb32_mdb_modernconnector_client = ShrinkWrap.create(JavaArchive.class, "ejb32_mdb_modernconnector_client.jar");
+            // The class files
+            ejb32_mdb_modernconnector_client.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.mdb.modernconnector.ejb.EventLoggerRemote.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb30.common.helper.TLogger.class,
+            com.sun.ts.tests.ejb32.mdb.modernconnector.Client.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The application-client.xml descriptor
+            URL resURL = Client.class.getResource("com/sun/ts/tests/ejb32/mdb/modernconnector/ejb32_mdb_modernconnector_client.xml");
+            if(resURL != null) {
+              ejb32_mdb_modernconnector_client.addAsManifestResource(resURL, "application-client.xml");
+            }
+            // The sun-application-client.xml file need to be added or should this be in in the vendor Arquillian extension?
+            resURL = Client.class.getResource("/com/sun/ts/tests/ejb32/mdb/modernconnector/ejb32_mdb_modernconnector_client.jar.sun-application-client.xml");
+            if(resURL != null) {
+              ejb32_mdb_modernconnector_client.addAsManifestResource(resURL, "application-client.xml");
+            }
+            ejb32_mdb_modernconnector_client.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
+            archiveProcessor.processClientArchive(ejb32_mdb_modernconnector_client, Client.class, resURL);
+
+
+        // Ejb
+            // the jar with the correct archive name
+            JavaArchive ejb32_mdb_modernconnector_ejb = ShrinkWrap.create(JavaArchive.class, "ejb32_mdb_modernconnector_ejb.jar");
+            // The class files
+            ejb32_mdb_modernconnector_ejb.addClasses(
+                com.sun.ts.tests.ejb32.mdb.modernconnector.ejb.BatchEventMonitorBean.class,
+                com.sun.ts.tests.ejb32.mdb.modernconnector.ejb.LoggerInterceptor.class,
+                com.sun.ts.tests.ejb32.mdb.modernconnector.ejb.EventLoggerRemote.class,
+                com.sun.ts.tests.ejb32.mdb.modernconnector.ejb.OnlineEventMonitorBean.class,
+                com.sun.ts.tests.ejb32.mdb.modernconnector.ejb.EventLoggerBean.class
+            );
+            // The ejb-jar.xml descriptor
+            URL ejbResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/mdb/modernconnector/ejb32_mdb_modernconnector_ejb.xml");
+            if(ejbResURL != null) {
+              ejb32_mdb_modernconnector_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
+            }
+            // The sun-ejb-jar.xml file
+            ejbResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/mdb/modernconnector/ejb32_mdb_modernconnector_ejb.jar.sun-ejb-jar.xml");
+            if(ejbResURL != null) {
+              ejb32_mdb_modernconnector_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+            }
+            archiveProcessor.processEjbArchive(ejb32_mdb_modernconnector_ejb, Client.class, ejbResURL);
+
+        // Rar
+            // the jar with the correct archive name
+            JavaArchive ejb32_mdb_modernconnector_ra_jar = ShrinkWrap.create(JavaArchive.class, "ejb32_mdb_modernconnector_ra.jar");
+            // The class files
+            ejb32_mdb_modernconnector_ra_jar.addClasses(
+                 com.sun.ts.tests.ejb32.mdb.modernconnector.connector.EventMonitorConfig.class,
+                 com.sun.ts.tests.ejb32.mdb.modernconnector.connector.EventMonitorAdapter.class,
+                 com.sun.ts.tests.ejb32.mdb.modernconnector.connector.NoUseListener.class,
+                 com.sun.ts.tests.ejb32.mdb.modernconnector.connector.EventMonitor.class
+            );
+            JavaArchive ejb32_mdb_modernconnector_ra = ShrinkWrap.create(JavaArchive.class, "ejb32_mdb_modernconnector.rar");
+            ejb32_mdb_modernconnector_ra.add(ejb32_mdb_modernconnector_ra_jar, ejb32_mdb_modernconnector_ra_jar.getName(), ZipExporter.class);
+            // The ra-jar.xml descriptor
+            URL raResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/mdb/modernconnector/connector/META-INF/ra.xml");
+            if(raResURL != null) {
+              ejb32_mdb_modernconnector_ra.addAsManifestResource(raResURL, "ra.xml");
+            }
+            // The sun-ra.xml file
+            raResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/mdb/modernconnector/connector/META-INF/ra.jar.sun-ra.xml");
+            if(raResURL != null) {
+              ejb32_mdb_modernconnector_ra.addAsManifestResource(raResURL, "sun-ra.xml");
+            }
+            archiveProcessor.processRarArchive(ejb32_mdb_modernconnector_ra, Client.class, raResURL);
+
+        // Ear
+            EnterpriseArchive ejb32_mdb_modernconnector_ear = ShrinkWrap.create(EnterpriseArchive.class, "ejb32_mdb_modernconnector.ear");
+
+            // Any libraries added to the ear
+
+            // The component jars built by the package target
+            ejb32_mdb_modernconnector_ear.addAsModule(ejb32_mdb_modernconnector_ejb);
+            ejb32_mdb_modernconnector_ear.addAsModule(ejb32_mdb_modernconnector_client);
+            ejb32_mdb_modernconnector_ear.addAsModule(ejb32_mdb_modernconnector_ra);
+
+
+
+            // The application.xml descriptor
+            URL earResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/mdb/modernconnector/application.xml");
+            if(earResURL != null) {
+              ejb32_mdb_modernconnector_ear.addAsManifestResource(earResURL, "application.xml");
+            }
+            // The sun-application.xml descriptor
+            earResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/mdb/modernconnector/application.ear.sun-application.xml");
+            if(earResURL != null) {
+              ejb32_mdb_modernconnector_ear.addAsManifestResource(earResURL, "sun-application.xml");
+            }
+            archiveProcessor.processEarArchive(ejb32_mdb_modernconnector_ear, Client.class, earResURL);
+        return ejb32_mdb_modernconnector_ear;
+        }
+
+        @Test
+        @Override
+        public void testModernConnector() throws Fault {
+            super.testModernConnector();
+        }
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/relaxedclientview/singleton/ClientTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/relaxedclientview/singleton/ClientTest.java
@@ -1,0 +1,185 @@
+package com.sun.ts.tests.ejb32.relaxedclientview.singleton;
+
+import com.sun.ts.tests.ejb32.relaxedclientview.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("ejb")
+@Tag("ejb32")
+@Tag("javaee")
+
+public class ClientTest extends com.sun.ts.tests.ejb32.relaxedclientview.singleton.Client {
+    /**
+        EE10 Deployment Descriptors:
+        singleton_relaxed_client_view: 
+        singleton_relaxed_client_view_client: 
+        singleton_relaxed_client_view_ejb: META-INF/ejb-jar.xml
+
+        Found Descriptors:
+        Client:
+
+        Ejb:
+
+        /com/sun/ts/tests/ejb32/relaxedclientview/singleton/singleton_relaxed_client_view_ejb.xml
+        Ear:
+
+        */
+        @TargetsContainer("tck-appclient")
+        @OverProtocol("appclient")
+        @Deployment(name = "singleton_relaxed_client_view", order = 2)
+        public static EnterpriseArchive createDeployment(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        // Client
+            // the jar with the correct archive name
+            JavaArchive singleton_relaxed_client_view_client = ShrinkWrap.create(JavaArchive.class, "singleton_relaxed_client_view_client.jar");
+            // The class files
+            singleton_relaxed_client_view_client.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface2.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.TestConstants.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.RemoteAnnotationInterface1.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.HelperSingleton.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.singleton.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb30.common.helper.TLogger.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface1.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The application-client.xml descriptor
+            URL resURL = Client.class.getResource("com/sun/ts/tests/ejb32/relaxedclientview/singleton/singleton_relaxed_client_view_client.xml");
+            if(resURL != null) {
+              singleton_relaxed_client_view_client.addAsManifestResource(resURL, "application-client.xml");
+            }
+            // The sun-application-client.xml file need to be added or should this be in in the vendor Arquillian extension?
+            resURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/singleton/singleton_relaxed_client_view_client.jar.sun-application-client.xml");
+            if(resURL != null) {
+              singleton_relaxed_client_view_client.addAsManifestResource(resURL, "application-client.xml");
+            }
+            singleton_relaxed_client_view_client.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
+            archiveProcessor.processClientArchive(singleton_relaxed_client_view_client, Client.class, resURL);
+
+
+        // Ejb
+            // the jar with the correct archive name
+            JavaArchive singleton_relaxed_client_view_ejb = ShrinkWrap.create(JavaArchive.class, "singleton_relaxed_client_view_ejb.jar");
+            // The class files
+            singleton_relaxed_client_view_ejb.addClasses(
+                com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.singleton.OneRemoteAnnotationOnInterfaceBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.singleton.OneRemoteAnnotationOnEjbBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.BaseBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.TestConstants.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.singleton.LocalDDBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.RemoteAnnotationInterface1.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.singleton.HelperSingletonBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.singleton.NoAnnotationBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.singleton.NoInterfaceViewBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.singleton.LocalAnnotationBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.singleton.RemoteAnnotationBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface2.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.HelperSingleton.class,
+                com.sun.ts.tests.ejb30.common.helper.TLogger.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.AbstractHelperSingleton.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface1.class
+            );
+            // The ejb-jar.xml descriptor
+            URL ejbResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/singleton/singleton_relaxed_client_view_ejb.xml");
+            if(ejbResURL != null) {
+              singleton_relaxed_client_view_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
+            }
+            // The sun-ejb-jar.xml file
+            ejbResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/singleton/singleton_relaxed_client_view_ejb.jar.sun-ejb-jar.xml");
+            if(ejbResURL != null) {
+              singleton_relaxed_client_view_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+            }
+            archiveProcessor.processEjbArchive(singleton_relaxed_client_view_ejb, Client.class, ejbResURL);
+
+        // Ear
+            EnterpriseArchive singleton_relaxed_client_view_ear = ShrinkWrap.create(EnterpriseArchive.class, "singleton_relaxed_client_view.ear");
+
+            // Any libraries added to the ear
+
+            // The component jars built by the package target
+            singleton_relaxed_client_view_ear.addAsModule(singleton_relaxed_client_view_ejb);
+            singleton_relaxed_client_view_ear.addAsModule(singleton_relaxed_client_view_client);
+
+
+
+            // The application.xml descriptor
+            URL earResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/singleton/application.xml");
+            if(earResURL != null) {
+              singleton_relaxed_client_view_ear.addAsManifestResource(earResURL, "application.xml");
+            }
+            // The sun-application.xml descriptor
+            earResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/singleton/application.ear.sun-application.xml");
+            if(earResURL != null) {
+              singleton_relaxed_client_view_ear.addAsManifestResource(earResURL, "sun-application.xml");
+            }
+            archiveProcessor.processEarArchive(singleton_relaxed_client_view_ear, Client.class, earResURL);
+        return singleton_relaxed_client_view_ear;
+        }
+
+        @Test
+        @Override
+        public void noAnnotationTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.noAnnotationTest();
+        }
+
+        @Test
+        @Override
+        public void localAnnotationTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.localAnnotationTest();
+        }
+
+        @Test
+        @Override
+        public void remoteAnnotationTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.remoteAnnotationTest();
+        }
+
+        @Test
+        @Override
+        public void oneRemoteAnnotationOnInterfaceTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.oneRemoteAnnotationOnInterfaceTest();
+        }
+
+        @Test
+        @Override
+        public void oneRemoteAnnotationOnEjbTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.oneRemoteAnnotationOnEjbTest();
+        }
+
+        @Test
+        @Override
+        public void noInterfaceViewTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.noInterfaceViewTest();
+        }
+
+        @Test
+        @Override
+        public void localDDTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.localDDTest();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/relaxedclientview/stateful/ClientTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/relaxedclientview/stateful/ClientTest.java
@@ -1,0 +1,185 @@
+package com.sun.ts.tests.ejb32.relaxedclientview.stateful;
+
+import com.sun.ts.tests.ejb32.relaxedclientview.stateful.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("ejb")
+@Tag("ejb32")
+@Tag("javaee")
+
+public class ClientTest extends com.sun.ts.tests.ejb32.relaxedclientview.stateful.Client {
+    /**
+        EE10 Deployment Descriptors:
+        stateful_relaxed_client_view: 
+        stateful_relaxed_client_view_client: 
+        stateful_relaxed_client_view_ejb: META-INF/ejb-jar.xml
+
+        Found Descriptors:
+        Client:
+
+        Ejb:
+
+        /com/sun/ts/tests/ejb32/relaxedclientview/stateful/stateful_relaxed_client_view_ejb.xml
+        Ear:
+
+        */
+        @TargetsContainer("tck-appclient")
+        @OverProtocol("appclient")
+        @Deployment(name = "stateful_relaxed_client_view", order = 2)
+        public static EnterpriseArchive createDeployment(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        // Client
+            // the jar with the correct archive name
+            JavaArchive stateful_relaxed_client_view_client = ShrinkWrap.create(JavaArchive.class, "stateful_relaxed_client_view_client.jar");
+            // The class files
+            stateful_relaxed_client_view_client.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface2.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.TestConstants.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.RemoteAnnotationInterface1.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.HelperSingleton.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb30.common.helper.TLogger.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface1.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.stateful.Client.class
+            );
+            // The application-client.xml descriptor
+            URL resURL = Client.class.getResource("com/sun/ts/tests/ejb32/relaxedclientview/stateful/stateful_relaxed_client_view_client.xml");
+            if(resURL != null) {
+              stateful_relaxed_client_view_client.addAsManifestResource(resURL, "application-client.xml");
+            }
+            // The sun-application-client.xml file need to be added or should this be in in the vendor Arquillian extension?
+            resURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateful/stateful_relaxed_client_view_client.jar.sun-application-client.xml");
+            if(resURL != null) {
+              stateful_relaxed_client_view_client.addAsManifestResource(resURL, "application-client.xml");
+            }
+            stateful_relaxed_client_view_client.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
+            archiveProcessor.processClientArchive(stateful_relaxed_client_view_client, Client.class, resURL);
+
+
+        // Ejb
+            // the jar with the correct archive name
+            JavaArchive stateful_relaxed_client_view_ejb = ShrinkWrap.create(JavaArchive.class, "stateful_relaxed_client_view_ejb.jar");
+            // The class files
+            stateful_relaxed_client_view_ejb.addClasses(
+                com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.BaseBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.TestConstants.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateful.LocalDDBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.RemoteAnnotationInterface1.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateful.HelperSingletonBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateful.LocalAnnotationBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateful.OneRemoteAnnotationOnInterfaceBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateful.OneRemoteAnnotationOnEjbBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateful.RemoteAnnotationBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateful.NoAnnotationBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface2.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.HelperSingleton.class,
+                com.sun.ts.tests.ejb30.common.helper.TLogger.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.AbstractHelperSingleton.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface1.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateful.NoInterfaceViewBean.class
+            );
+            // The ejb-jar.xml descriptor
+            URL ejbResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateful/stateful_relaxed_client_view_ejb.xml");
+            if(ejbResURL != null) {
+              stateful_relaxed_client_view_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
+            }
+            // The sun-ejb-jar.xml file
+            ejbResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateful/stateful_relaxed_client_view_ejb.jar.sun-ejb-jar.xml");
+            if(ejbResURL != null) {
+              stateful_relaxed_client_view_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+            }
+            archiveProcessor.processEjbArchive(stateful_relaxed_client_view_ejb, Client.class, ejbResURL);
+
+        // Ear
+            EnterpriseArchive stateful_relaxed_client_view_ear = ShrinkWrap.create(EnterpriseArchive.class, "stateful_relaxed_client_view.ear");
+
+            // Any libraries added to the ear
+
+            // The component jars built by the package target
+            stateful_relaxed_client_view_ear.addAsModule(stateful_relaxed_client_view_ejb);
+            stateful_relaxed_client_view_ear.addAsModule(stateful_relaxed_client_view_client);
+
+
+
+            // The application.xml descriptor
+            URL earResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateful/application.xml");
+            if(earResURL != null) {
+              stateful_relaxed_client_view_ear.addAsManifestResource(earResURL, "application.xml");
+            }
+            // The sun-application.xml descriptor
+            earResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateful/application.ear.sun-application.xml");
+            if(earResURL != null) {
+              stateful_relaxed_client_view_ear.addAsManifestResource(earResURL, "sun-application.xml");
+            }
+            archiveProcessor.processEarArchive(stateful_relaxed_client_view_ear, Client.class, earResURL);
+        return stateful_relaxed_client_view_ear;
+        }
+
+        @Test
+        @Override
+        public void noAnnotationTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.noAnnotationTest();
+        }
+
+        @Test
+        @Override
+        public void localAnnotationTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.localAnnotationTest();
+        }
+
+        @Test
+        @Override
+        public void remoteAnnotationTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.remoteAnnotationTest();
+        }
+
+        @Test
+        @Override
+        public void oneRemoteAnnotationOnInterfaceTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.oneRemoteAnnotationOnInterfaceTest();
+        }
+
+        @Test
+        @Override
+        public void oneRemoteAnnotationOnEjbTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.oneRemoteAnnotationOnEjbTest();
+        }
+
+        @Test
+        @Override
+        public void noInterfaceViewTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.noInterfaceViewTest();
+        }
+
+        @Test
+        @Override
+        public void localDDTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.localDDTest();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/relaxedclientview/stateless/ClientTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/relaxedclientview/stateless/ClientTest.java
@@ -1,0 +1,185 @@
+package com.sun.ts.tests.ejb32.relaxedclientview.stateless;
+
+import com.sun.ts.tests.ejb32.relaxedclientview.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("ejb")
+@Tag("ejb32")
+@Tag("javaee")
+
+public class ClientTest extends com.sun.ts.tests.ejb32.relaxedclientview.stateless.Client {
+    /**
+        EE10 Deployment Descriptors:
+        stateless_relaxed_client_view: 
+        stateless_relaxed_client_view_client: 
+        stateless_relaxed_client_view_ejb: META-INF/ejb-jar.xml
+
+        Found Descriptors:
+        Client:
+
+        Ejb:
+
+        /com/sun/ts/tests/ejb32/relaxedclientview/stateless/stateless_relaxed_client_view_ejb.xml
+        Ear:
+
+        */
+        @TargetsContainer("tck-appclient")
+        @OverProtocol("appclient")
+        @Deployment(name = "stateless_relaxed_client_view", order = 2)
+        public static EnterpriseArchive createDeployment(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        // Client
+            // the jar with the correct archive name
+            JavaArchive stateless_relaxed_client_view_client = ShrinkWrap.create(JavaArchive.class, "stateless_relaxed_client_view_client.jar");
+            // The class files
+            stateless_relaxed_client_view_client.addClasses(
+            com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface2.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.TestConstants.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.RemoteAnnotationInterface1.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.HelperSingleton.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.stateless.Client.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.tests.ejb30.common.helper.TLogger.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface1.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The application-client.xml descriptor
+            URL resURL = Client.class.getResource("com/sun/ts/tests/ejb32/relaxedclientview/stateless/stateless_relaxed_client_view_client.xml");
+            if(resURL != null) {
+              stateless_relaxed_client_view_client.addAsManifestResource(resURL, "application-client.xml");
+            }
+            // The sun-application-client.xml file need to be added or should this be in in the vendor Arquillian extension?
+            resURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateless/stateless_relaxed_client_view_client.jar.sun-application-client.xml");
+            if(resURL != null) {
+              stateless_relaxed_client_view_client.addAsManifestResource(resURL, "application-client.xml");
+            }
+            stateless_relaxed_client_view_client.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
+            archiveProcessor.processClientArchive(stateless_relaxed_client_view_client, Client.class, resURL);
+
+
+        // Ejb
+            // the jar with the correct archive name
+            JavaArchive stateless_relaxed_client_view_ejb = ShrinkWrap.create(JavaArchive.class, "stateless_relaxed_client_view_ejb.jar");
+            // The class files
+            stateless_relaxed_client_view_ejb.addClasses(
+                com.sun.ts.tests.ejb30.common.helper.TestFailedException.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.BaseBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.TestConstants.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.RemoteAnnotationInterface1.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateless.LocalDDBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateless.OneRemoteAnnotationOnInterfaceBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateless.NoInterfaceViewBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateless.HelperSingletonBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateless.LocalAnnotationBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface2.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateless.NoAnnotationBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.HelperSingleton.class,
+                com.sun.ts.tests.ejb30.common.helper.TLogger.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateless.RemoteAnnotationBean.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.AbstractHelperSingleton.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.common.NormalInterface1.class,
+                com.sun.ts.tests.ejb32.relaxedclientview.stateless.OneRemoteAnnotationOnEjbBean.class
+            );
+            // The ejb-jar.xml descriptor
+            URL ejbResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateless/stateless_relaxed_client_view_ejb.xml");
+            if(ejbResURL != null) {
+              stateless_relaxed_client_view_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
+            }
+            // The sun-ejb-jar.xml file
+            ejbResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateless/stateless_relaxed_client_view_ejb.jar.sun-ejb-jar.xml");
+            if(ejbResURL != null) {
+              stateless_relaxed_client_view_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+            }
+            archiveProcessor.processEjbArchive(stateless_relaxed_client_view_ejb, Client.class, ejbResURL);
+
+        // Ear
+            EnterpriseArchive stateless_relaxed_client_view_ear = ShrinkWrap.create(EnterpriseArchive.class, "stateless_relaxed_client_view.ear");
+
+            // Any libraries added to the ear
+
+            // The component jars built by the package target
+            stateless_relaxed_client_view_ear.addAsModule(stateless_relaxed_client_view_ejb);
+            stateless_relaxed_client_view_ear.addAsModule(stateless_relaxed_client_view_client);
+
+
+
+            // The application.xml descriptor
+            URL earResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateless/application.xml");
+            if(earResURL != null) {
+              stateless_relaxed_client_view_ear.addAsManifestResource(earResURL, "application.xml");
+            }
+            // The sun-application.xml descriptor
+            earResURL = Client.class.getResource("/com/sun/ts/tests/ejb32/relaxedclientview/stateless/application.ear.sun-application.xml");
+            if(earResURL != null) {
+              stateless_relaxed_client_view_ear.addAsManifestResource(earResURL, "sun-application.xml");
+            }
+            archiveProcessor.processEarArchive(stateless_relaxed_client_view_ear, Client.class, earResURL);
+        return stateless_relaxed_client_view_ear;
+        }
+
+        @Test
+        @Override
+        public void noAnnotationTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.noAnnotationTest();
+        }
+
+        @Test
+        @Override
+        public void localAnnotationTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.localAnnotationTest();
+        }
+
+        @Test
+        @Override
+        public void remoteAnnotationTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.remoteAnnotationTest();
+        }
+
+        @Test
+        @Override
+        public void oneRemoteAnnotationOnInterfaceTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.oneRemoteAnnotationOnInterfaceTest();
+        }
+
+        @Test
+        @Override
+        public void oneRemoteAnnotationOnEjbTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.oneRemoteAnnotationOnEjbTest();
+        }
+
+        @Test
+        @Override
+        public void noInterfaceViewTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.noInterfaceViewTest();
+        }
+
+        @Test
+        @Override
+        public void localDDTest() throws com.sun.ts.tests.ejb30.common.helper.TestFailedException {
+            super.localDDTest();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/timer/service/singleton/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/timer/service/singleton/ClientEjbliteservletTest.java
@@ -1,0 +1,105 @@
+package com.sun.ts.tests.ejb32.timer.service.singleton;
+
+import com.sun.ts.tests.ejb32.timer.service.singleton.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("ejb")
+@Tag("ejb32")
+@Tag("javaee")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.timer.service.singleton.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_timer_service_singleton_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_timer_service_singleton_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_timer_service_singleton_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_timer_service_singleton_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_timer_service_singleton_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.ejb32.timer.service.singleton.Client.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.AutoTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb32.timer.service.singleton.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.timer.service.singleton.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_timer_service_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_timer_service_singleton_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_timer_service_singleton_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_timer_service_singleton_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/timer/service/stateless/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/timer/service/stateless/ClientEjbliteservletTest.java
@@ -1,0 +1,105 @@
+package com.sun.ts.tests.ejb32.timer.service.stateless;
+
+import com.sun.ts.tests.ejb32.timer.service.stateless.Client;
+import java.net.URL;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("ejb")
+@Tag("ejb32")
+@Tag("javaee")
+
+public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.timer.service.stateless.Client {
+    static final String VEHICLE_ARCHIVE = "ejb32_timer_service_stateless_ejbliteservlet_vehicle";
+
+        /**
+        EE10 Deployment Descriptors:
+        ejb32_timer_service_stateless_ejbliteservlet_vehicle_web: WEB-INF/web.xml
+
+        Found Descriptors:
+        War:
+
+        /com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml
+        */
+        @TargetsContainer("tck-javatest")
+        @OverProtocol("javatest")
+        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+        public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        // War
+            // the war with the correct archive name
+            WebArchive ejb32_timer_service_stateless_ejbliteservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "ejb32_timer_service_stateless_ejbliteservlet_vehicle_web.war");
+            // The class files
+            ejb32_timer_service_stateless_ejbliteservlet_vehicle_web.addClasses(
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBase.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimerIF.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimersStatelessBean.class,
+            com.sun.ts.tests.ejb30.common.helper.Helper.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.common.AutoTimerBeanBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerBeanBaseWithoutTimeOutMethod.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberIF.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.EJBLiteClientIF.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerInfo.class,
+            com.sun.ts.tests.ejb32.timer.service.common.NoTimersStatefulBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.TimersSingletonBean.class,
+            com.sun.ts.tests.common.vehicle.ejbliteshare.ReasonableStatus.class,
+            com.sun.ts.tests.ejb32.timer.service.stateless.HttpServletDelegate.class,
+            com.sun.ts.tests.ejb30.timer.common.TimeoutStatusBean.class,
+            com.sun.ts.tests.ejb32.timer.service.common.ClientBase.class,
+            com.sun.ts.tests.ejb32.timer.service.stateless.Client.class,
+            com.sun.ts.tests.ejb30.common.lite.NumberEnum.class,
+            com.sun.ts.tests.ejb32.timer.service.stateless.EJBLiteServletVehicle.class,
+            com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.class,
+            com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class
+            );
+            // The web.xml descriptor
+            URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
+            if(warResURL != null) {
+              ejb32_timer_service_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+            }
+            // The sun-web.xml descriptor
+            warResURL = Client.class.getResource("/ejbliteservlet_vehicle_web.war.sun-web.xml");
+            if(warResURL != null) {
+              ejb32_timer_service_stateless_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+            }
+            // Web content
+           archiveProcessor.processWebArchive(ejb32_timer_service_stateless_ejbliteservlet_vehicle_web, Client.class, warResURL);
+
+        return ejb32_timer_service_stateless_ejbliteservlet_vehicle_web;
+        }
+
+        @Test
+        @Override
+        @TargetVehicle("ejbliteservlet")
+        public void testGetAllTimers() {
+            super.testGetAllTimers();
+        }
+
+
+}


### PR DESCRIPTION
**Fixes Iusse**
Relates to #1429

**Describe the change**
The initial transformation of the ejb32 codebase. This compiles but has not been fully tested.

**Additional context**
The code was generated using:

``` bash
 mvn -f rewrite-pom.xml -Dtcksourcepath=src/main/java -Dts.home=/home/starksm/Dev/Jakarta/wildflytck/jakartaeetck org.openrewrite.maven:rewrite-maven-plugin:runNoFork 2>&1 | tee /tmp/tck.log
 ```
