### PR TITLE
JSONB TCK refactored to run in ejb, jsp, servlet vehicles

### DIFF
--- a/glassfish-runner/jsonb-platform-tck/pom.xml
+++ b/glassfish-runner/jsonb-platform-tck/pom.xml
@@ -27,16 +27,32 @@
     <packaging>jar</packaging>
 
     <properties>
+        <arquillian.junit>1.9.1.Final</arquillian.junit>
         <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
         <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version>
         <!-- Use JDK21 to run with GF 8.0.0-M5 -->
         <!-- <glassfish.container.version>8.0.0-M5</glassfish.container.version> -->
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
-        <junit.jupiter.version>5.9.1</junit.jupiter.version>
+        <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <tck.artifactId>jsonb-platform-tck</tck.artifactId>
         <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <ts.home>/jakartaeetck</ts.home>
+        <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
+        <version.jakarta.tck.arquillian>1.0.0-M15</version.jakarta.tck.arquillian>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.junit</groupId>
+                <artifactId>junit-bom</artifactId>
+                <version>${junit.jupiter.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
         <dependency>
@@ -95,6 +111,76 @@
             <version>1.4</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-appclient</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-spi-maven</artifactId>
+            <version>3.2.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-javatest</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                    <artifactId>shrinkwrap-resolver-api</artifactId>
+                    <!-- <version>3.1.4</version> -->
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                    <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+                    <!-- <version>3.1.4</version> -->
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                    <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+                    <!-- <version>3.1.4</version> -->
+                </exclusion>
+                <exclusion>
+                    <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                    <artifactId>shrinkwrap-resolver-spi-maven</artifactId>
+                    <!-- <version>3.1.4</version> -->
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-common</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-lib</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>tck-porting-lib</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+
     </dependencies>
 
     <build>
@@ -144,70 +230,41 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
                 <executions>
                     <execution>
-                        <id>03-StopDomain1</id>
+                        <id>07-copy-protocol-lib</id>
                         <goals>
-                            <goal>exec</goal>
+                            <goal>copy</goal>
                         </goals>
-                        <phase>pre-integration-test</phase>
+                        <phase>process-test-resources</phase>
                         <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>stop-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>04-StartDomain1</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>start-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>05-Enable Trace requests</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>set</argument>
-                                <argument>server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>06-StopDomain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>stop-domain</argument>
-                            </arguments>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.tck.arquillian</groupId>
+                                    <artifactId>arquillian-protocol-lib</artifactId>
+                                    <version>${version.jakarta.tck.arquillian}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/protocol</outputDirectory>
+                                    <destFileName>protocol.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
                         </configuration>
                     </execution>
                 </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0-M5</version>
+                <version>3.5.0</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                </configuration>
                 <executions>
                     <execution>
-                        <id>gf-tests</id>
+                        <id>cdi-tests-appclient</id>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
@@ -217,6 +274,11 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/yasson.jar</additionalClasspathElement>
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
                             </additionalClasspathElements>
+                            <includes>
+                                <include>com/sun/ts/tests/jsonb/cdi/**/*Ejb*.java</include>
+                            </includes>
+                            <!-- Select the @Tag("tck-appclient") tests -->
+                            <groups>tck-appclient</groups>
                             <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
@@ -225,6 +287,102 @@
                                 <harness.log.traceflag>true</harness.log.traceflag>
                                 <cts.harness.debug>true</cts.harness.debug>
                                 <java.io.tmpdir>/tmp</java.io.tmpdir>
+                                <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                            <environmentVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>cdi-tests-javatest</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/yasson.jar</additionalClasspathElement>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
+                            </additionalClasspathElements>
+                            <includes>
+                                <include>com/sun/ts/tests/jsonb/cdi/**/*Servlet*.java</include>
+                                <include>com/sun/ts/tests/jsonb/cdi/**/*Jsp*.java</include>
+                            </includes>
+                            <!-- Select the @Tag("tck-javatest") tests -->
+                            <groups>tck-javatest</groups>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
+                            <systemPropertyVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                                <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                                <junit.log.traceflag>true</junit.log.traceflag>
+                                <harness.log.traceflag>true</harness.log.traceflag>
+                                <cts.harness.debug>true</cts.harness.debug>
+                                <java.io.tmpdir>/tmp</java.io.tmpdir>
+                                <arquillian.xml>arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                            <environmentVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>pluggability-tests-appclient</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <!-- <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/yasson.jar</additionalClasspathElement>
+                            </additionalClasspathElements> -->
+                            <includes>
+                                <include>com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/*Appclient*.java</include>
+                                <include>com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/*Ejb*.java</include>
+                            </includes>
+                            <!-- Select the @Tag("tck-appclient") tests -->
+                            <groups>tck-appclient</groups>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
+                            <systemPropertyVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                                <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                                <junit.log.traceflag>true</junit.log.traceflag>
+                                <harness.log.traceflag>true</harness.log.traceflag>
+                                <cts.harness.debug>true</cts.harness.debug>
+                                <java.io.tmpdir>/tmp</java.io.tmpdir>
+                                <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                            <environmentVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                            </environmentVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>pluggability-tests-javatest</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <!-- <additionalClasspathElements>
+                                <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/yasson.jar</additionalClasspathElement>
+                            </additionalClasspathElements> -->
+                            <includes>
+                                <include>com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/*Servlet*.java</include>
+                                <include>com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/*Jsp*.java</include>
+                            </includes>
+                            <!-- Select the @Tag("tck-javatest") tests -->
+                            <groups>tck-javatest</groups>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
+                            <systemPropertyVariables>
+                                <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
+                                <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                                <junit.log.traceflag>true</junit.log.traceflag>
+                                <harness.log.traceflag>true</harness.log.traceflag>
+                                <cts.harness.debug>true</cts.harness.debug>
+                                <java.io.tmpdir>/tmp</java.io.tmpdir>
+                                <arquillian.xml>arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>
                             <environmentVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>

--- a/glassfish-runner/jsonb-platform-tck/src/test/resources/appclient-arquillian.xml
+++ b/glassfish-runner/jsonb-platform-tck/src/test/resources/appclient-arquillian.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns="http://jboss.org/schema/arquillian"
+            xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <engine>
+    <property name="deploymentExportPath">target/deployments</property>
+  </engine>
+
+  <group qualifier="glassfish-servers" default="true">
+    <container qualifier="tck-appclient" default="true">
+        <configuration>
+            <property name="glassFishHome">target/glassfish8</property>
+        </configuration>
+        <protocol type="appclient">
+            <property name="runClient">true</property>
+            <property name="runAsVehicle">true</property>
+            <property name="clientEarDir">target/appclient</property>
+            <!-- Need to populate from ts.jte command.testExecuteAppClient setting for glassfish -->
+            <property name="clientCmdLineString">${jboss.home}/bin/appclient.sh;-y;target/test-classes/appclient.yml;-y;target/test-classes/derby.yml;${clientEarDir}/${vehicleArchiveName}.ear#${vehicleArchiveName}_client.jar</property>
+            <!-- Pass ENV vars here -->
+            <property name="clientEnvString">CLASSPATH=${project.build.directory}/appclient/javatest.jar:${project.build.directory}/appclient/libutil.jar:${project.build.directory}/appclient/libcommon.jar</property>
+            <property name="clientDir">${project.basedir}</property>
+            <property name="workDir">${ts.home}/tmp</property>
+            <property name="tsJteFile">${ts.home}/bin/ts.jte</property>
+            <property name="trace">true</property>
+            <property name="clientTimeout">20000</property>
+        </protocol>
+    </container>
+  </group>
+
+</arquillian>

--- a/glassfish-runner/jsonb-platform-tck/src/test/resources/arquillian.xml
+++ b/glassfish-runner/jsonb-platform-tck/src/test/resources/arquillian.xml
@@ -4,14 +4,19 @@
             xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
   <engine>
-    <!-- property name="deploymentExportPath">target/</property -->
+    <property name="deploymentExportPath">target/</property>
   </engine>
 
   <group qualifier="glassfish-servers" default="true">
-    <container qualifier="http" default="true">
+    <container qualifier="tck-javatest" default="true">
         <configuration>
             <property name="glassFishHome">target/glassfish8</property>
         </configuration>
+        <protocol type="javatest">
+            <property name="trace">true</property>
+            <property name="workDir">/tmp</property>
+            <property name="tsJteFile">${ts.home}/bin/ts.jte</property>
+        </protocol>
     </container>
   </group>
 

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -37,6 +37,8 @@
         <jakarta.json-api.version>2.1.3</jakarta.json-api.version>
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
+        <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
+        <version.jakarta.tck.arquillian>1.0.0-M15</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencies>
@@ -77,6 +79,31 @@
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-appclient</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-javatest</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-common</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-lib</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>tck-porting-lib</artifactId>
+            <version>${version.jakarta.tck.arquillian}</version>
         </dependency>
     </dependencies>
     <build>

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/AdaptersCustomizationCDIEjbTest.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/AdaptersCustomizationCDIEjbTest.java
@@ -1,0 +1,234 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters;
+
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.lib.harness.Status;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.AnimalShelterInjectedAdapter;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Animal;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Cat;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Dog;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import tck.arquillian.protocol.common.TargetVehicle;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+
+
+import java.lang.System.Logger;
+
+/**
+ * @test
+ * @sources AdaptersCustomizationTest.java
+ * @executeClass com.sun.ts.tests.jsonb.customizedmapping.adapters.AdaptersCustomizationTest
+ **/
+/*
+ * @class.setup_props: webServerHost; webServerPort; ts_home;
+ */
+
+@Tag("tck-appclient")
+@Tag("jsonb")
+@Tag("platform")
+@Tag("web")
+@ExtendWith(ArquillianExtension.class)
+public class AdaptersCustomizationCDIEjbTest extends ServiceEETest {
+
+  private static final long serialVersionUID = 10L;
+
+  static final String VEHICLE_ARCHIVE = "jsonb_cdi_customizedmapping_adapters_ejb_vehicle";
+
+  private final Jsonb jsonb = JsonbBuilder.create();
+
+  public static void main(String[] args) {
+    AdaptersCustomizationCDIEjbTest t = new AdaptersCustomizationCDIEjbTest();
+    Status s = t.run(args, System.out, System.err);
+    s.exit();
+  }
+
+  public void setup(String[] args, Properties p) throws Exception {
+    // logMsg("setup ok");
+  }
+
+  public void cleanup() throws Exception {
+    // logMsg("cleanup ok");
+  }
+
+  private static final Logger logger = System.getLogger(AdaptersCustomizationCDIEjbTest.class.getName());
+
+  private static String packagePath = AdaptersCustomizationCDIEjbTest.class.getPackageName().replace(".", "/");
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+  }
+
+  @TargetsContainer("tck-appclient")
+  @OverProtocol("appclient")
+  @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+  public static EnterpriseArchive createDeploymentVehicle() {
+  
+    JavaArchive jsonb_cdi_customizedmapping_adapters_ejb_vehicle_client = ShrinkWrap.create(JavaArchive.class, "jsonb_cdi_customizedmapping_adapters_ejb_vehicle_client.jar");
+    jsonb_cdi_customizedmapping_adapters_ejb_vehicle_client.addClass(AdaptersCustomizationCDIEjbTest.class)
+        .addClass(com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class)
+        .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
+        .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
+        .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
+        .addClass(com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class)
+        .addClass(com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRunner.class)
+        .addClass(com.sun.ts.lib.harness.EETest.class)
+        .addClass(com.sun.ts.lib.harness.EETest.Fault.class)
+        .addClass(com.sun.ts.lib.harness.EETest.SetupException.class)
+        .addClass(com.sun.ts.lib.harness.ServiceEETest.class);
+
+    URL resURL = AdaptersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_client.xml");
+    if(resURL != null) {
+      jsonb_cdi_customizedmapping_adapters_ejb_vehicle_client.addAsManifestResource(resURL, "application-client.xml");
+    }
+    jsonb_cdi_customizedmapping_adapters_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + AdaptersCustomizationCDIEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+
+    // resURL = AdaptersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_client.jar.sun-application-client.xml");
+    // if(resURL != null) {
+    //     jsonb_cdi_customizedmapping_adapters_ejb_vehicle_client.addAsManifestResource(resURL, "sun-ejb-jar.xml");
+    // }
+    // archiveProcessor.processEjbArchive(jsonb_cdi_customizedmapping_adapters_ejb_vehicle_client, AdaptersCustomizationCDIEjbTest.class, resURL);
+
+
+    JavaArchive jsonb_cdi_customizedmapping_adapters_ejb_vehicle_ejb = ShrinkWrap.create(JavaArchive.class, "jsonb_cdi_customizedmapping_adapters_ejb_vehicle_ejb.jar");
+    // The class files
+    jsonb_cdi_customizedmapping_adapters_ejb_vehicle_ejb.addClasses(
+        com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+        com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+        com.sun.ts.tests.common.vehicle.VehicleClient.class,
+        com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class,
+        com.sun.ts.tests.common.vehicle.ejb.EJBVehicle.class,
+        com.sun.ts.lib.harness.EETest.class,
+        com.sun.ts.lib.harness.EETest.Fault.class,
+        com.sun.ts.lib.harness.EETest.SetupException.class,
+        com.sun.ts.lib.harness.ServiceEETest.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalIdentifier.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalJson.TYPE.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalJson.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedAdapter.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedListAdapter.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Animal.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.AnimalShelterInjectedAdapter.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Cat.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Dog.class,
+        AdaptersCustomizationCDIEjbTest.class
+    );
+
+    // The ejb-jar.xml descriptor
+    URL ejbResURL = AdaptersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_ejb.xml");
+    if(ejbResURL != null) {
+      jsonb_cdi_customizedmapping_adapters_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
+    }
+
+    URL warResURL = AdaptersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/beans.xml");
+    if(warResURL != null) {
+      jsonb_cdi_customizedmapping_adapters_ejb_vehicle_ejb.addAsManifestResource(warResURL, "beans.xml");
+    }
+
+
+    // The sun-ejb-jar.xml file need to be added or should this be in in the vendor Arquillian extension?
+    // ejbResURL = AdaptersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_ejb.jar.sun-ejb-jar.xml");
+    // if(ejbResURL != null) {
+    //     jsonb_cdi_customizedmapping_adapters_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+    // }
+    // archiveProcessor.processEjbArchive(jsonb_cdi_customizedmapping_adapters_ejb_vehicle_ejb, AdaptersCustomizationCDIEjbTest.class, ejbResURL);
+
+    EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonb_cdi_customizedmapping_adapters_ejb_vehicle.ear");
+    ear.addAsModule(jsonb_cdi_customizedmapping_adapters_ejb_vehicle_client);
+    ear.addAsModule(jsonb_cdi_customizedmapping_adapters_ejb_vehicle_ejb);
+    
+    return ear;
+
+  }
+
+  /*
+   * @testName: testCDISupport
+   *
+   * @assertion_ids: JSONB:SPEC:JSB-4.7.1-3
+   *
+   * @test_Strategy: Assert that CDI injection is supported in adapters
+   */
+  @Test
+  @TargetVehicle("ejb")
+  public void testCDISupport() throws Exception {
+    AnimalShelterInjectedAdapter animalShelter = new AnimalShelterInjectedAdapter();
+    animalShelter.addAnimal(new Cat(5, "Garfield", 10.5f, true, true));
+    animalShelter.addAnimal(new Dog(3, "Milo", 5.5f, false, true));
+    animalShelter.addAnimal(new Animal(6, "Tweety", 0.5f, false));
+
+    String jsonString = jsonb.toJson(animalShelter);
+    if (!jsonString.matches("\\{\\s*\"animals\"\\s*:\\s*\\[\\s*"
+        + "\\{\\s*\"age\"\\s*:\\s*5\\s*,\\s*\"cuddly\"\\s*:\\s*true\\s*,\\s*\"furry\"\\s*:\\s*true\\s*,\\s*\"name\"\\s*:\\s*\"Garfield\"\\s*,\\s*\"type\"\\s*:\\s*\"CAT\"\\s*,\\s*\"weight\"\\s*:\\s*10.5\\s*}\\s*,\\s*"
+        + "\\{\\s*\"age\"\\s*:\\s*3\\s*,\\s*\"barking\"\\s*:\\s*true\\s*,\\s*\"furry\"\\s*:\\s*false\\s*,\\s*\"name\"\\s*:\\s*\"Milo\"\\s*,\\s*\"type\"\\s*:\\s*\"DOG\"\\s*,\\s*\"weight\"\\s*:\\s*5.5\\s*}\\s*,\\s*"
+        + "\\{\\s*\"age\"\\s*:\\s*6\\s*,\\s*\"furry\"\\s*:\\s*false\\s*,\\s*\"name\"\\s*:\\s*\"Tweety\"\\s*,\\s*\"type\"\\s*:\\s*\"GENERIC\"\\s*,\\s*\"weight\"\\s*:\\s*0.5\\s*}\\s*"
+        + "]\\s*}")) {
+      throw new Exception(
+          "Failed to correctly marshall complex type hierarchy using an adapter with a CDI managed field configured using JsonbTypeAdapter annotation to a simpler class.");
+    }
+
+    AnimalShelterInjectedAdapter unmarshalledObject = jsonb
+        .fromJson("{ \"animals\" : [ "
+            + "{ \"age\" : 5, \"cuddly\" : true, \"furry\" : true, \"name\" : \"Garfield\" , \"type\" : \"CAT\", \"weight\" : 10.5}, "
+            + "{ \"age\" : 3, \"barking\" : true, \"furry\" : false, \"name\" : \"Milo\", \"type\" : \"DOG\", \"weight\" : 5.5}, "
+            + "{ \"age\" : 6, \"furry\" : false, \"name\" : \"Tweety\", \"type\" : \"GENERIC\", \"weight\" : 0.5}"
+            + " ] }", AnimalShelterInjectedAdapter.class);
+    if (!animalShelter.equals(unmarshalledObject)) {
+      throw new Exception(
+          "Failed to correctly unmarshall complex type hierarchy using an adapter with a CDI managed field configured using JsonbTypeAdapter annotation to a simpler class.");
+    }
+  }
+}

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/AdaptersCustomizationCDIJspTest.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/AdaptersCustomizationCDIJspTest.java
@@ -32,6 +32,7 @@ import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 
 import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.lib.harness.Status;
 import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.AnimalShelterInjectedAdapter;
 import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Animal;
 import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Cat;
@@ -40,8 +41,9 @@ import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Dog;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-// import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 
 import org.junit.jupiter.api.AfterEach;
@@ -54,6 +56,10 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import tck.arquillian.protocol.common.TargetVehicle;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+
 
 import java.lang.System.Logger;
 
@@ -65,18 +71,23 @@ import java.lang.System.Logger;
 /*
  * @class.setup_props: webServerHost; webServerPort; ts_home;
  */
-@ExtendWith(ArquillianExtension.class)
-public class AdaptersCustomizationCDITestIT { //extends ServiceEETest {
 
-  private static final long serialVersionUID = 10L;
+@Tag("tck-javatest")
+@Tag("jsonb")
+@Tag("platform")
+@Tag("web")
+@ExtendWith(ArquillianExtension.class)
+public class AdaptersCustomizationCDIJspTest extends ServiceEETest {
+
+  static final String VEHICLE_ARCHIVE = "jsonb_cdi_customizedmapping_adapters_jsp_vehicle";
 
   private final Jsonb jsonb = JsonbBuilder.create();
 
-  // public static void main(String[] args) {
-  //   EETest t = new AdaptersCustomizationCDITest();
-  //   Status s = t.run(args, System.out, System.err);
-  //   s.exit();
-  // }
+  public static void main(String[] args) {
+    AdaptersCustomizationCDIJspTest t = new AdaptersCustomizationCDIJspTest();
+    Status s = t.run(args, System.out, System.err);
+    s.exit();
+  }
 
   public void setup(String[] args, Properties p) throws Exception {
     // logMsg("setup ok");
@@ -86,9 +97,9 @@ public class AdaptersCustomizationCDITestIT { //extends ServiceEETest {
     // logMsg("cleanup ok");
   }
 
-  private static final Logger logger = System.getLogger(AdaptersCustomizationCDITestIT.class.getName());
+  private static final Logger logger = System.getLogger(AdaptersCustomizationCDIJspTest.class.getName());
 
-  private static String packagePath = AdaptersCustomizationCDITestIT.class.getPackageName().replace(".", "/");
+  private static String packagePath = AdaptersCustomizationCDIJspTest.class.getPackageName().replace(".", "/");
 
   @BeforeEach
   void logStartTest(TestInfo testInfo) {
@@ -100,51 +111,49 @@ public class AdaptersCustomizationCDITestIT { //extends ServiceEETest {
       logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
   }
 
-  @Deployment(testable = false)
-  public static WebArchive createServletDeployment() throws IOException {
+  @TargetsContainer("tck-javatest")
+  @OverProtocol("javatest")
+  @Deployment(name = VEHICLE_ARCHIVE, testable = true)
+  public static EnterpriseArchive createServletDeployment() throws IOException {
   
   //   EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonb_cdi_customizedmapping_adapters_servlet_vehicle.ear");
-    WebArchive war = ShrinkWrap.create(WebArchive.class, "jsonb_cdi_customizedmapping_adapters_servlet_vehicle_web.war");
-    war.addClass(AdaptersCustomizationCDITestIT.class);
+    WebArchive jsonb_cdi_customizedmapping_adapters_jsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "jsonb_cdi_customizedmapping_adapters_jsp_vehicle_web.war");
+    jsonb_cdi_customizedmapping_adapters_jsp_vehicle_web.addClass(AdaptersCustomizationCDIJspTest.class)
+     .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
+     .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
+     .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
+     .addClass(com.sun.ts.lib.harness.EETest.class)
+     .addClass(com.sun.ts.lib.harness.EETest.SetupException.class)
+     .addClass(com.sun.ts.lib.harness.EETest.Fault.class)
+     .addClass(com.sun.ts.lib.harness.Status.class)
+     .addClass(com.sun.ts.lib.harness.ServiceEETest.class)
+     .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalIdentifier.class)
+     .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalJson.TYPE.class)
+     .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalJson.class)
+     .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedAdapter.class)
+     .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedListAdapter.class)
+     .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Animal.class)
+     .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.AnimalShelterInjectedAdapter.class)
+     .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Cat.class)
+     .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Dog.class);
 
-    war.addClass(com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class);
-    war.addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class);
-    war.addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class);
-    war.addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class);
-    war.addClass(com.sun.ts.lib.harness.EETest.class);
-    war.addClass(com.sun.ts.lib.harness.RemoteStatus.class);
-    war.addClass(com.sun.ts.lib.harness.Status.class);
-    war.addClass(com.sun.ts.lib.harness.ServiceEETest.class);
+     jsonb_cdi_customizedmapping_adapters_jsp_vehicle_web.setWebXML(AdaptersCustomizationCDIJspTest.class.getClassLoader().getResource(packagePath+"/jsp_vehicle_web.xml"));
 
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalIdentifier.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalJson.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedAdapter.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedListAdapter.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Animal.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.AnimalShelterInjectedAdapter.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Cat.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Dog.class);
+    // Web content
+    URL resURL = AdaptersCustomizationCDIJspTest.class.getResource("/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
+    jsonb_cdi_customizedmapping_adapters_jsp_vehicle_web.addAsWebResource(resURL, "/jsp_vehicle.jsp");
+    resURL = AdaptersCustomizationCDIJspTest.class.getResource("/vehicle/jsp/contentRoot/client.html");
+    jsonb_cdi_customizedmapping_adapters_jsp_vehicle_web.addAsWebResource(resURL, "/client.html");
 
-    // InputStream inStream = AdaptersCustomizationCDITestIT.class.getClassLoader().getResourceAsStream(packagePath + "/servlet_vehicle_web.xml");
-    // String webXml = editWebXmlString(inStream, "jsonb_cdi_customizedmapping_adapters_servlet_vehicle");
-    // war.setWebXML(new StringAsset(webXml));
-    war.setWebXML(AdaptersCustomizationCDITestIT.class.getClassLoader().getResource(packagePath+"/servlet_vehicle_web.xml"));
-
-    InputStream inStream = AdaptersCustomizationCDITestIT.class.getClassLoader().getResourceAsStream(packagePath+"/beans.xml");
-    String beansXml = toString(inStream);
-    war.addAsWebInfResource(new StringAsset(beansXml), "beans.xml");
-
-  //   war.as(ZipExporter.class).exportTo(new File("/tmp/jsonbprovidertests_servlet_vehicle_web.war"), true);
-  //   ear.addAsModule(war);
-
-    return war;
-
-  }
-
-  public static String toString(InputStream inStream) throws IOException{
-    try (BufferedReader bufReader = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
-      return bufReader.lines().collect(Collectors.joining(System.lineSeparator()));
+    URL warResURL = AdaptersCustomizationCDIJspTest.class.getClassLoader().getResource(packagePath+"/beans.xml");
+    if(warResURL != null) {
+      jsonb_cdi_customizedmapping_adapters_jsp_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/beans.xml");
     }
+
+    EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonb_cdi_customizedmapping_adapters_jsp_vehicle.ear");
+    ear.addAsModule(jsonb_cdi_customizedmapping_adapters_jsp_vehicle_web);
+    return ear;
+
   }
 
   /*
@@ -155,6 +164,7 @@ public class AdaptersCustomizationCDITestIT { //extends ServiceEETest {
    * @test_Strategy: Assert that CDI injection is supported in adapters
    */
   @Test
+  @TargetVehicle("jsp")
   public void testCDISupport() throws Exception {
     AnimalShelterInjectedAdapter animalShelter = new AnimalShelterInjectedAdapter();
     animalShelter.addAnimal(new Cat(5, "Garfield", 10.5f, true, true));

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/AdaptersCustomizationCDIServletTest.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/AdaptersCustomizationCDIServletTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters;
+
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.lib.harness.Status;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.AnimalShelterInjectedAdapter;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Animal;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Cat;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Dog;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import tck.arquillian.protocol.common.TargetVehicle;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+
+
+import java.lang.System.Logger;
+
+/**
+ * @test
+ * @sources AdaptersCustomizationTest.java
+ * @executeClass com.sun.ts.tests.jsonb.customizedmapping.adapters.AdaptersCustomizationTest
+ **/
+/*
+ * @class.setup_props: webServerHost; webServerPort; ts_home;
+ */
+
+@Tag("tck-javatest")
+@Tag("jsonb")
+@Tag("platform")
+@Tag("web")
+@ExtendWith(ArquillianExtension.class)
+public class AdaptersCustomizationCDIServletTest extends ServiceEETest {
+
+  private static final long serialVersionUID = 10L;
+
+  static final String VEHICLE_ARCHIVE = "jsonb_cdi_customizedmapping_adapters_servlet_vehicle";
+
+  private final Jsonb jsonb = JsonbBuilder.create();
+
+  public static void main(String[] args) {
+    AdaptersCustomizationCDIServletTest t = new AdaptersCustomizationCDIServletTest();
+    Status s = t.run(args, System.out, System.err);
+    s.exit();
+  }
+
+  public void setup(String[] args, Properties p) throws Exception {
+    // logMsg("setup ok");
+  }
+
+  public void cleanup() throws Exception {
+    // logMsg("cleanup ok");
+  }
+
+  private static final Logger logger = System.getLogger(AdaptersCustomizationCDIServletTest.class.getName());
+
+  private static String packagePath = AdaptersCustomizationCDIServletTest.class.getPackageName().replace(".", "/");
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+  }
+
+  @TargetsContainer("tck-javatest")
+  @OverProtocol("javatest")
+  @Deployment(name = VEHICLE_ARCHIVE, testable = true)
+  public static EnterpriseArchive createServletDeployment() throws Exception {
+  
+  //   EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonb_cdi_customizedmapping_adapters_servlet_vehicle.ear");
+    WebArchive war = ShrinkWrap.create(WebArchive.class, "jsonb_cdi_customizedmapping_adapters_servlet_vehicle_web.war");
+    war.addClass(AdaptersCustomizationCDIServletTest.class)
+      .addClass(com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class)
+      .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
+      .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
+      .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
+      .addClass(com.sun.ts.lib.harness.EETest.class)
+      .addClass(com.sun.ts.lib.harness.EETest.SetupException.class)      
+      .addClass(com.sun.ts.lib.harness.EETest.Fault.class)      
+      .addClass(com.sun.ts.lib.harness.ServiceEETest.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalIdentifier.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalJson.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedAdapter.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedListAdapter.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Animal.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.AnimalShelterInjectedAdapter.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Cat.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Dog.class);
+
+    // InputStream inStream = AdaptersCustomizationCDIServletTest.class.getClassLoader().getResourceAsStream(packagePath + "/servlet_vehicle_web.xml");
+    // String webXml = editWebXmlString(inStream, "jsonb_cdi_customizedmapping_adapters_servlet_vehicle");
+    // war.setWebXML(new StringAsset(webXml));
+    war.setWebXML(AdaptersCustomizationCDIServletTest.class.getClassLoader().getResource(packagePath+"/servlet_vehicle_web.xml"));
+
+    // InputStream inStream = AdaptersCustomizationCDIServletTest.class.getClassLoader().getResourceAsStream(packagePath+"/beans.xml");
+    // String beansXml = toString(inStream);
+    // war.addAsWebInfResource(AdaptersCustomizationCDIServletTest.class.getClassLoader().getResource(packagePath+"/beans.xml"));
+
+    URL warResURL = AdaptersCustomizationCDIServletTest.class.getClassLoader().getResource(packagePath+"/beans.xml");
+    if(warResURL != null) {
+      war.addAsWebResource(warResURL, "/WEB-INF/beans.xml");
+    }
+
+    EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonb_cdi_customizedmapping_adapters_servlet_vehicle.ear");
+    ear.addAsModule(war);
+    return ear;
+
+  }
+
+  // public static String toString(InputStream inStream) throws IOException{
+  //   try (BufferedReader bufReader = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
+  //     return bufReader.lines().collect(Collectors.joining(System.lineSeparator()));
+  //   }
+  // }
+
+  /*
+   * @testName: testCDISupport
+   *
+   * @assertion_ids: JSONB:SPEC:JSB-4.7.1-3
+   *
+   * @test_Strategy: Assert that CDI injection is supported in adapters
+   */
+  @Test
+  @TargetVehicle("servlet")
+  public void testCDISupport() throws Exception {
+    AnimalShelterInjectedAdapter animalShelter = new AnimalShelterInjectedAdapter();
+    animalShelter.addAnimal(new Cat(5, "Garfield", 10.5f, true, true));
+    animalShelter.addAnimal(new Dog(3, "Milo", 5.5f, false, true));
+    animalShelter.addAnimal(new Animal(6, "Tweety", 0.5f, false));
+
+    String jsonString = jsonb.toJson(animalShelter);
+    if (!jsonString.matches("\\{\\s*\"animals\"\\s*:\\s*\\[\\s*"
+        + "\\{\\s*\"age\"\\s*:\\s*5\\s*,\\s*\"cuddly\"\\s*:\\s*true\\s*,\\s*\"furry\"\\s*:\\s*true\\s*,\\s*\"name\"\\s*:\\s*\"Garfield\"\\s*,\\s*\"type\"\\s*:\\s*\"CAT\"\\s*,\\s*\"weight\"\\s*:\\s*10.5\\s*}\\s*,\\s*"
+        + "\\{\\s*\"age\"\\s*:\\s*3\\s*,\\s*\"barking\"\\s*:\\s*true\\s*,\\s*\"furry\"\\s*:\\s*false\\s*,\\s*\"name\"\\s*:\\s*\"Milo\"\\s*,\\s*\"type\"\\s*:\\s*\"DOG\"\\s*,\\s*\"weight\"\\s*:\\s*5.5\\s*}\\s*,\\s*"
+        + "\\{\\s*\"age\"\\s*:\\s*6\\s*,\\s*\"furry\"\\s*:\\s*false\\s*,\\s*\"name\"\\s*:\\s*\"Tweety\"\\s*,\\s*\"type\"\\s*:\\s*\"GENERIC\"\\s*,\\s*\"weight\"\\s*:\\s*0.5\\s*}\\s*"
+        + "]\\s*}")) {
+      throw new Exception(
+          "Failed to correctly marshall complex type hierarchy using an adapter with a CDI managed field configured using JsonbTypeAdapter annotation to a simpler class.");
+    }
+
+    AnimalShelterInjectedAdapter unmarshalledObject = jsonb
+        .fromJson("{ \"animals\" : [ "
+            + "{ \"age\" : 5, \"cuddly\" : true, \"furry\" : true, \"name\" : \"Garfield\" , \"type\" : \"CAT\", \"weight\" : 10.5}, "
+            + "{ \"age\" : 3, \"barking\" : true, \"furry\" : false, \"name\" : \"Milo\", \"type\" : \"DOG\", \"weight\" : 5.5}, "
+            + "{ \"age\" : 6, \"furry\" : false, \"name\" : \"Tweety\", \"type\" : \"GENERIC\", \"weight\" : 0.5}"
+            + " ] }", AnimalShelterInjectedAdapter.class);
+    if (!animalShelter.equals(unmarshalledObject)) {
+      throw new Exception(
+          "Failed to correctly unmarshall complex type hierarchy using an adapter with a CDI managed field configured using JsonbTypeAdapter annotation to a simpler class.");
+    }
+  }
+}

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/model/adapter/InjectedAdapter.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/model/adapter/InjectedAdapter.java
@@ -28,10 +28,8 @@ import jakarta.inject.Inject;
 import jakarta.json.bind.adapter.JsonbAdapter;
 
 public class InjectedAdapter implements JsonbAdapter<Animal, AnimalJson> {
-  // @Inject
-  // TODO: Check why Inject is not working. 
-  // creating object instead of Inject for now.
-  private AnimalIdentifier animalIdentifier = new AnimalIdentifier();
+  @Inject
+  private AnimalIdentifier animalIdentifier;
 
   @Override
   public AnimalJson adaptToJson(Animal animal) throws Exception {

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/model/adapter/InjectedListAdapter.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/model/adapter/InjectedListAdapter.java
@@ -30,10 +30,8 @@ import jakarta.json.bind.adapter.JsonbAdapter;
 
 public class InjectedListAdapter
     implements JsonbAdapter<List<Animal>, List<AnimalJson>> {
-  // @Inject
-  // TODO: Check why Inject is not working. 
-  // creating object instead of Inject for now.
-  private InjectedAdapter animalAdapter = new InjectedAdapter();
+  @Inject
+  private InjectedAdapter animalAdapter;
 
   @Override
   public List<AnimalJson> adaptToJson(List<Animal> animals) throws Exception {

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/SerializersCustomizationCDIEjbTest.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/SerializersCustomizationCDIEjbTest.java
@@ -1,0 +1,232 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers;
+
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.lib.harness.Status;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Animal;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Cat;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Dog;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import tck.arquillian.protocol.common.TargetVehicle;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+
+import java.lang.System.Logger;
+
+/**
+ * @test
+ * @sources SerializersCustomizationTest.java
+ * @executeClass com.sun.ts.tests.jsonb.customizedmapping.serializers.SerializersCustomizationTest
+ **/
+@Tag("tck-appclient")
+@Tag("jsonb")
+@Tag("platform")
+@Tag("web")
+@ExtendWith(ArquillianExtension.class)
+public class SerializersCustomizationCDIEjbTest extends ServiceEETest {
+
+  private static final long serialVersionUID = 10L;
+
+  static final String VEHICLE_ARCHIVE = "jsonb_cdi_customizedmapping_serializers_servlet_vehicle";
+
+  private final Jsonb jsonb = JsonbBuilder.create();
+
+  public static void main(String[] args) {
+    SerializersCustomizationCDIEjbTest t = new SerializersCustomizationCDIEjbTest();
+    Status s = t.run(args, System.out, System.err);
+    s.exit();
+  }
+
+  public void setup(String[] args, Properties p) throws Exception {
+    // logMsg("setup ok");
+  }
+
+  public void cleanup() throws Exception {
+    // logMsg("cleanup ok");
+  }
+
+  private static final Logger logger = System.getLogger(SerializersCustomizationCDIServletTest.class.getName());
+
+  private static String packagePath = SerializersCustomizationCDIServletTest.class.getPackageName().replace(".", "/");
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+  }
+
+  @TargetsContainer("tck-appclient")
+  @OverProtocol("appclient")
+  @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+  public static EnterpriseArchive createDeploymentVehicle() {
+
+    JavaArchive jsonb_cdi_customizedmapping_serializers_ejb_vehicle_client = ShrinkWrap.create(JavaArchive.class, "jsonb_cdi_customizedmapping_serializers_ejb_vehicle_client.jar");
+    jsonb_cdi_customizedmapping_serializers_ejb_vehicle_client.addClass(SerializersCustomizationCDIEjbTest.class)
+        .addClass(com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class)
+        .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
+        .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
+        .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
+        .addClass(com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class)
+        .addClass(com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRunner.class)
+        .addClass(com.sun.ts.lib.harness.EETest.class)
+        .addClass(com.sun.ts.lib.harness.EETest.Fault.class)
+        .addClass(com.sun.ts.lib.harness.EETest.SetupException.class)
+        .addClass(com.sun.ts.lib.harness.ServiceEETest.class);
+
+    URL resURL = SerializersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_client.xml");
+    if(resURL != null) {
+      jsonb_cdi_customizedmapping_serializers_ejb_vehicle_client.addAsManifestResource(resURL, "application-client.xml");
+    }
+    jsonb_cdi_customizedmapping_serializers_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + SerializersCustomizationCDIEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+
+    // resURL = AdaptersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_client.jar.sun-application-client.xml");
+    // if(resURL != null) {
+    //     jsonb_cdi_customizedmapping_serializers_ejb_vehicle_client.addAsManifestResource(resURL, "sun-ejb-jar.xml");
+    // }
+    // archiveProcessor.processEjbArchive(jsonb_cdi_customizedmapping_serializers_ejb_vehicle_client, SerializersCustomizationCDIEjbTest.class, resURL);
+
+
+    JavaArchive jsonb_cdi_customizedmapping_serializers_ejb_vehicle_ejb = ShrinkWrap.create(JavaArchive.class, "jsonb_cdi_customizedmapping_serializers_ejb_vehicle_ejb.jar");
+    // The class files
+    jsonb_cdi_customizedmapping_serializers_ejb_vehicle_ejb.addClasses(
+        com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+        com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+        com.sun.ts.tests.common.vehicle.VehicleClient.class,
+        com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class,
+        com.sun.ts.tests.common.vehicle.ejb.EJBVehicle.class,
+        com.sun.ts.lib.harness.EETest.class,
+        com.sun.ts.lib.harness.EETest.Fault.class,
+        com.sun.ts.lib.harness.EETest.SetupException.class,
+        com.sun.ts.lib.harness.ServiceEETest.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalIdentifier.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalJson.TYPE.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.AnimalJson.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedAdapter.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.adapter.InjectedListAdapter.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Animal.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.AnimalShelterInjectedAdapter.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Cat.class,
+        com.sun.ts.tests.jsonb.cdi.customizedmapping.adapters.model.Dog.class,
+        SerializersCustomizationCDIEjbTest.class
+    );
+
+    // The ejb-jar.xml descriptor
+    URL ejbResURL = SerializersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_ejb.xml");
+    if(ejbResURL != null) {
+      jsonb_cdi_customizedmapping_serializers_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
+    }
+
+    URL warResURL = SerializersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/beans.xml");
+    if(warResURL != null) {
+      jsonb_cdi_customizedmapping_serializers_ejb_vehicle_ejb.addAsManifestResource(warResURL, "beans.xml");
+    }
+
+
+    // The sun-ejb-jar.xml file need to be added or should this be in in the vendor Arquillian extension?
+    // ejbResURL = SerializersCustomizationCDIEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_ejb.jar.sun-ejb-jar.xml");
+    // if(ejbResURL != null) {
+    //     jsonb_cdi_customizedmapping_serializers_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+    // }
+    // archiveProcessor.processEjbArchive(jsonb_cdi_customizedmapping_serializers_ejb_vehicle_ejb, SerializersCustomizationCDIEjbTest.class, ejbResURL);
+
+    EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonb_cdi_customizedmapping_serializers_ejb_vehicle.ear");
+    ear.addAsModule(jsonb_cdi_customizedmapping_serializers_ejb_vehicle_client);
+    ear.addAsModule(jsonb_cdi_customizedmapping_serializers_ejb_vehicle_ejb);
+    
+    return ear;
+
+  }
+
+
+  /*
+   * @testName: testCDISupport
+   *
+   * @assertion_ids: JSONB:SPEC:JSB-4.7.2-3
+   *
+   * @test_Strategy: Assert that CDI injection is supported in serializers and
+   * deserializers
+   */
+  @Test
+  @TargetVehicle("ejb")
+  public void testCDISupport() throws Exception {
+    AnimalShelterWithInjectedSerializer animalShelter = new AnimalShelterWithInjectedSerializer();
+    animalShelter.addAnimal(new Cat(5, "Garfield", 10.5f, true, true));
+    animalShelter.addAnimal(new Dog(3, "Milo", 5.5f, false, true));
+    animalShelter.addAnimal(new Animal(6, "Tweety", 0.5f, false));
+
+    String jsonString = jsonb.toJson(animalShelter);
+    if (!jsonString.matches("\\{\\s*\"animals\"\\s*:\\s*\\[\\s*"
+        + "\\{\\s*\"type\"\\s*:\\s*\"cat\"\\s*,\\s*\"cuddly\"\\s*:\\s*true\\s*,\\s*\"age\"\\s*:\\s*5\\s*,\\s*\"furry\"\\s*:\\s*true\\s*,\\s*\"name\"\\s*:\\s*\"Garfield\"\\s*,\\s*\"weight\"\\s*:\\s*10.5\\s*}\\s*,\\s*"
+        + "\\{\\s*\"type\"\\s*:\\s*\"dog\"\\s*,\\s*\"barking\"\\s*:\\s*true\\s*,\\s*\"age\"\\s*:\\s*3\\s*,\\s*\"furry\"\\s*:\\s*false\\s*,\\s*\"name\"\\s*:\\s*\"Milo\"\\s*,\\s*\"weight\"\\s*:\\s*5.5\\s*}\\s*,\\s*"
+        + "\\{\\s*\"type\"\\s*:\\s*\"animal\"\\s*,\\s*\"age\"\\s*:\\s*6\\s*,\\s*\"furry\"\\s*:\\s*false\\s*,\\s*\"name\"\\s*:\\s*\"Tweety\"\\s*,\\s*\"weight\"\\s*:\\s*0.5\\s*}\\s*"
+        + "]\\s*}")) {
+      throw new Exception(
+          "Failed to correctly marshall complex type hierarchy using a serializer configured using JsonbTypeSerializer annotation and a deserializer with a CDI managed field configured using JsonbTypeDeserializer annotation.");
+    }
+
+    AnimalShelterWithInjectedSerializer unmarshalledObject = jsonb
+        .fromJson("{ \"animals\" : [ "
+            + "{ \"type\" : \"cat\", \"cuddly\" : true, \"age\" : 5, \"furry\" : true, \"name\" : \"Garfield\" , \"weight\" : 10.5}, "
+            + "{ \"type\" : \"dog\", \"barking\" : true, \"age\" : 3, \"furry\" : false, \"name\" : \"Milo\", \"weight\" : 5.5}, "
+            + "{ \"type\" : \"animal\", \"age\" : 6, \"furry\" : false, \"name\" : \"Tweety\", \"weight\" : 0.5}"
+            + " ] }", AnimalShelterWithInjectedSerializer.class);
+    if (!animalShelter.equals(unmarshalledObject)) {
+      throw new Exception(
+          "Failed to correctly unmarshall complex type hierarchy using a serializer configured using JsonbTypeSerializer annotation and a deserializer with a CDI managed field configured using JsonbTypeDeserializer annotation.");
+    }
+  }
+}

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/SerializersCustomizationCDIJspTest.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/SerializersCustomizationCDIJspTest.java
@@ -28,11 +28,11 @@ import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.net.URL;
 
-
 import jakarta.json.bind.Jsonb;
 import jakarta.json.bind.JsonbBuilder;
 
-// import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.lib.harness.Status;
 import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer;
 import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Animal;
 import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Cat;
@@ -57,6 +57,9 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
+import tck.arquillian.protocol.common.TargetVehicle;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 
 import java.lang.System.Logger;
 
@@ -65,18 +68,22 @@ import java.lang.System.Logger;
  * @sources SerializersCustomizationTest.java
  * @executeClass com.sun.ts.tests.jsonb.customizedmapping.serializers.SerializersCustomizationTest
  **/
+@Tag("tck-javatest")
+@Tag("jsonb")
+@Tag("platform")
+@Tag("web")
 @ExtendWith(ArquillianExtension.class)
-public class SerializersCustomizationCDITestIT { // extends ServiceEETest {
+public class SerializersCustomizationCDIJspTest extends ServiceEETest {
 
-  private static final long serialVersionUID = 10L;
+  static final String VEHICLE_ARCHIVE = "jsonb_cdi_customizedmapping_serializers_jsp_vehicle";
 
   private final Jsonb jsonb = JsonbBuilder.create();
 
-  // public static void main(String[] args) {
-  //   EETest t = new SerializersCustomizationCDITest();
-  //   Status s = t.run(args, System.out, System.err);
-  //   s.exit();
-  // }
+  public static void main(String[] args) {
+    SerializersCustomizationCDIJspTest t = new SerializersCustomizationCDIJspTest();
+    Status s = t.run(args, System.out, System.err);
+    s.exit();
+  }
 
   public void setup(String[] args, Properties p) throws Exception {
     // logMsg("setup ok");
@@ -86,9 +93,9 @@ public class SerializersCustomizationCDITestIT { // extends ServiceEETest {
     // logMsg("cleanup ok");
   }
 
-  private static final Logger logger = System.getLogger(SerializersCustomizationCDITestIT.class.getName());
+  private static final Logger logger = System.getLogger(SerializersCustomizationCDIJspTest.class.getName());
 
-  private static String packagePath = SerializersCustomizationCDITestIT.class.getPackageName().replace(".", "/");
+  private static String packagePath = SerializersCustomizationCDIJspTest.class.getPackageName().replace(".", "/");
 
   @BeforeEach
   void logStartTest(TestInfo testInfo) {
@@ -100,56 +107,50 @@ public class SerializersCustomizationCDITestIT { // extends ServiceEETest {
       logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
   }
 
-  @Deployment(testable = false)
-  public static WebArchive createServletDeployment() throws IOException {
+  @TargetsContainer("tck-javatest")
+  @OverProtocol("javatest")
+  @Deployment(name = VEHICLE_ARCHIVE, testable = true)
+  public static EnterpriseArchive createServletDeployment() throws Exception {
   
-    // EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonb_cdi_customizedmapping_serializers_servlet_vehicle.ear");
-    WebArchive war = ShrinkWrap.create(WebArchive.class, "jsonb_cdi_customizedmapping_serializers_servlet_vehicle_web.war");
-    war.addClass(SerializersCustomizationCDITestIT.class);
+    WebArchive jsonb_cdi_customizedmapping_serializers_jsp_vehicle = ShrinkWrap.create(WebArchive.class, "jsonb_cdi_customizedmapping_serializers_jsp_vehicle_web.war");
+    jsonb_cdi_customizedmapping_serializers_jsp_vehicle.addClass(SerializersCustomizationCDIJspTest.class)
+      .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
+      .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
+      .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
+      .addClass(com.sun.ts.lib.harness.EETest.class)
+      .addClass(com.sun.ts.lib.harness.EETest.SetupException.class)      
+      .addClass(com.sun.ts.lib.harness.EETest.Fault.class)      
+      .addClass(com.sun.ts.lib.harness.ServiceEETest.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalBuilder.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalBuilder.TYPE.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalDeserializer.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalDeserializerInjected.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalListDeserializerInjected.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalListSerializer.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalSerializer.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Animal.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Cat.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Dog.class);
 
-    war.addClass(com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class);
-    war.addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class);
-    war.addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class);
-    war.addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class);
-    war.addClass(com.sun.ts.lib.harness.EETest.class);
-    war.addClass(com.sun.ts.lib.harness.RemoteStatus.class);
-    war.addClass(com.sun.ts.lib.harness.Status.class);
-    war.addClass(com.sun.ts.lib.harness.ServiceEETest.class);
+    jsonb_cdi_customizedmapping_serializers_jsp_vehicle.setWebXML(SerializersCustomizationCDIJspTest.class.getClassLoader().getResource(packagePath+"/jsp_vehicle_web.xml"));
+    URL warResURL = SerializersCustomizationCDIJspTest.class.getClassLoader().getResource(packagePath+"/beans.xml");
+    if(warResURL != null) {
+      jsonb_cdi_customizedmapping_serializers_jsp_vehicle.addAsWebResource(warResURL, "/WEB-INF/beans.xml");
+    }
 
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalBuilder.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalDeserializer.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalDeserializerInjected.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalListDeserializerInjected.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalListSerializer.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalSerializer.class);
+    // Web content
+    URL resURL = SerializersCustomizationCDIJspTest.class.getResource("/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
+    jsonb_cdi_customizedmapping_serializers_jsp_vehicle.addAsWebResource(resURL, "/jsp_vehicle.jsp");
+    resURL = SerializersCustomizationCDIJspTest.class.getResource("/vehicle/jsp/contentRoot/client.html");
+    jsonb_cdi_customizedmapping_serializers_jsp_vehicle.addAsWebResource(resURL, "/client.html");    
 
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Animal.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Cat.class);
-    war.addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Dog.class);
-
-    // InputStream inStream = SerializersCustomizationCDITestIT.class.getClassLoader().getResourceAsStream(packagePath + "/servlet_vehicle_web.xml");
-    // String webXml = editWebXmlString(inStream, "jsonb_cdi_customizedmapping_serializers_servlet_vehicle");
-    // war.setWebXML(new StringAsset(webXml));
-
-    war.setWebXML(SerializersCustomizationCDITestIT.class.getClassLoader().getResource(packagePath+"/servlet_vehicle_web.xml"));
-
-    InputStream inStream = SerializersCustomizationCDITestIT.class.getClassLoader().getResourceAsStream(packagePath+"/beans.xml");
-    String beansXml = toString(inStream);
-    war.addAsWebInfResource(new StringAsset(beansXml), "beans.xml");
-    // war.as(ZipExporter.class).exportTo(new File("/Users/alwjosep/Downloads/jsonbprovidertests_servlet_vehicle_web.war"), true);
-
-    // ear.addAsModule(war);
-
-    return war;
+    EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonb_cdi_customizedmapping_serializers_jsp_vehicle.ear");
+    ear.addAsModule(jsonb_cdi_customizedmapping_serializers_jsp_vehicle);
+    return ear;
 
   }
 
-  public static String toString(InputStream inStream) throws IOException{
-      try (BufferedReader bufReader = new BufferedReader(new InputStreamReader(inStream, StandardCharsets.UTF_8))) {
-        return bufReader.lines().collect(Collectors.joining(System.lineSeparator()));
-      }
-  }
 
   /*
    * @testName: testCDISupport
@@ -160,6 +161,7 @@ public class SerializersCustomizationCDITestIT { // extends ServiceEETest {
    * deserializers
    */
   @Test
+  @TargetVehicle("jsp")
   public void testCDISupport() throws Exception {
     AnimalShelterWithInjectedSerializer animalShelter = new AnimalShelterWithInjectedSerializer();
     animalShelter.addAnimal(new Cat(5, "Garfield", 10.5f, true, true));

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/SerializersCustomizationCDIServletTest.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/SerializersCustomizationCDIServletTest.java
@@ -1,0 +1,189 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+
+package com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers;
+
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+
+import jakarta.json.bind.Jsonb;
+import jakarta.json.bind.JsonbBuilder;
+
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.lib.harness.Status;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Animal;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Cat;
+import com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Dog;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import tck.arquillian.protocol.common.TargetVehicle;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+
+import java.lang.System.Logger;
+
+/**
+ * @test
+ * @sources SerializersCustomizationTest.java
+ * @executeClass com.sun.ts.tests.jsonb.customizedmapping.serializers.SerializersCustomizationTest
+ **/
+@Tag("tck-javatest")
+@Tag("jsonb")
+@Tag("platform")
+@Tag("web")
+@ExtendWith(ArquillianExtension.class)
+public class SerializersCustomizationCDIServletTest extends ServiceEETest {
+
+  private static final long serialVersionUID = 10L;
+
+  static final String VEHICLE_ARCHIVE = "jsonb_cdi_customizedmapping_serializers_servlet_vehicle";
+
+  private final Jsonb jsonb = JsonbBuilder.create();
+
+  public static void main(String[] args) {
+    SerializersCustomizationCDIServletTest t = new SerializersCustomizationCDIServletTest();
+    Status s = t.run(args, System.out, System.err);
+    s.exit();
+  }
+
+  public void setup(String[] args, Properties p) throws Exception {
+    // logMsg("setup ok");
+  }
+
+  public void cleanup() throws Exception {
+    // logMsg("cleanup ok");
+  }
+
+  private static final Logger logger = System.getLogger(SerializersCustomizationCDIServletTest.class.getName());
+
+  private static String packagePath = SerializersCustomizationCDIServletTest.class.getPackageName().replace(".", "/");
+
+  @BeforeEach
+  void logStartTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+  }
+
+  @AfterEach
+  void logFinishTest(TestInfo testInfo) {
+      logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+  }
+
+  @TargetsContainer("tck-javatest")
+  @OverProtocol("javatest")
+  @Deployment(name = VEHICLE_ARCHIVE, testable = true)
+  public static EnterpriseArchive createServletDeployment() throws Exception {
+  
+    WebArchive war = ShrinkWrap.create(WebArchive.class, "jsonb_cdi_customizedmapping_serializers_servlet_vehicle_web.war");
+    war.addClass(SerializersCustomizationCDIServletTest.class)
+      .addClass(com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class)
+      .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
+      .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
+      .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
+      .addClass(com.sun.ts.lib.harness.EETest.class)
+      .addClass(com.sun.ts.lib.harness.EETest.SetupException.class)      
+      .addClass(com.sun.ts.lib.harness.EETest.Fault.class)      
+      .addClass(com.sun.ts.lib.harness.ServiceEETest.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalBuilder.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalBuilder.TYPE.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalDeserializer.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalDeserializerInjected.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalListDeserializerInjected.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalListSerializer.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.serializer.AnimalSerializer.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Animal.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.AnimalShelterWithInjectedSerializer.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Cat.class)
+      .addClass(com.sun.ts.tests.jsonb.cdi.customizedmapping.serializers.model.Dog.class);
+
+    war.setWebXML(SerializersCustomizationCDIServletTest.class.getClassLoader().getResource(packagePath+"/servlet_vehicle_web.xml"));
+    URL warResURL = SerializersCustomizationCDIServletTest.class.getClassLoader().getResource(packagePath+"/beans.xml");
+    if(warResURL != null) {
+      war.addAsWebResource(warResURL, "/WEB-INF/beans.xml");
+    }
+
+    EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonb_cdi_customizedmapping_serializers_servlet_vehicle.ear");
+    ear.addAsModule(war);
+    return ear;
+
+  }
+
+
+  /*
+   * @testName: testCDISupport
+   *
+   * @assertion_ids: JSONB:SPEC:JSB-4.7.2-3
+   *
+   * @test_Strategy: Assert that CDI injection is supported in serializers and
+   * deserializers
+   */
+  @Test
+  @TargetVehicle("servlet")
+  public void testCDISupport() throws Exception {
+    AnimalShelterWithInjectedSerializer animalShelter = new AnimalShelterWithInjectedSerializer();
+    animalShelter.addAnimal(new Cat(5, "Garfield", 10.5f, true, true));
+    animalShelter.addAnimal(new Dog(3, "Milo", 5.5f, false, true));
+    animalShelter.addAnimal(new Animal(6, "Tweety", 0.5f, false));
+
+    String jsonString = jsonb.toJson(animalShelter);
+    if (!jsonString.matches("\\{\\s*\"animals\"\\s*:\\s*\\[\\s*"
+        + "\\{\\s*\"type\"\\s*:\\s*\"cat\"\\s*,\\s*\"cuddly\"\\s*:\\s*true\\s*,\\s*\"age\"\\s*:\\s*5\\s*,\\s*\"furry\"\\s*:\\s*true\\s*,\\s*\"name\"\\s*:\\s*\"Garfield\"\\s*,\\s*\"weight\"\\s*:\\s*10.5\\s*}\\s*,\\s*"
+        + "\\{\\s*\"type\"\\s*:\\s*\"dog\"\\s*,\\s*\"barking\"\\s*:\\s*true\\s*,\\s*\"age\"\\s*:\\s*3\\s*,\\s*\"furry\"\\s*:\\s*false\\s*,\\s*\"name\"\\s*:\\s*\"Milo\"\\s*,\\s*\"weight\"\\s*:\\s*5.5\\s*}\\s*,\\s*"
+        + "\\{\\s*\"type\"\\s*:\\s*\"animal\"\\s*,\\s*\"age\"\\s*:\\s*6\\s*,\\s*\"furry\"\\s*:\\s*false\\s*,\\s*\"name\"\\s*:\\s*\"Tweety\"\\s*,\\s*\"weight\"\\s*:\\s*0.5\\s*}\\s*"
+        + "]\\s*}")) {
+      throw new Exception(
+          "Failed to correctly marshall complex type hierarchy using a serializer configured using JsonbTypeSerializer annotation and a deserializer with a CDI managed field configured using JsonbTypeDeserializer annotation.");
+    }
+
+    AnimalShelterWithInjectedSerializer unmarshalledObject = jsonb
+        .fromJson("{ \"animals\" : [ "
+            + "{ \"type\" : \"cat\", \"cuddly\" : true, \"age\" : 5, \"furry\" : true, \"name\" : \"Garfield\" , \"weight\" : 10.5}, "
+            + "{ \"type\" : \"dog\", \"barking\" : true, \"age\" : 3, \"furry\" : false, \"name\" : \"Milo\", \"weight\" : 5.5}, "
+            + "{ \"type\" : \"animal\", \"age\" : 6, \"furry\" : false, \"name\" : \"Tweety\", \"weight\" : 0.5}"
+            + " ] }", AnimalShelterWithInjectedSerializer.class);
+    if (!animalShelter.equals(unmarshalledObject)) {
+      throw new Exception(
+          "Failed to correctly unmarshall complex type hierarchy using a serializer configured using JsonbTypeSerializer annotation and a deserializer with a CDI managed field configured using JsonbTypeDeserializer annotation.");
+    }
+  }
+}

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/model/serializer/AnimalListDeserializerInjected.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/model/serializer/AnimalListDeserializerInjected.java
@@ -33,10 +33,8 @@ import jakarta.json.stream.JsonParser;
 
 public class AnimalListDeserializerInjected
     implements JsonbDeserializer<List<Animal>> {
-  // @Inject
-  // TODO: Check why Inject is not working. 
-  // creating object instead of Inject for now.
-  private AnimalDeserializer animalDeserializer = new AnimalDeserializer();
+  @Inject
+  private AnimalDeserializer animalDeserializer;
 
   public List<Animal> deserialize(JsonParser jsonParser,
       DeserializationContext deserializationContext, Type type) {

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ClientAppclientTest.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ClientAppclientTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.jsonb.pluggability.jsonbprovidertests;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.spi.JsonbProvider;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import tck.arquillian.protocol.common.TargetVehicle;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+
+import com.sun.ts.tests.jsonb.provider.MyJsonbBuilder;
+import com.sun.ts.tests.jsonb.provider.MyJsonbProvider;
+import com.sun.ts.lib.harness.Status;
+import com.sun.ts.lib.harness.ServiceEETest;
+import java.lang.System.Logger;
+
+@Tag("tck-appclient")
+@Tag("jsonb")
+@Tag("platform")
+@Tag("web")
+@ExtendWith(ArquillianExtension.class)
+public class ClientAppclientTest extends ServiceEETest {
+
+    private static final Logger logger = System.getLogger(ClientAppclientTest.class.getName());
+
+    static final String VEHICLE_ARCHIVE = "jsonprovidertests_appclient_vehicle";
+
+    private static String packagePath = ClientAppclientTest.class.getPackageName().replace(".", "/");
+
+    private static final String providerPackagePath = MyJsonbProvider.class.getPackageName().replace(".", "/");
+    
+    private boolean providerJarDeployed = false;
+    
+    public static final String TEMP_DIR = System.getProperty("java.io.tmpdir", "/tmp");
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    @TargetsContainer("tck-appclient")
+    @OverProtocol("appclient")
+    @Deployment(name = VEHICLE_ARCHIVE, testable = true)
+    public static EnterpriseArchive createAppclientDeployment() throws Exception {
+    
+        JavaArchive jarArchive = ShrinkWrap.create(JavaArchive.class, "jsonb_alternate_provider.jar")
+        .addClass(com.sun.ts.tests.jsonb.provider.MyJsonbBuilder.class)
+        .addClass(com.sun.ts.tests.jsonb.provider.MyJsonbProvider.class)
+        .addAsResource(new UrlAsset(com.sun.ts.tests.jsonb.provider.MyJsonbProvider.class.getClassLoader().getResource(providerPackagePath+"/META-INF/services/jakarta.json.bind.spi.JsonbProvider")), "META-INF/services/jakarta.json.bind.spi.JsonbProvider");    
+
+        JavaArchive jsonbprovidertests_appclient_vehicle_client = ShrinkWrap.create(JavaArchive.class, "jsonbprovidertests_appclient_vehicle_client.jar");
+        jsonbprovidertests_appclient_vehicle_client.addClass(ClientAppclientTest.class)
+          .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
+          .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
+          .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
+          .addClass(com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class)
+          .addClass(com.sun.ts.lib.harness.EETest.class)
+          .addClass(com.sun.ts.lib.harness.EETest.Fault.class)
+          .addClass(com.sun.ts.lib.harness.EETest.SetupException.class)
+          .addClass(com.sun.ts.lib.harness.ServiceEETest.class);
+        
+        URL resURL = ClientAppclientTest.class.getClassLoader().getResource(packagePath+"/appclient_vehicle_client.xml");
+        if(resURL != null) {
+            jsonbprovidertests_appclient_vehicle_client.addAsManifestResource(resURL, "application-client.xml");
+        }
+        jsonbprovidertests_appclient_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + ClientAppclientTest.class.getName() + "\n"), "MANIFEST.MF");
+    
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonbprovidertests_appclient_vehicle.ear");
+        ear.addAsModule(jsonbprovidertests_appclient_vehicle_client);
+        ear.addAsLibrary(jarArchive);
+        return ear;
+
+    }
+
+    public void removeProviderJarFromCP() throws Exception {
+		if (providerJarDeployed) {
+			URLClassLoader currentThreadClassLoader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
+			Thread.currentThread().setContextClassLoader(currentThreadClassLoader.getParent());
+			currentThreadClassLoader.close();
+			providerJarDeployed = false;
+		}
+	}
+
+	public void createProviderJar() throws Exception {
+        
+        JavaArchive jarArchive = ShrinkWrap.create(JavaArchive.class, "jsonb_alternate_provider.jar")
+            .addClass(MyJsonbBuilder.class)
+            .addClass(MyJsonbProvider.class)
+            .addAsResource(new UrlAsset(MyJsonbProvider.class.getClassLoader().getResource(providerPackagePath+"/META-INF/services/jakarta.json.bind.spi.JsonbProvider")), "META-INF/services/jakarta.json.bind.spi.JsonbProvider");
+
+        jarArchive.as(ZipExporter.class).exportTo(new File(TEMP_DIR + File.separator + "jsonb_alternate_provider.jar"), true);
+
+		ClassLoader currentThreadClassLoader = Thread.currentThread().getContextClassLoader();
+		URLClassLoader urlClassLoader = new URLClassLoader(
+				new URL[] { new File(TEMP_DIR + File.separator + "jsonb_alternate_provider.jar").toURL() },
+				currentThreadClassLoader);
+		Thread.currentThread().setContextClassLoader(urlClassLoader);
+
+		providerJarDeployed = true;
+
+	}
+    
+    private static final String MY_JSONBROVIDER_CLASS = "com.sun.ts.tests.jsonb.provider.MyJsonbProvider";
+    private static final String MY_JSONBBUILDER_CLASS = "com.sun.ts.tests.jsonb.provider.MyJsonbBuilder";
+
+    // public static void main(String[] args) {
+    //     Client theTests = new Client();
+    //     Status s = theTests.run(args, System.out, System.err);
+    //     s.exit();
+    // }
+
+
+    /* Test setup */
+
+    /*
+     * @class.setup_props:
+     */
+    @BeforeEach
+    public void setup() throws Exception {
+        createProviderJar();
+        logger.log(Logger.Level.INFO, "setup ok");
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        removeProviderJarFromCP();
+        logger.log(Logger.Level.INFO, "cleanup ok");
+    }
+
+    /* Tests */
+
+    /*
+     * @testName: jsonbProviderTest1
+     *
+     * @test_Strategy: Test call of SPI provider method with signature: o public
+     * static JsonbProvider provider()
+     */
+    @Test
+    @TargetVehicle("appclient")
+    public void jsonbProviderTest1() throws Exception {
+        try {
+            // Load any provider
+            JsonbProvider provider = JsonbProvider.provider();
+            String providerClass = provider.getClass().getName();
+            logger.log(Logger.Level.INFO, "provider class=" + providerClass);
+        } catch (Exception e) {
+            throw new Exception("jsonbProviderTest1 Failed: ", e);
+        }
+    }
+
+    /*
+     * @testName: jsonbProviderTest2
+     *
+     * @test_Strategy: Test call of SPI provider method with signature: o public
+     * static JsonbProvider provider(String provider)
+     */
+    @Test
+    @TargetVehicle("appclient")
+    public void jsonbProviderTest2() throws Exception {
+        boolean pass = true;
+        try {
+            // Load my provider
+            JsonbProvider provider = JsonbProvider.provider(MY_JSONBROVIDER_CLASS);
+            String providerClass = provider.getClass().getName();
+            logger.log(Logger.Level.INFO, "provider class=" + providerClass);
+            if (providerClass.equals(MY_JSONBROVIDER_CLASS))
+            logger.log(Logger.Level.INFO, "Current provider is my provider - expected.");
+            else {
+                logger.log(Logger.Level.ERROR, "Current provider is not my provider - unexpected.");
+                pass = false;
+                ServiceLoader<JsonbProvider> loader = ServiceLoader.load(JsonbProvider.class);
+                Iterator<JsonbProvider> it = loader.iterator();
+                List<JsonbProvider> providers = new ArrayList<>();
+                while(it.hasNext()) {
+                    providers.add(it.next());
+                }
+                logger.log(Logger.Level.INFO, "Providers: "+providers);
+            }
+        } catch (Exception e) {
+            throw new Exception("jsonbProviderTest2 Failed: ", e);
+        }
+        if (!pass)
+            throw new Exception("jsonbProviderTest2 Failed");
+    }
+
+    /*
+     * @testName: jsonbProviderTest3
+     *
+     * @test_Strategy: Test call of provider method with signature: o public JsonbBuilder create()
+     */
+    @Test
+    @TargetVehicle("appclient")
+    public void jsonbProviderTest3() throws Exception {
+        try {
+            // Load my provider
+            JsonbBuilder builder = JsonbProvider.provider(MY_JSONBROVIDER_CLASS).create();
+            String providerClass = builder.getClass().getName();
+            logger.log(Logger.Level.INFO, "jsonb builder class=" + providerClass);
+            if (providerClass.equals(MY_JSONBBUILDER_CLASS))
+            logger.log(Logger.Level.INFO, "Current jsonb builder is my builder - expected.");
+            else {
+                logger.log(Logger.Level.ERROR, "Current jsonb builder is not my builder - unexpected.");
+                throw new Exception("jsonbProviderTest3 Failed");
+            }
+        } catch (Exception e) {
+            throw new Exception("jsonbProviderTest3 Failed: ", e);
+        }
+    }
+
+}

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ClientEjbTest.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ClientEjbTest.java
@@ -1,0 +1,309 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.jsonb.pluggability.jsonbprovidertests;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.spi.JsonbProvider;
+import com.sun.ts.tests.jsonb.provider.MyJsonbBuilder;
+import com.sun.ts.tests.jsonb.provider.MyJsonbProvider;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import tck.arquillian.protocol.common.TargetVehicle;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+
+import com.sun.ts.lib.harness.Status;
+import com.sun.ts.lib.harness.ServiceEETest;
+import java.lang.System.Logger;
+
+@Tag("tck-appclient")
+@Tag("jsonb")
+@Tag("platform")
+@Tag("web")
+@ExtendWith(ArquillianExtension.class)
+public class ClientEjbTest extends ServiceEETest {
+
+    private static final Logger logger = System.getLogger(ClientEjbTest.class.getName());
+
+    static final String VEHICLE_ARCHIVE = "jsonprovidertests_ejb_vehicle";
+
+    private static String packagePath = ClientEjbTest.class.getPackageName().replace(".", "/");
+
+    private static final String providerPackagePath = MyJsonbProvider.class.getPackageName().replace(".", "/");
+    
+    private boolean providerJarDeployed = false;
+    
+    public static final String TEMP_DIR = System.getProperty("java.io.tmpdir", "/tmp");
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    @TargetsContainer("tck-appclient")
+    @OverProtocol("appclient")
+    @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+    public static EnterpriseArchive createDeploymentVehicle() {
+    // public static EnterpriseArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+
+        JavaArchive jsonb_alternate_provider = ShrinkWrap.create(JavaArchive.class, "jsonb_alternate_provider.jar")
+            .addClass(com.sun.ts.tests.jsonb.provider.MyJsonbBuilder.class)
+            .addClass(com.sun.ts.tests.jsonb.provider.MyJsonbProvider.class)
+            .addAsResource(new UrlAsset(com.sun.ts.tests.jsonb.provider.MyJsonbProvider.class.getClassLoader().getResource(providerPackagePath+"/META-INF/services/jakarta.json.bind.spi.JsonbProvider")), "META-INF/services/jakarta.json.bind.spi.JsonbProvider");
+
+        JavaArchive jsonbprovidertests_ejb_vehicle_client = ShrinkWrap.create(JavaArchive.class, "jsonbprovidertests_ejb_vehicle_client.jar");
+        jsonbprovidertests_ejb_vehicle_client.addClass(ClientEjbTest.class)
+            .addClass(com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class)
+            .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
+            .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
+            .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
+            .addClass(com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class)
+            .addClass(com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRunner.class)
+            .addClass(com.sun.ts.lib.harness.EETest.class)
+            .addClass(com.sun.ts.lib.harness.EETest.Fault.class)
+            .addClass(com.sun.ts.lib.harness.EETest.SetupException.class)
+            .addClass(com.sun.ts.lib.harness.ServiceEETest.class);
+
+        URL resURL = ClientEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_client.xml");
+        if(resURL != null) {
+            jsonbprovidertests_ejb_vehicle_client.addAsManifestResource(resURL, "application-client.xml");
+        }
+        jsonbprovidertests_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + ClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+
+        // resURL = ClientEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_client.jar.sun-application-client.xml");
+        // if(resURL != null) {
+        //     jsonbprovidertests_ejb_vehicle_client.addAsManifestResource(resURL, "sun-ejb-jar.xml");
+        // }
+        // archiveProcessor.processEjbArchive(jsonbprovidertests_ejb_vehicle_client, ClientEjbTest.class, resURL);
+
+
+        JavaArchive jsonbprovidertests_ejb_vehicle_ejb = ShrinkWrap.create(JavaArchive.class, "jsonbprovidertests_ejb_vehicle_ejb.jar");
+        // The class files
+        jsonbprovidertests_ejb_vehicle_ejb.addClasses(
+            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+            com.sun.ts.tests.common.vehicle.VehicleClient.class,
+            com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class,
+            com.sun.ts.tests.common.vehicle.ejb.EJBVehicle.class,
+            com.sun.ts.lib.harness.EETest.class,
+            com.sun.ts.lib.harness.EETest.Fault.class,
+            com.sun.ts.lib.harness.EETest.SetupException.class,
+            com.sun.ts.lib.harness.ServiceEETest.class,
+            ClientEjbTest.class       
+        );
+
+        // The ejb-jar.xml descriptor
+        URL ejbResURL = ClientEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_ejb.xml");
+        if(ejbResURL != null) {
+            jsonbprovidertests_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
+        }
+
+        // The sun-ejb-jar.xml file need to be added or should this be in in the vendor Arquillian extension?
+        // ejbResURL = ClientEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_ejb.jar.sun-ejb-jar.xml");
+        // if(ejbResURL != null) {
+        //     jsonbprovidertests_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+        // }
+        // archiveProcessor.processEjbArchive(jsonbprovidertests_ejb_vehicle_ejb, ClientEjbTest.class, ejbResURL);
+
+        EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonbprovidertests_ejb_vehicle.ear");
+        ear.addAsModule(jsonbprovidertests_ejb_vehicle_client);
+        ear.addAsModule(jsonbprovidertests_ejb_vehicle_ejb);
+        ear.addAsLibrary(jsonb_alternate_provider);
+        
+        return ear;
+
+    }
+
+    public void removeProviderJarFromCP() throws Exception {
+		if (providerJarDeployed) {
+			URLClassLoader currentThreadClassLoader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
+			Thread.currentThread().setContextClassLoader(currentThreadClassLoader.getParent());
+			currentThreadClassLoader.close();
+			providerJarDeployed = false;
+		}
+	}
+
+	public void createProviderJar() throws Exception {
+        
+        JavaArchive jarArchive = ShrinkWrap.create(JavaArchive.class, "jsonb_alternate_provider.jar")
+            .addClass(MyJsonbBuilder.class)
+            .addClass(MyJsonbProvider.class)
+            .addAsResource(new UrlAsset(MyJsonbProvider.class.getClassLoader().getResource(providerPackagePath+"/META-INF/services/jakarta.json.bind.spi.JsonbProvider")), "META-INF/services/jakarta.json.bind.spi.JsonbProvider");
+
+        jarArchive.as(ZipExporter.class).exportTo(new File(TEMP_DIR + File.separator + "jsonb_alternate_provider.jar"), true);
+
+		ClassLoader currentThreadClassLoader = Thread.currentThread().getContextClassLoader();
+		URLClassLoader urlClassLoader = new URLClassLoader(
+				new URL[] { new File(TEMP_DIR + File.separator + "jsonb_alternate_provider.jar").toURL() },
+				currentThreadClassLoader);
+		Thread.currentThread().setContextClassLoader(urlClassLoader);
+
+		providerJarDeployed = true;
+
+	}
+    
+    private static final String MY_JSONBROVIDER_CLASS = "com.sun.ts.tests.jsonb.provider.MyJsonbProvider";
+    private static final String MY_JSONBBUILDER_CLASS = "com.sun.ts.tests.jsonb.provider.MyJsonbBuilder";
+
+    public static void main(String[] args) {
+        ClientEjbTest theTests = new ClientEjbTest();
+        Status s = theTests.run(args, System.out, System.err);
+        s.exit();
+    }
+
+
+    /* Test setup */
+
+    /*
+     * @class.setup_props:
+     */
+    @BeforeEach
+    public void setup() throws Exception {
+        createProviderJar();
+        logger.log(Logger.Level.INFO, "setup ok");
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        removeProviderJarFromCP();
+        logger.log(Logger.Level.INFO, "cleanup ok");
+    }
+
+    /* Tests */
+
+    /*
+     * @testName: jsonbProviderTest1
+     *
+     * @test_Strategy: Test call of SPI provider method with signature: o public
+     * static JsonbProvider provider()
+     */
+    @Test
+    @TargetVehicle("ejb")
+    public void jsonbProviderTest1() throws Exception {
+        try {
+            // Load any provider
+            JsonbProvider provider = JsonbProvider.provider();
+            String providerClass = provider.getClass().getName();
+            logger.log(Logger.Level.INFO, "provider class=" + providerClass);
+        } catch (Exception e) {
+            throw new Exception("jsonbProviderTest1 Failed: ", e);
+        }
+    }
+
+    /*
+     * @testName: jsonbProviderTest2
+     *
+     * @test_Strategy: Test call of SPI provider method with signature: o public
+     * static JsonbProvider provider(String provider)
+     */
+    @Test
+    @TargetVehicle("ejb")
+    public void jsonbProviderTest2() throws Exception {
+        boolean pass = true;
+        try {
+            // Load my provider
+            JsonbProvider provider = JsonbProvider.provider(MY_JSONBROVIDER_CLASS);
+            String providerClass = provider.getClass().getName();
+            logger.log(Logger.Level.INFO, "provider class=" + providerClass);
+            if (providerClass.equals(MY_JSONBROVIDER_CLASS))
+            logger.log(Logger.Level.INFO, "Current provider is my provider - expected.");
+            else {
+                logger.log(Logger.Level.ERROR, "Current provider is not my provider - unexpected.");
+                pass = false;
+                ServiceLoader<JsonbProvider> loader = ServiceLoader.load(JsonbProvider.class);
+                Iterator<JsonbProvider> it = loader.iterator();
+                List<JsonbProvider> providers = new ArrayList<>();
+                while(it.hasNext()) {
+                    providers.add(it.next());
+                }
+                logger.log(Logger.Level.INFO, "Providers: "+providers);
+            }
+        } catch (Exception e) {
+            throw new Exception("jsonbProviderTest2 Failed: ", e);
+        }
+        if (!pass)
+            throw new Exception("jsonbProviderTest2 Failed");
+    }
+
+    /*
+     * @testName: jsonbProviderTest3
+     *
+     * @test_Strategy: Test call of provider method with signature: o public JsonbBuilder create()
+     */
+    @Test
+    @TargetVehicle("ejb")
+    public void jsonbProviderTest3() throws Exception {
+        try {
+            // Load my provider
+            JsonbBuilder builder = JsonbProvider.provider(MY_JSONBROVIDER_CLASS).create();
+            String providerClass = builder.getClass().getName();
+            logger.log(Logger.Level.INFO, "jsonb builder class=" + providerClass);
+            if (providerClass.equals(MY_JSONBBUILDER_CLASS))
+            logger.log(Logger.Level.INFO, "Current jsonb builder is my builder - expected.");
+            else {
+                logger.log(Logger.Level.ERROR, "Current jsonb builder is not my builder - unexpected.");
+                throw new Exception("jsonbProviderTest3 Failed");
+            }
+        } catch (Exception e) {
+            throw new Exception("jsonbProviderTest3 Failed: ", e);
+        }
+    }
+
+}

--- a/jsonb/src/main/java/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ClientServletTest.java
+++ b/jsonb/src/main/java/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ClientServletTest.java
@@ -1,0 +1,274 @@
+/*
+ * Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * $Id$
+ */
+package com.sun.ts.tests.jsonb.pluggability.jsonbprovidertests;
+
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Properties;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.io.InputStream;
+import java.io.IOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
+import java.net.URL;
+import java.net.URLClassLoader;
+
+import jakarta.json.bind.JsonbBuilder;
+import jakarta.json.bind.spi.JsonbProvider;
+
+import org.jboss.arquillian.container.test.api.RunAsClient;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.shrinkwrap.api.Filters;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.asset.UrlAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import tck.arquillian.protocol.common.TargetVehicle;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+
+import com.sun.ts.tests.jsonb.provider.MyJsonbBuilder;
+import com.sun.ts.tests.jsonb.provider.MyJsonbProvider;
+import com.sun.ts.lib.harness.Status;
+import com.sun.ts.lib.harness.ServiceEETest;
+import java.lang.System.Logger;
+
+@Tag("tck-javatest")
+@Tag("jsonb")
+@Tag("platform")
+@Tag("web")
+@ExtendWith(ArquillianExtension.class)
+public class ClientServletTest extends ServiceEETest {
+
+    private static final Logger logger = System.getLogger(ClientServletTest.class.getName());
+
+    static final String VEHICLE_ARCHIVE = "jsonbprovidertests_servlet_vehicle";
+
+    private static String packagePath = ClientServletTest.class.getPackageName().replace(".", "/");
+
+    private static final String providerPackagePath = MyJsonbProvider.class.getPackageName().replace(".", "/");
+    
+    private boolean providerJarDeployed = false;
+    
+    public static final String TEMP_DIR = System.getProperty("java.io.tmpdir", "/tmp");
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    @TargetsContainer("tck-javatest")
+    @OverProtocol("javatest")
+    @Deployment(name = VEHICLE_ARCHIVE, testable = true)
+    public static EnterpriseArchive createServletDeployment() throws Exception {
+    
+      WebArchive warArchive = ShrinkWrap.create(WebArchive.class, "jsonbprovidertests_servlet_vehicle_web.war");
+      warArchive.addClass(ClientServletTest.class)
+        .addClass(com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class)
+        .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class)
+        .addClass(com.sun.ts.tests.common.vehicle.VehicleRunnable.class)
+        .addClass(com.sun.ts.tests.common.vehicle.VehicleClient.class)
+        .addClass(com.sun.ts.lib.harness.EETest.class)
+        .addClass(com.sun.ts.lib.harness.EETest.Fault.class)
+        .addClass(com.sun.ts.lib.harness.EETest.SetupException.class)
+        .addClass(com.sun.ts.lib.harness.ServiceEETest.class)
+        .setWebXML(ClientServletTest.class.getClassLoader().getResource(packagePath+"/servlet_vehicle_web.xml"));
+
+      JavaArchive jarArchive = ShrinkWrap.create(JavaArchive.class, "jsonb_alternate_provider.jar")
+        .addClass(com.sun.ts.tests.jsonb.provider.MyJsonbBuilder.class)
+        .addClass(com.sun.ts.tests.jsonb.provider.MyJsonbProvider.class)
+        .addAsResource(new UrlAsset(com.sun.ts.tests.jsonb.provider.MyJsonbProvider.class.getClassLoader().getResource(providerPackagePath+"/META-INF/services/jakarta.json.bind.spi.JsonbProvider")), "META-INF/services/jakarta.json.bind.spi.JsonbProvider");
+
+      warArchive.addAsLibrary(jarArchive);
+
+      EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "jsonbprovidertests_servlet_vehicle.ear");
+      ear.addAsModule(warArchive);
+      ear.addAsLibrary(jarArchive);
+      return ear;
+
+    }
+
+    public void removeProviderJarFromCP() throws Exception {
+		if (providerJarDeployed) {
+			URLClassLoader currentThreadClassLoader = (URLClassLoader) Thread.currentThread().getContextClassLoader();
+			Thread.currentThread().setContextClassLoader(currentThreadClassLoader.getParent());
+			currentThreadClassLoader.close();
+			providerJarDeployed = false;
+		}
+	}
+
+	public void createProviderJar() throws Exception {
+        
+        JavaArchive jarArchive = ShrinkWrap.create(JavaArchive.class, "jsonb_alternate_provider.jar")
+            .addClass(MyJsonbBuilder.class)
+            .addClass(MyJsonbProvider.class)
+            .addAsResource(new UrlAsset(MyJsonbProvider.class.getClassLoader().getResource(providerPackagePath+"/META-INF/services/jakarta.json.bind.spi.JsonbProvider")), "META-INF/services/jakarta.json.bind.spi.JsonbProvider");
+
+        jarArchive.as(ZipExporter.class).exportTo(new File(TEMP_DIR + File.separator + "jsonb_alternate_provider.jar"), true);
+
+		ClassLoader currentThreadClassLoader = Thread.currentThread().getContextClassLoader();
+		URLClassLoader urlClassLoader = new URLClassLoader(
+				new URL[] { new File(TEMP_DIR + File.separator + "jsonb_alternate_provider.jar").toURL() },
+				currentThreadClassLoader);
+		Thread.currentThread().setContextClassLoader(urlClassLoader);
+
+		providerJarDeployed = true;
+
+	}
+    
+    private static final String MY_JSONBROVIDER_CLASS = "com.sun.ts.tests.jsonb.provider.MyJsonbProvider";
+    private static final String MY_JSONBBUILDER_CLASS = "com.sun.ts.tests.jsonb.provider.MyJsonbBuilder";
+
+    public static void main(String[] args) {
+        ClientServletTest theTests = new ClientServletTest();
+        Status s = theTests.run(args, System.out, System.err);
+        s.exit();
+    }
+
+    /*
+     * @class.setup_props:
+     * This is needed by the vehicle base classes
+     */
+    public void setup(String[] args, Properties p) throws Exception {
+
+    }
+
+
+
+    /* Test setup */
+
+    /*
+     * @class.setup_props:
+     */
+    @BeforeEach
+    public void setup() throws Exception {
+        createProviderJar();
+        logger.log(Logger.Level.INFO, "setup ok");
+    }
+
+    @AfterEach
+    public void cleanup() throws Exception {
+        removeProviderJarFromCP();
+        logger.log(Logger.Level.INFO, "cleanup ok");
+    }
+
+    /* Tests */
+
+    /*
+     * @testName: jsonbProviderTest1
+     *
+     * @test_Strategy: Test call of SPI provider method with signature: o public
+     * static JsonbProvider provider()
+     */
+    @Test
+    @TargetVehicle("servlet")
+    public void jsonbProviderTest1() throws Exception {
+        try {
+            // Load any provider
+            JsonbProvider provider = JsonbProvider.provider();
+            String providerClass = provider.getClass().getName();
+            logger.log(Logger.Level.INFO, "provider class=" + providerClass);
+        } catch (Exception e) {
+            throw new Exception("jsonbProviderTest1 Failed: ", e);
+        }
+    }
+
+    /*
+     * @testName: jsonbProviderTest2
+     *
+     * @test_Strategy: Test call of SPI provider method with signature: o public
+     * static JsonbProvider provider(String provider)
+     */
+    @Test
+    @TargetVehicle("servlet")
+    public void jsonbProviderTest2() throws Exception {
+        boolean pass = true;
+        try {
+            // Load my provider
+            JsonbProvider provider = JsonbProvider.provider(MY_JSONBROVIDER_CLASS);
+            String providerClass = provider.getClass().getName();
+            logger.log(Logger.Level.INFO, "provider class=" + providerClass);
+            if (providerClass.equals(MY_JSONBROVIDER_CLASS))
+            logger.log(Logger.Level.INFO, "Current provider is my provider - expected.");
+            else {
+                logger.log(Logger.Level.ERROR, "Current provider is not my provider - unexpected.");
+                pass = false;
+                ServiceLoader<JsonbProvider> loader = ServiceLoader.load(JsonbProvider.class);
+                Iterator<JsonbProvider> it = loader.iterator();
+                List<JsonbProvider> providers = new ArrayList<>();
+                while(it.hasNext()) {
+                    providers.add(it.next());
+                }
+                logger.log(Logger.Level.INFO, "Providers: "+providers);
+            }
+        } catch (Exception e) {
+            throw new Exception("jsonbProviderTest2 Failed: ", e);
+        }
+        if (!pass)
+            throw new Exception("jsonbProviderTest2 Failed");
+    }
+
+    /*
+     * @testName: jsonbProviderTest3
+     *
+     * @test_Strategy: Test call of provider method with signature: o public JsonbBuilder create()
+     */
+    @Test
+    @TargetVehicle("servlet")
+    public void jsonbProviderTest3() throws Exception {
+        try {
+            // Load my provider
+            JsonbBuilder builder = JsonbProvider.provider(MY_JSONBROVIDER_CLASS).create();
+            String providerClass = builder.getClass().getName();
+            logger.log(Logger.Level.INFO, "jsonb builder class=" + providerClass);
+            if (providerClass.equals(MY_JSONBBUILDER_CLASS))
+            logger.log(Logger.Level.INFO, "Current jsonb builder is my builder - expected.");
+            else {
+                logger.log(Logger.Level.ERROR, "Current jsonb builder is not my builder - unexpected.");
+                throw new Exception("jsonbProviderTest3 Failed");
+            }
+        } catch (Exception e) {
+            throw new Exception("jsonbProviderTest3 Failed: ", e);
+        }
+    }
+
+}

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/ejb_vehicle_client.jar.sun-application-client.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/ejb_vehicle_client.jar.sun-application-client.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-application-client PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 Application Client 5.0//EN" "http://www.sun.com/software/appserver/dtds/sun-application-client_5_0-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-application-client>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <jndi-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</jndi-name>
+  </ejb-ref>
+</sun-application-client>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/ejb_vehicle_client.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/ejb_vehicle_client.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application-client version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd">
+  <description>TS ejbvehicle client</description>
+  <display-name>jsonb_cdi_customizedmapping_adapters_ejb_vehicle_client</display-name>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <ejb-ref-type>Session</ejb-ref-type>
+    <remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</remote>
+  </ejb-ref>
+</application-client>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/ejb_vehicle_ejb.jar.sun-ejb-jar.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/ejb_vehicle_ejb.jar.sun-ejb-jar.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 EJB 3.0//EN" "http://www.sun.com/software/appserver/dtds/sun-ejb-jar_3_0-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-ejb-jar>
+  <enterprise-beans>
+    <unique-id>0</unique-id>
+    <ejb>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <jndi-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</jndi-name>
+      <pass-by-reference>false</pass-by-reference>
+      <ior-security-config>
+        <transport-config>
+          <integrity>supported</integrity>
+          <confidentiality>supported</confidentiality>
+          <establish-trust-in-target>supported</establish-trust-in-target>
+          <establish-trust-in-client>supported</establish-trust-in-client>
+        </transport-config>
+        <as-context>
+          <auth-method>username_password</auth-method>
+          <realm>default</realm>
+          <required>false</required>
+        </as-context>
+        <sas-context>
+          <caller-propagation>supported</caller-propagation>
+        </sas-context>
+      </ior-security-config>
+      <is-read-only-bean>false</is-read-only-bean>
+      <refresh-period-in-seconds>-1</refresh-period-in-seconds>
+      <gen-classes/>
+    </ejb>
+  </enterprise-beans>
+</sun-ejb-jar>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/ejb_vehicle_ejb.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/ejb_vehicle_ejb.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<ejb-jar version="4.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
+  <display-name>Ejb1</display-name>
+  <enterprise-beans>
+    <session>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <business-remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</business-remote>
+      <ejb-class>com.sun.ts.tests.common.vehicle.ejb.EJBVehicle</ejb-class>
+      <session-type>Stateful</session-type>
+      <transaction-type>Container</transaction-type>
+      <security-identity>
+        <use-caller-identity/>
+      </security-identity>
+    </session>
+  </enterprise-beans>
+  <assembly-descriptor>
+    <container-transaction>
+      <method>
+        <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+        <method-intf>Remote</method-intf>
+        <method-name>runTest</method-name>
+      </method>
+      <trans-attribute>Required</trans-attribute>
+    </container-transaction>
+  </assembly-descriptor>
+</ejb-jar>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/jsp_vehicle_web.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/adapters/jsp_vehicle_web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+  <display-name>jsonb_cdi_customizedmapping_adapters_jsp_vehicle</display-name>
+  <servlet>
+    <servlet-name>jsp_vehicle</servlet-name>
+    <jsp-file>/jsp_vehicle.jsp</jsp-file>
+    <load-on-startup>0</load-on-startup>
+  </servlet>
+  <session-config>
+    <session-timeout>54</session-timeout>
+  </session-config>
+</web-app>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/ejb_vehicle_client.jar.sun-application-client.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/ejb_vehicle_client.jar.sun-application-client.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-application-client PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 Application Client 5.0//EN" "http://www.sun.com/software/appserver/dtds/sun-application-client_5_0-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-application-client>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <jndi-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</jndi-name>
+  </ejb-ref>
+</sun-application-client>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/ejb_vehicle_client.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/ejb_vehicle_client.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application-client version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd">
+  <description>TS ejbvehicle client</description>
+  <display-name>jsonb_cdi_customizedmapping_serializers_ejb_vehicle_client</display-name>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <ejb-ref-type>Session</ejb-ref-type>
+    <remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</remote>
+  </ejb-ref>
+</application-client>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/ejb_vehicle_ejb.jar.sun-ejb-jar.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/ejb_vehicle_ejb.jar.sun-ejb-jar.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 EJB 3.0//EN" "http://www.sun.com/software/appserver/dtds/sun-ejb-jar_3_0-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-ejb-jar>
+  <enterprise-beans>
+    <unique-id>0</unique-id>
+    <ejb>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <jndi-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</jndi-name>
+      <pass-by-reference>false</pass-by-reference>
+      <ior-security-config>
+        <transport-config>
+          <integrity>supported</integrity>
+          <confidentiality>supported</confidentiality>
+          <establish-trust-in-target>supported</establish-trust-in-target>
+          <establish-trust-in-client>supported</establish-trust-in-client>
+        </transport-config>
+        <as-context>
+          <auth-method>username_password</auth-method>
+          <realm>default</realm>
+          <required>false</required>
+        </as-context>
+        <sas-context>
+          <caller-propagation>supported</caller-propagation>
+        </sas-context>
+      </ior-security-config>
+      <is-read-only-bean>false</is-read-only-bean>
+      <refresh-period-in-seconds>-1</refresh-period-in-seconds>
+      <gen-classes/>
+    </ejb>
+  </enterprise-beans>
+</sun-ejb-jar>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/ejb_vehicle_ejb.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/ejb_vehicle_ejb.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<ejb-jar version="4.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
+  <display-name>Ejb1</display-name>
+  <enterprise-beans>
+    <session>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <business-remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</business-remote>
+      <ejb-class>com.sun.ts.tests.common.vehicle.ejb.EJBVehicle</ejb-class>
+      <session-type>Stateful</session-type>
+      <transaction-type>Container</transaction-type>
+      <security-identity>
+        <use-caller-identity/>
+      </security-identity>
+    </session>
+  </enterprise-beans>
+  <assembly-descriptor>
+    <container-transaction>
+      <method>
+        <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+        <method-intf>Remote</method-intf>
+        <method-name>runTest</method-name>
+      </method>
+      <trans-attribute>Required</trans-attribute>
+    </container-transaction>
+  </assembly-descriptor>
+</ejb-jar>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/jsp_vehicle_web.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/cdi/customizedmapping/serializers/jsp_vehicle_web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+  <display-name>jsonb_cdi_customizedmapping_serializers_jsp_vehicle</display-name>
+  <servlet>
+    <servlet-name>jsp_vehicle</servlet-name>
+    <jsp-file>/jsp_vehicle.jsp</jsp-file>
+    <load-on-startup>0</load-on-startup>
+  </servlet>
+  <session-config>
+    <session-timeout>54</session-timeout>
+  </session-config>
+</web-app>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/appclient_vehicle_client.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/appclient_vehicle_client.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2022 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application-client version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd">
+  <description>TS app client vehicle</description>
+  <display-name>jsonbprovidertests_appclient_vehicle_client</display-name>
+</application-client>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ejb_vehicle_client.jar.sun-application-client.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ejb_vehicle_client.jar.sun-application-client.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-application-client PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 Application Client 5.0//EN" "http://www.sun.com/software/appserver/dtds/sun-application-client_5_0-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-application-client>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <jndi-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</jndi-name>
+  </ejb-ref>
+</sun-application-client>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ejb_vehicle_client.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ejb_vehicle_client.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application-client version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd">
+  <description>TS ejbvehicle client</description>
+  <display-name>jsonbprovidertests_ejb_vehicle_client</display-name>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <ejb-ref-type>Session</ejb-ref-type>
+    <remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</remote>
+  </ejb-ref>
+</application-client>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ejb_vehicle_ejb.jar.sun-ejb-jar.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ejb_vehicle_ejb.jar.sun-ejb-jar.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Application Server 9.0 EJB 3.0//EN" "http://www.sun.com/software/appserver/dtds/sun-ejb-jar_3_0-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-ejb-jar>
+  <enterprise-beans>
+    <unique-id>0</unique-id>
+    <ejb>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <jndi-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</jndi-name>
+      <pass-by-reference>false</pass-by-reference>
+      <ior-security-config>
+        <transport-config>
+          <integrity>supported</integrity>
+          <confidentiality>supported</confidentiality>
+          <establish-trust-in-target>supported</establish-trust-in-target>
+          <establish-trust-in-client>supported</establish-trust-in-client>
+        </transport-config>
+        <as-context>
+          <auth-method>username_password</auth-method>
+          <realm>default</realm>
+          <required>false</required>
+        </as-context>
+        <sas-context>
+          <caller-propagation>supported</caller-propagation>
+        </sas-context>
+      </ior-security-config>
+      <is-read-only-bean>false</is-read-only-bean>
+      <refresh-period-in-seconds>-1</refresh-period-in-seconds>
+      <gen-classes/>
+    </ejb>
+  </enterprise-beans>
+</sun-ejb-jar>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ejb_vehicle_ejb.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ejb_vehicle_ejb.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<ejb-jar version="4.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
+  <display-name>Ejb1</display-name>
+  <enterprise-beans>
+    <session>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <business-remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</business-remote>
+      <ejb-class>com.sun.ts.tests.common.vehicle.ejb.EJBVehicle</ejb-class>
+      <session-type>Stateful</session-type>
+      <transaction-type>Container</transaction-type>
+      <security-identity>
+        <use-caller-identity/>
+      </security-identity>
+    </session>
+  </enterprise-beans>
+  <assembly-descriptor>
+    <container-transaction>
+      <method>
+        <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+        <method-intf>Remote</method-intf>
+        <method-name>runTest</method-name>
+      </method>
+      <trans-attribute>Required</trans-attribute>
+    </container-transaction>
+  </assembly-descriptor>
+</ejb-jar>

--- a/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/jsp_vehicle_web.xml
+++ b/jsonb/src/main/resources/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/jsp_vehicle_web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+  <display-name>jsonbprovidertests_jsp_vehicle</display-name>
+  <servlet>
+    <servlet-name>jsp_vehicle</servlet-name>
+    <jsp-file>/jsp_vehicle.jsp</jsp-file>
+    <load-on-startup>0</load-on-startup>
+  </servlet>
+  <session-config>
+    <session-timeout>54</session-timeout>
+  </session-config>
+</web-app>

--- a/jsonb/src/main/resources/vehicle/jsp/contentRoot/client.html
+++ b/jsonb/src/main/resources/vehicle/jsp/contentRoot/client.html
@@ -1,0 +1,30 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+  <head>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+    <title>Invoke the generic Jsp for testing purposes</title>
+  </head>
+
+  <h1>Invoke the generic Jsp for testing purposes</h1>
+
+  <body>
+   <a href="jsp_vehicle.jsp"> Invoke the jsp here! </a>
+ </body>
+</html>

--- a/jsonb/src/main/resources/vehicle/jsp/contentRoot/jsp_vehicle.jsp
+++ b/jsonb/src/main/resources/vehicle/jsp/contentRoot/jsp_vehicle.jsp
@@ -1,0 +1,117 @@
+<%--
+
+    Copyright (c) 2006, 2020 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+--%>
+
+<%@ page language="java" %>
+<%@ page import="javax.naming.*" %>
+<%@ page import="java.rmi.RemoteException" %>
+<%@ page import="java.util.*" %>
+<%@ page import="java.io.*" %>
+<%@ page import="com.sun.ts.lib.util.*" %>
+<%@ page import="com.sun.ts.lib.harness.*" %>
+<%@ page import="com.sun.ts.lib.harness.Status" %>
+<%@ page session="false" %>
+
+<%! Properties properties = null;
+    String[] arguments = null;
+    EETest testObj = null;
+	Properties stp=new Properties();
+ 	StringBuffer propsData = new StringBuffer();
+
+%>
+
+<%! private RemoteStatus runTest() throws RemoteException {
+        RemoteStatus sTestStatus = new RemoteStatus(Status.passed(""));
+        try
+        {
+            //call EETest impl's run method
+            sTestStatus = new RemoteStatus(testObj.run(arguments, properties));
+            if(sTestStatus.getType() == Status.PASSED)
+				TestUtil.logMsg("Test running in jsp vehicle passed");
+			else
+				TestUtil.logMsg("Test running in jsp vehicle failed");
+        }
+        catch(Throwable e)
+        {
+            TestUtil.logErr("Test running in jsp vehicle failed", e);
+            sTestStatus =
+                new RemoteStatus(Status.failed("Test running in jsp vehicle failed"));
+        }
+	return sTestStatus;
+    }
+
+%>
+
+<%
+		try {
+            //get the inputstream and read any objects passed from the
+            //client, e.g. properties, args, etc.
+            //wrap the Inputstream in an ObjectInputstream and read
+            //the properties and args.
+            TestUtil.logTrace("JSPVehicle - In doJSPGet");
+            ObjectInputStream objInStream =
+                new ObjectInputStream(new BufferedInputStream(request.getInputStream()));
+            TestUtil.logTrace("JSPVehicle - got InputStream");
+            properties = (Properties)objInStream.readObject();
+            TestUtil.logTrace("JSP Vehicle -read properties!!!");
+            TestUtil.logTrace("JSP Vehicle - list the props ");
+            TestUtil.list(properties);
+            
+            //create an instance of the test client and run here
+            Class c =
+            Class.forName(properties.getProperty("test_classname"));
+            testObj = (EETest) c.newInstance();
+
+            arguments = (String[])objInStream.readObject();
+            //arguments = new String[1];
+            //arguments[0] = "";
+            TestUtil.logTrace("JSPVehicle - read Objects");
+            try
+            {
+                TestUtil.init(properties);
+                TestUtil.logTrace("Remote logging set for JSP Vehicle");
+                TestUtil.logTrace("JSPVehicle - Here are the props");
+                //TestUtil.list(properties);
+            }
+            catch (Exception e)
+            {
+                throw new ServletException("unable to initialize remote logging");
+            }
+            //now run the test and return the result
+            RemoteStatus finalStatus = runTest();
+			// Create properties object
+			stp.setProperty("type", String.valueOf(finalStatus.toStatus().getType()));
+			stp.setProperty("reason", finalStatus.toStatus().getReason());
+    		java.util.Enumeration key = stp.keys();
+    		String name;
+    		while (key.hasMoreElements())
+    		{
+     			name = (String)key.nextElement();
+     			propsData.append(name+"="+stp.getProperty(name)+"\n");
+    		}
+
+        }
+        catch(Exception e2)
+        {
+            System.out.println(e2.getMessage());
+            TestUtil.logTrace(e2.getMessage());
+            e2.printStackTrace();
+            throw new ServletException("test failed to run within the Servlet Vehicle");
+        }
+%>
+
+<%= propsData.toString() %>


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1373

**Describe the change**
- All jsonb tests refactored to run in ejb, jsp, servlet and appclient vehicles

**Additional context**
- The tests run in ejb, appclient vehicles need more changes especially in the glassfish runner, to pass the tests .

Total tests in jsonb : 18
Test failures : 8 (ejb, appclient vehicles)

