### PR TITLE
Add the org.apache.commons:commons-lang3:3.9 lib to tests using DateUtils

### DIFF
--- a/ejb30/src/main/java/com/sun/ts/tests/ejb30/timer/common/TimerUtil.java
+++ b/ejb30/src/main/java/com/sun/ts/tests/ejb30/timer/common/TimerUtil.java
@@ -193,6 +193,7 @@ public final class TimerUtil {
       Timer t = it.next();
       Serializable ser = t.getInfo();
       if (ser != null) {
+        Helper.getLogger().info("Checking timer: "+t);
         if (testName.trim().equals(getTimerName(t))) {
           result = t;
           break;

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/ClientEjblitejsfTest.java
@@ -118,6 +118,8 @@ public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.basi
             if(warResURL != null) {
               ejb32_lite_timer_basic_xa_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
             }
+            warResURL = Client.class.getResource("persistence.xml");
+            ejb32_lite_timer_basic_xa_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "classes/META-INF/persistence.xml");
 
            // Call the archive processor
            archiveProcessor.processWebArchive(ejb32_lite_timer_basic_xa_ejblitejsf_vehicle_web, Client.class, warResURL);

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/ClientEjblitejspTest.java
@@ -106,6 +106,8 @@ public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.basi
             if(warResURL != null) {
               ejb32_lite_timer_basic_xa_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
             }
+            warResURL = Client.class.getResource("persistence.xml");
+            ejb32_lite_timer_basic_xa_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "classes/META-INF/persistence.xml");
 
            // Call the archive processor
            archiveProcessor.processWebArchive(ejb32_lite_timer_basic_xa_ejblitejsp_vehicle_web, Client.class, warResURL);

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/ClientEjbliteservlet2Test.java
@@ -95,18 +95,12 @@ public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer
               ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
             }
             // Web content
-            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/EJBLiteServlet2Filter.java.txt");
-            if(warResURL != null) {
-              ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/EJBLiteServlet2Filter.java.txt");
-            }
-            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml");
-            if(warResURL != null) {
-              ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/ejbliteservlet2_vehicle_web.xml");
-            }
             warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle.jsp");
             if(warResURL != null) {
               ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
             }
+            warResURL = Client.class.getResource("persistence.xml");
+            ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "classes/META-INF/persistence.xml");
 
            // Call the archive processor
            archiveProcessor.processWebArchive(ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web, Client.class, warResURL);

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/ClientEjbliteservletTest.java
@@ -95,18 +95,8 @@ public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.
               ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
             }
             // Web content
-            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet/EJBLiteServletVehicle.java.txt");
-            if(warResURL != null) {
-              ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebResource(warResURL, "/EJBLiteServletVehicle.java.txt");
-            }
-            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet/HttpServletDelegate.java.txt");
-            if(warResURL != null) {
-              ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebResource(warResURL, "/HttpServletDelegate.java.txt");
-            }
-            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml");
-            if(warResURL != null) {
-              ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/ejbliteservlet_vehicle_web.xml");
-            }
+            warResURL = Client.class.getResource("persistence.xml");
+            ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "classes/META-INF/persistence.xml");
 
            // Call the archive processor
            archiveProcessor.processWebArchive(ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web, Client.class, warResURL);

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/JsfClientEjblitejsfTest.java
@@ -118,6 +118,8 @@ public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.b
             if(warResURL != null) {
               ejb32_lite_timer_basic_xa_ejblitejsf_vehicle_web.addAsWebResource(warResURL, "/ejblitejsf_vehicle.xhtml");
             }
+            warResURL = Client.class.getResource("persistence.xml");
+            ejb32_lite_timer_basic_xa_ejblitejsf_vehicle_web.addAsWebInfResource(warResURL, "classes/META-INF/persistence.xml");
 
            // Call the archive processor
            archiveProcessor.processWebArchive(ejb32_lite_timer_basic_xa_ejblitejsf_vehicle_web, JsfClient.class, warResURL);

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/JsfClientEjblitejspTest.java
@@ -106,6 +106,8 @@ public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.b
             if(warResURL != null) {
               ejb32_lite_timer_basic_xa_ejblitejsp_vehicle_web.addAsWebResource(warResURL, "/ejblitejsp_vehicle.jsp");
             }
+            warResURL = Client.class.getResource("persistence.xml");
+            ejb32_lite_timer_basic_xa_ejblitejsp_vehicle_web.addAsWebInfResource(warResURL, "classes/META-INF/persistence.xml");
 
            // Call the archive processor
            archiveProcessor.processWebArchive(ejb32_lite_timer_basic_xa_ejblitejsp_vehicle_web, JsfClient.class, warResURL);

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/JsfClientEjbliteservlet2Test.java
@@ -95,10 +95,6 @@ public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.ti
               ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
             }
             // Web content
-            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/EJBLiteServlet2Filter.java.txt");
-            if(warResURL != null) {
-              ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/EJBLiteServlet2Filter.java.txt");
-            }
             warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet2/ejbliteservlet2_vehicle_web.xml");
             if(warResURL != null) {
               ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/ejbliteservlet2_vehicle_web.xml");
@@ -107,6 +103,8 @@ public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.ti
             if(warResURL != null) {
               ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebResource(warResURL, "/ejbliteservlet2_vehicle.jsp");
             }
+            warResURL = Client.class.getResource("persistence.xml");
+            ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web.addAsWebInfResource(warResURL, "classes/META-INF/persistence.xml");
 
            // Call the archive processor
            archiveProcessor.processWebArchive(ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web, JsfClient.class, warResURL);

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/basic/xa/JsfClientEjbliteservletTest.java
@@ -95,18 +95,12 @@ public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.tim
               ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
             }
             // Web content
-            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet/EJBLiteServletVehicle.java.txt");
-            if(warResURL != null) {
-              ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebResource(warResURL, "/EJBLiteServletVehicle.java.txt");
-            }
-            warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet/HttpServletDelegate.java.txt");
-            if(warResURL != null) {
-              ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebResource(warResURL, "/HttpServletDelegate.java.txt");
-            }
             warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejbliteservlet/ejbliteservlet_vehicle_web.xml");
             if(warResURL != null) {
               ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/ejbliteservlet_vehicle_web.xml");
             }
+            warResURL = Client.class.getResource("persistence.xml");
+            ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web.addAsWebInfResource(warResURL, "classes/META-INF/persistence.xml");
 
            // Call the archive processor
            archiveProcessor.processWebArchive(ejb32_lite_timer_basic_xa_ejbliteservlet_vehicle_web, JsfClient.class, warResURL);

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejsfTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +83,13 @@ public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.sche
             com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addAsLibraries(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejspTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +83,13 @@ public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.sche
             com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addAsLibraries(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservlet2Test.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +84,13 @@ public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer
             com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addAsLibraries(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservletTest.java
@@ -14,6 +14,10 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenFormatStage;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
+import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +86,14 @@ public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.
             com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.addAsLibraries(resolvedArtifact.asFile());
+
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejsfTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +83,13 @@ public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.s
             com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addAsLibraries(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejspTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +83,13 @@ public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.s
             com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addAsLibraries(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjbliteservlet2Test.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +84,13 @@ public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.ti
             com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addAsLibraries(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjbliteservletTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +84,13 @@ public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.tim
             com.sun.ts.tests.ejb32.lite.timer.schedule.expire.JsfClient.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.addAsLibraries(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjblitejsfTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +83,13 @@ public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.sche
             com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addAsLibraries(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjblitejspTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +83,13 @@ public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.sche
             com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            // commons lang jar
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjbliteservlet2Test.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +84,12 @@ public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer
             com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/ClientEjbliteservletTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +84,12 @@ public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.
             com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjblitejsfTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +83,12 @@ public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.s
             com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsf_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjblitejspTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -81,6 +83,12 @@ public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.s
             com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_lifecycle_ejblitejsp_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjbliteservlet2Test.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +84,12 @@ public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.ti
             com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet2_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/lifecycle/JsfClientEjbliteservletTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -82,6 +84,12 @@ public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.tim
             com.sun.ts.tests.ejb30.timer.common.TimerUtil.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_lifecycle_ejbliteservlet_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjblitejsfTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,6 +81,12 @@ public class ClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.sche
             com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjblitejspTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,6 +81,12 @@ public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.sche
             com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjbliteservlet2Test.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,6 +82,12 @@ public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer
             com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("ejbliteservlet2_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/ClientEjbliteservletTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,6 +82,12 @@ public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.
             com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = Client.class.getResource("ejbliteservlet_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjblitejsfTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjblitejsfTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,6 +81,12 @@ public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.s
             com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_tz_ejblitejsf_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("/com/sun/ts/tests/common/vehicle/ejblitejsf/ejblitejsf_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjblitejspTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjblitejspTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -79,6 +81,12 @@ public class JsfClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.s
             com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_tz_ejblitejsp_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("/vehicle/ejblitejsp/ejblitejsp_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjbliteservlet2Test.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjbliteservlet2Test.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,6 +82,12 @@ public class JsfClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.ti
             com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_tz_ejbliteservlet2_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("ejbliteservlet2_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjbliteservletTest.java
+++ b/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/tz/JsfClientEjbliteservletTest.java
@@ -14,6 +14,8 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -80,6 +82,12 @@ public class JsfClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.tim
             com.sun.ts.tests.ejb32.lite.timer.schedule.tz.Client.class,
             com.sun.ts.lib.harness.EETest.SetupException.class
             );
+            String[] activeMavenProfiles = {"staging"};
+            MavenResolvedArtifact resolvedArtifact = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve("org.apache.commons:commons-lang3:3.9")
+                    .withTransitivity()
+                    .asSingleResolvedArtifact();
+            ejb32_lite_timer_schedule_tz_ejbliteservlet_vehicle_web.addAsLibrary(resolvedArtifact.asFile());
             // The web.xml descriptor
             URL warResURL = JsfClient.class.getResource("ejbliteservlet_vehicle_web.xml");
             if(warResURL != null) {

--- a/ejb32/src/test/java/LibResolveTest.java
+++ b/ejb32/src/test/java/LibResolveTest.java
@@ -1,0 +1,18 @@
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenFormatStage;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
+import org.jboss.shrinkwrap.resolver.api.maven.ScopeType;
+import org.junit.jupiter.api.Test;
+
+public class LibResolveTest {
+    @Test
+    public void resolveCommonsLib() {
+        String[] activeMavenProfiles = {"staging"};
+        MavenFormatStage mavenFormatStage = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                .resolve("org.apache.commons:commons-lang3")
+                .withoutTransitivity();
+        MavenResolvedArtifact resolvedArtifacts = mavenFormatStage.asSingleResolvedArtifact();
+        System.out.println("Resolved artifact: " + resolvedArtifacts.asFile());
+    }
+}


### PR DESCRIPTION

**Related Issue(s)**
#1421 

**Describe the change**
A number of time tests were using the DateUtils class from org.apache.commons:commons-lang3:3.9
This was not captured by the ant build

