### PR TITLE
Javaee module tests : create Ears, add keyword tag "platform"

### DIFF
--- a/glassfish-runner/javaee-module-tck/pom.xml
+++ b/glassfish-runner/javaee-module-tck/pom.xml
@@ -28,9 +28,9 @@
 
     <properties>
         <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
-        <!-- <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version> -->
+        <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version>
         <!-- Use JDK21 to run with GF 8.0.0-M5 -->
-        <glassfish.container.version>8.0.0-M5</glassfish.container.version>
+        <!-- <glassfish.container.version>8.0.0-M5</glassfish.container.version> -->
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
@@ -200,12 +200,6 @@
             </activation>
             <properties>
                 <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-        </profile>
-        <profile>
-            <id>web</id>
-            <properties>
-                <glassfish-artifact-id>web</glassfish-artifact-id>
             </properties>
         </profile>
     </profiles>

--- a/javaee/src/main/java/com/sun/ts/tests/javaee/resource/servlet/URLClientIT.java
+++ b/javaee/src/main/java/com/sun/ts/tests/javaee/resource/servlet/URLClientIT.java
@@ -33,12 +33,32 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 
+import java.lang.System.Logger;
+
+@Tag("platform")
 @ExtendWith(ArquillianExtension.class)
 public class URLClientIT extends AbstractUrlClient {
+
+  private static final Logger logger = System.getLogger(URLClientIT.class.getName());
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+  }
 
   public URLClientIT() {
     setServletName("TestServlet");
@@ -47,14 +67,17 @@ public class URLClientIT extends AbstractUrlClient {
   /* Run test */
 
   @Deployment(testable = false)
-  public static WebArchive createDeployment() throws IOException {
+  public static EnterpriseArchive createDeployment() throws IOException {
 
-    WebArchive archive = ShrinkWrap.create(WebArchive.class, "javaee_resource_servlet.war");
-    archive.addPackages(true, Filters.exclude(URLClientIT.class, Pojo.class),
-            URLClientIT.class.getPackageName());
-    archive.addClasses(HttpTCKServlet.class, ServletTestUtil.class, Data.class);
-    archive.addAsLibrary(prepackage());
-    return archive;
+    WebArchive webarchive = ShrinkWrap.create(WebArchive.class, "javaee_resource_servlet.war");
+    webarchive.addPackages(true, Filters.exclude(URLClientIT.class, Pojo.class), URLClientIT.class.getPackageName())
+            .addClasses(HttpTCKServlet.class, ServletTestUtil.class, Data.class)
+            .addAsLibrary(prepackage());
+
+    EnterpriseArchive earArchive = ShrinkWrap.create(EnterpriseArchive.class, "javaee_resource_servlet.ear");
+    earArchive.addAsModule(webarchive);
+
+    return earArchive;
 
   }
 


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1480

**Describe the change**
- Create EARs with the war archives
- Add "platform" tag replacing "javaee" in keyword.properties.
- javaee module passes all 24 tests with Glassfish 8.0.0-JDK17-M5, runner at glassfish-runner/javaee-module-tck/