### PR TITLE
JSTL TCK : Add keyword tags for jstl tests , include missing tests

### DIFF
--- a/glassfish-runner/jstl-tck/pom.xml
+++ b/glassfish-runner/jstl-tck/pom.xml
@@ -30,8 +30,8 @@
         <db.delimiter>;</db.delimiter>
         <db.name>derby</db.name>
         <exec.asadmin>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</exec.asadmin>
-        <!-- <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version> -->
-        <glassfish.container.version>8.0.0-M5</glassfish.container.version>
+        <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version>
+        <!-- <glassfish.container.version>8.0.0-M5</glassfish.container.version> -->
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
         <jdbc.classpath>${project.build.directory}/${glassfish.toplevel.dir}/javadb/lib/derbyclient.jar:${project.build.directory}/${glassfish.toplevel.dir}/javadb/lib/derbyshared.jar:${project.build.directory}/${glassfish.toplevel.dir}/javadb/lib/derbytools.jar</jdbc.classpath>

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/JSTLClientIT.java
@@ -26,9 +26,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends CompatAbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/conditional/cwo/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/conditional/cwo/JSTLClientIT.java
@@ -27,9 +27,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/conditional/iftag/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/conditional/iftag/JSTLClientIT.java
@@ -26,9 +26,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/general/catchtag/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/general/catchtag/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/general/outtag/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/general/outtag/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/general/remove/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/general/remove/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/general/set/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/general/set/JSTLClientIT.java
@@ -27,9 +27,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/iteration/foreach/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/iteration/foreach/JSTLClientIT.java
@@ -29,9 +29,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/iteration/fortokens/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/iteration/fortokens/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/iteration/loopstatus/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/iteration/loopstatus/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/urlresource/importtag/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/urlresource/importtag/JSTLClientIT.java
@@ -30,9 +30,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/urlresource/param/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/urlresource/param/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/urlresource/redirect/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/urlresource/redirect/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/urlresource/url/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/core/urlresource/url/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/config/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/config/JSTLClientIT.java
@@ -27,9 +27,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/functions/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/functions/JSTLClientIT.java
@@ -26,9 +26,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/tlv/permitted/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/tlv/permitted/JSTLClientIT.java
@@ -26,9 +26,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/tlv/scrfree/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/tlv/scrfree/JSTLClientIT.java
@@ -25,9 +25,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/uri/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/etu/uri/JSTLClientIT.java
@@ -26,9 +26,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/fmtdate/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/fmtnum/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/fmtnum/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/localecontext/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsedate/JSTLClientIT.java
@@ -30,9 +30,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsenum/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/parsenum/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/settimezone/JSTLClientIT.java
@@ -30,9 +30,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/timezone/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/format/timezone/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/bundle/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/bundle/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/message/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/message/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 
@@ -384,7 +388,7 @@ public class JSTLClientIT extends AbstractUrlClient {
    * @test_Strategy: validates jakarta.servlet.jsp.jstl.fmt.LocaleSupport for
    * static getLocalizedMessage() methods.
    */
-
+  @Test
   public void localeSupportTest() throws Exception {
     TEST_PROPS.setProperty(REQUEST,
         "GET /jstl_fmt_message_web/localeSupportTest.jsp HTTP/1.1");
@@ -404,7 +408,7 @@ public class JSTLClientIT extends AbstractUrlClient {
    * @test_Strategy: validates jakarta.servlet.jsp.jstl.fmt.LocaleSupport for
    * static getLocalizedMessage() methods.
    */
-
+  @Test
   public void negativeLocaleSupportTest() throws Exception {
     TEST_PROPS.setProperty(REQUEST,
         "GET /jstl_fmt_message_web/negativeLocaleSupportTest.jsp HTTP/1.1");

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/param/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/param/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/requestencoding/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/requestencoding/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/resourcelookup/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/resourcelookup/JSTLClientIT.java
@@ -26,9 +26,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/responseencoding/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/responseencoding/JSTLClientIT.java
@@ -26,9 +26,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/setbundle/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/setbundle/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/setlocale/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/fmt/i18n/setlocale/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/param/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/param/JSTLClientIT.java
@@ -30,9 +30,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends SqlUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/query/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/query/JSTLClientIT.java
@@ -30,9 +30,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends SqlUrlClient {
 
@@ -538,7 +542,7 @@ public class JSTLClientIT extends SqlUrlClient {
    * cusotm tag resultSetQuery, which invokes ResultSupport.toResult() to
    * convert a java.sql.ResultSet to jakarta.servlet.jsp.jstl.sql.Result.
    */
-
+  @Test
   public void positiveResultSupportTest() throws Exception {
     String testName = "positiveResultSupportTest";
     TEST_PROPS.setProperty(REQUEST,

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/result/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/result/JSTLClientIT.java
@@ -30,9 +30,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends SqlUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/setdatasource/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/setdatasource/JSTLClientIT.java
@@ -30,9 +30,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends SqlUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/transaction/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/transaction/JSTLClientIT.java
@@ -30,9 +30,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends SqlUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/update/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/sql/update/JSTLClientIT.java
@@ -30,9 +30,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends SqlUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xconditional/xcwo/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xconditional/xcwo/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xconditional/xforeach/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xconditional/xforeach/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xconditional/xif/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xconditional/xif/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/bindings/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/bindings/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/parse/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/parse/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/types/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/types/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/xout/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/xout/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/xset/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xmlcore/xset/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xtransform/param/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xtransform/param/JSTLClientIT.java
@@ -26,9 +26,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 

--- a/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xtransform/transform/JSTLClientIT.java
+++ b/jstl/src/main/java/com/sun/ts/tests/jstl/spec/xml/xtransform/transform/JSTLClientIT.java
@@ -28,9 +28,13 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.asset.UrlAsset;
 
+@Tag("jstl")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
 public class JSTLClientIT extends AbstractUrlClient {
 


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1376 

**Describe the change**
- Add below tags for the tests in sync with the keyword.properties 
```
@Tag("jstl")
@Tag("platform")
@Tag("web")
```
- Include missing tests and match the test count for the platform TCK : 541 jstl tests in Platform TCK.

