### PR TITLE
TestUtil should check if socketOnRemoteVM is non-null before closing it on exception case.

### DIFF
--- a/libutil/src/main/java/com/sun/ts/lib/util/TestUtil.java
+++ b/libutil/src/main/java/com/sun/ts/lib/util/TestUtil.java
@@ -440,7 +440,9 @@ public final class TestUtil {
             throw new RemoteLoggingInitException(
                 "Init: Error while trying to getProperty(harness.host) - returned null");
           }
-          socketOnRemoteVM.close();
+          if(socketOnRemoteVM != null) {
+            socketOnRemoteVM.close();
+          }
           socketOnRemoteVM = new Socket(hostOfHarness, portOfHarness);
           objectOutputStream = new ObjectOutputStream(
               socketOnRemoteVM.getOutputStream());


### PR DESCRIPTION
In support of getting clearer error for https://github.com/jakartaee/platform-tck/issues/1497

With this change, the error listed in issues/1497 is really:

```
2024-08-26 13:27:28,254 INFO  [org.jboss.as.server] (management-handler-thread - 1) WFLYSRV0010: Deployed "jpa_core_EntityGraph_vehicles.ear" (runtime-name : "jpa_core_EntityGraph_vehicles.ear")
2024-08-26 13:27:28,363 INFO  [stdout] (default task-1) ************************************************************
2024-08-26 13:27:28,364 INFO  [stdout] (default task-1) * props file set to "/tmp/smarlow-cts-props.txt"
2024-08-26 13:27:28,364 INFO  [stdout] (default task-1) ************************************************************
2024-08-26 13:27:28,364 INFO  [stdout] (default task-1) In doPost!
2024-08-26 13:27:28,367 INFO  [stdout] (default task-1) ServletVehicle - got InputStream
2024-08-26 13:27:28,370 INFO  [stdout] (default task-1) read properties!!!
2024-08-26 13:31:56,166 ERROR [stderr] (default task-1) java.net.ConnectException: Connection timed out
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at java.base/sun.nio.ch.Net.connect0(Native Method)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at java.base/sun.nio.ch.Net.connect(Net.java:579)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at java.base/sun.nio.ch.Net.connect(Net.java:568)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at java.base/sun.nio.ch.NioSocketImpl.connect(NioSocketImpl.java:593)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at java.base/java.net.SocksSocketImpl.connect(SocksSocketImpl.java:327)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at java.base/java.net.Socket.connect(Socket.java:633)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at java.base/java.net.Socket.connect(Socket.java:583)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at java.base/java.net.Socket.<init>(Socket.java:507)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at java.base/java.net.Socket.<init>(Socket.java:287)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at deployment.jpa_core_EntityGraph_vehicles.ear//com.sun.ts.lib.util.TestUtil.init(TestUtil.java:447)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at deployment.jpa_core_EntityGraph_vehicles.ear.jpa_core_EntityGraph_pmservlet_vehicle_web.war//com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.doGet(ServletVehicle.java:84)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at deployment.jpa_core_EntityGraph_vehicles.ear.jpa_core_EntityGraph_pmservlet_vehicle_web.war//com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.doPost(ServletVehicle.java:115)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at jakarta.servlet.api@6.0.0//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:547)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at jakarta.servlet.api@6.0.0//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:614)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:74)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletChain$1.handleRequest(ServletChain.java:68)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-web.undertow-server@4.1.0.Final//org.wildfly.elytron.web.undertow.server.ElytronRunAsHandler.lambda$handleRequest$1(ElytronRunAsHandler.java:68)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-base@2.5.0.Final//org.wildfly.security.auth.server.FlexibleIdentityAssociation.runAsFunctionEx(FlexibleIdentityAssociation.java:103)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-base@2.5.0.Final//org.wildfly.security.auth.server.Scoped.runAsFunctionEx(Scoped.java:161)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-base@2.5.0.Final//org.wildfly.security.auth.server.Scoped.runAs(Scoped.java:73)
2024-08-26 13:31:56,167 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-web.undertow-server@4.1.0.Final//org.wildfly.elytron.web.undertow.server.ElytronRunAsHandler.handleRequest(ElytronRunAsHandler.java:67)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.RedirectDirHandler.handleRequest(RedirectDirHandler.java:68)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:117)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-web.undertow-server-servlet@4.1.0.Final//org.wildfly.elytron.web.undertow.server.servlet.CleanUpHandler.handleRequest(CleanUpHandler.java:38)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:44)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.GlobalRequestControllerHandler.handleRequest(GlobalRequestControllerHandler.java:51)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.SendErrorPageHandler.handleRequest(SendErrorPageHandler.java:52)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:276)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:135)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:132)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:256)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:101)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.Connectors.executeRootHandler(Connectors.java:393)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:859)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.jboss.threads@2.4.0.Final//org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:1990)
2024-08-26 13:31:56,168 ERROR [stderr] (default task-1) 	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1486)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1348)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.jboss.xnio@3.8.16.Final//org.xnio.XnioWorker$WorkerThreadFactory$1$1.run(XnioWorker.java:1282)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at java.base/java.lang.Thread.run(Thread.java:840)
2024-08-26 13:31:56,169 INFO  [stdout] (default task-1) unable to initialize remote logging
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) jakarta.servlet.ServletException: unable to initialize remote logging
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at deployment.jpa_core_EntityGraph_vehicles.ear.jpa_core_EntityGraph_pmservlet_vehicle_web.war//com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.doGet(ServletVehicle.java:89)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at deployment.jpa_core_EntityGraph_vehicles.ear.jpa_core_EntityGraph_pmservlet_vehicle_web.war//com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.doPost(ServletVehicle.java:115)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at jakarta.servlet.api@6.0.0//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:547)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at jakarta.servlet.api@6.0.0//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:614)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:74)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletChain$1.handleRequest(ServletChain.java:68)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-web.undertow-server@4.1.0.Final//org.wildfly.elytron.web.undertow.server.ElytronRunAsHandler.lambda$handleRequest$1(ElytronRunAsHandler.java:68)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-base@2.5.0.Final//org.wildfly.security.auth.server.FlexibleIdentityAssociation.runAsFunctionEx(FlexibleIdentityAssociation.java:103)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-base@2.5.0.Final//org.wildfly.security.auth.server.Scoped.runAsFunctionEx(Scoped.java:161)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-base@2.5.0.Final//org.wildfly.security.auth.server.Scoped.runAs(Scoped.java:73)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-web.undertow-server@4.1.0.Final//org.wildfly.elytron.web.undertow.server.ElytronRunAsHandler.handleRequest(ElytronRunAsHandler.java:67)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.RedirectDirHandler.handleRequest(RedirectDirHandler.java:68)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:117)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.wildfly.security.elytron-web.undertow-server-servlet@4.1.0.Final//org.wildfly.elytron.web.undertow.server.servlet.CleanUpHandler.handleRequest(CleanUpHandler.java:38)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:44)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.GlobalRequestControllerHandler.handleRequest(GlobalRequestControllerHandler.java:51)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.SendErrorPageHandler.handleRequest(SendErrorPageHandler.java:52)
2024-08-26 13:31:56,169 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:276)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:135)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:132)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:256)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:101)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.Connectors.executeRootHandler(Connectors.java:393)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at io.undertow.core@2.3.15.Final//io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:859)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.jboss.threads@2.4.0.Final//org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:1990)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1486)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1348)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at org.jboss.xnio@3.8.16.Final//org.xnio.XnioWorker$WorkerThreadFactory$1$1.run(XnioWorker.java:1282)
2024-08-26 13:31:56,170 ERROR [stderr] (default task-1) 	at java.base/java.lang.Thread.run(Thread.java:840)
2024-08-26 13:31:56,170 ERROR [io.undertow.request] (default task-1) UT005023: Exception handling request to /jpa_core_EntityGraph_pmservlet_vehicle_web/pmservlet_vehicle: jakarta.servlet.ServletException: test failed to run within the Servlet Vehicle
	at deployment.jpa_core_EntityGraph_vehicles.ear.jpa_core_EntityGraph_pmservlet_vehicle_web.war//com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.doGet(ServletVehicle.java:105)
	at deployment.jpa_core_EntityGraph_vehicles.ear.jpa_core_EntityGraph_pmservlet_vehicle_web.war//com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.doPost(ServletVehicle.java:115)
	at jakarta.servlet.api@6.0.0//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:547)
	at jakarta.servlet.api@6.0.0//jakarta.servlet.http.HttpServlet.service(HttpServlet.java:614)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletHandler.handleRequest(ServletHandler.java:74)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.ServletSecurityRoleHandler.handleRequest(ServletSecurityRoleHandler.java:62)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletChain$1.handleRequest(ServletChain.java:68)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletDispatchingHandler.handleRequest(ServletDispatchingHandler.java:36)
	at org.wildfly.security.elytron-web.undertow-server@4.1.0.Final//org.wildfly.elytron.web.undertow.server.ElytronRunAsHandler.lambda$handleRequest$1(ElytronRunAsHandler.java:68)
	at org.wildfly.security.elytron-base@2.5.0.Final//org.wildfly.security.auth.server.FlexibleIdentityAssociation.runAsFunctionEx(FlexibleIdentityAssociation.java:103)
	at org.wildfly.security.elytron-base@2.5.0.Final//org.wildfly.security.auth.server.Scoped.runAsFunctionEx(Scoped.java:161)
	at org.wildfly.security.elytron-base@2.5.0.Final//org.wildfly.security.auth.server.Scoped.runAs(Scoped.java:73)
	at org.wildfly.security.elytron-web.undertow-server@4.1.0.Final//org.wildfly.elytron.web.undertow.server.ElytronRunAsHandler.handleRequest(ElytronRunAsHandler.java:67)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.RedirectDirHandler.handleRequest(RedirectDirHandler.java:68)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.SSLInformationAssociationHandler.handleRequest(SSLInformationAssociationHandler.java:117)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.ServletAuthenticationCallHandler.handleRequest(ServletAuthenticationCallHandler.java:57)
	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.core@2.3.15.Final//io.undertow.security.handlers.AbstractConfidentialityHandler.handleRequest(AbstractConfidentialityHandler.java:46)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.security.ServletConfidentialityConstraintHandler.handleRequest(ServletConfidentialityConstraintHandler.java:64)
	at io.undertow.core@2.3.15.Final//io.undertow.security.handlers.AbstractSecurityContextAssociationHandler.handleRequest(AbstractSecurityContextAssociationHandler.java:43)
	at org.wildfly.security.elytron-web.undertow-server-servlet@4.1.0.Final//org.wildfly.elytron.web.undertow.server.servlet.CleanUpHandler.handleRequest(CleanUpHandler.java:38)
	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.security.jacc.JACCContextIdHandler.handleRequest(JACCContextIdHandler.java:44)
	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.GlobalRequestControllerHandler.handleRequest(GlobalRequestControllerHandler.java:51)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.SendErrorPageHandler.handleRequest(SendErrorPageHandler.java:52)
	at io.undertow.core@2.3.15.Final//io.undertow.server.handlers.PredicateHandler.handleRequest(PredicateHandler.java:43)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler.handleFirstRequest(ServletInitialHandler.java:276)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:135)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler$2.call(ServletInitialHandler.java:132)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.core.ServletRequestContextThreadSetupAction$1.call(ServletRequestContextThreadSetupAction.java:48)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.core.ContextClassLoaderSetupAction$1.call(ContextClassLoaderSetupAction.java:43)
	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
	at org.wildfly.extension.undertow@34.0.0.Beta1-SNAPSHOT//org.wildfly.extension.undertow.deployment.UndertowDeploymentInfoService$UndertowThreadSetupAction.lambda$create$0(UndertowDeploymentInfoService.java:1421)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler.dispatchRequest(ServletInitialHandler.java:256)
	at io.undertow.servlet@2.3.15.Final//io.undertow.servlet.handlers.ServletInitialHandler$1.handleRequest(ServletInitialHandler.java:101)
	at io.undertow.core@2.3.15.Final//io.undertow.server.Connectors.executeRootHandler(Connectors.java:393)
	at io.undertow.core@2.3.15.Final//io.undertow.server.HttpServerExchange$1.run(HttpServerExchange.java:859)
	at org.jboss.threads@2.4.0.Final//org.jboss.threads.ContextClassLoaderSavingRunnable.run(ContextClassLoaderSavingRunnable.java:35)
	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor.safeRun(EnhancedQueueExecutor.java:1990)
	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.doRunTask(EnhancedQueueExecutor.java:1486)
	at org.jboss.threads@2.4.0.Final//org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1348)
	at org.jboss.xnio@3.8.16.Final//org.xnio.XnioWorker$WorkerThreadFactory$1$1.run(XnioWorker.java:1282)
	at java.base/java.lang.Thread.run(Thread.java:840)


```