### PR TITLE
JMS test artifact was missing deployment descriptors

### DIFF
--- a/jms/pom.xml
+++ b/jms/pom.xml
@@ -85,6 +85,18 @@
         </dependency>
     </dependencies>
     <build>
+        <!-- Include the container descriptors in the output artifact -->
+        <resources>
+            <resource>
+                <directory>src/main/java</directory>
+                <includes>
+                    <include>**/*.xml</include>
+                </includes>
+                <excludes>
+                    <exclude>**/build.xml</exclude>
+                </excludes>
+            </resource>
+        </resources>
         <plugins>
             <!-- do not publish this artifact to Maven repositories -->
             <plugin>


### PR DESCRIPTION
The jms module had not been updated to include the various deployment descriptors in the tests directories.
