### PR TITLE
Simplify glassfish runners for jaxrs/javaee modules, add Junit tags for jaxrs based on keyword.properties

### DIFF
--- a/glassfish-runner/javaee-module-tck/pom.xml
+++ b/glassfish-runner/javaee-module-tck/pom.xml
@@ -27,10 +27,10 @@
     <packaging>jar</packaging>
 
     <properties>
-        <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
-        <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version>
-        <!-- Use JDK21 to run with GF 8.0.0-M5 -->
-        <!-- <glassfish.container.version>8.0.0-M5</glassfish.container.version> -->
+        <!-- Use JDK17 to run with GF 8.0.0-JDK17-M7 -->
+        <glassfish.container.version>8.0.0-JDK17-M7</glassfish.container.version>
+        <!-- Use JDK21 to run with GF 8.0.0-M7 -->
+        <!-- <glassfish.container.version>8.0.0-M7</glassfish.container.version> -->
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
@@ -105,65 +105,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>1-StopDomain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>stop-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>2-StartDomain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>start-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>3-EnableTraceRequests</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>set</argument>
-                                <argument>server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>4-StopDomain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>stop-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <version>3.0.0-M5</version>
                 <executions>
@@ -178,6 +119,8 @@
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                                <glassfish.maxHeapSize>2048m</glassfish.maxHeapSize>
+                                <glassfish.postBootCommands>set server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</glassfish.postBootCommands>
                                 <junit.log.traceflag>true</junit.log.traceflag>
                                 <harness.log.traceflag>true</harness.log.traceflag>
                                 <cts.harness.debug>true</cts.harness.debug>

--- a/glassfish-runner/jaxrs-platform-tck/pom.xml
+++ b/glassfish-runner/jaxrs-platform-tck/pom.xml
@@ -34,10 +34,10 @@
     by running jaxrs-platform-tck</description>
 
     <properties>
-        <!-- Use JDK17 to run with GF-8.0.0-JDK17-M5 -->
-        <!-- <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version> -->
-        <!-- Use JDK21 to run with GF-8.0.0-M5 -->
-        <glassfish.container.version>8.0.0-M5</glassfish.container.version>
+        <!-- Use JDK17 to run with GF-8.0.0-JDK17-M7 -->
+        <glassfish.container.version>8.0.0-JDK17-M7</glassfish.container.version>
+        <!-- Use JDK21 to run with GF-8.0.0-M7 -->
+        <!-- <glassfish.container.version>8.0.0-M7</glassfish.container.version> -->
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.artifactId>jaxrs-platform-tck</tck.artifactId>
@@ -144,154 +144,6 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>03-StopDomain1</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>stop-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>04-StartDomain1</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>start-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>05-Enable Trace requests</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>set</argument>
-                                <argument>server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>06-Delete User j2ee</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>--passwordfile</argument>
-                                <argument>${project.basedir}/j2ee.pass</argument>
-                                <argument>delete-file-user</argument>
-                                <argument>j2ee</argument>
-                            </arguments>
-                            <successCodes>
-                                <successCode>0</successCode>
-                                <successCode>1</successCode>
-                            </successCodes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>07-Add User j2ee</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>--passwordfile</argument>
-                                <argument>${project.basedir}/j2ee.pass</argument>
-                                <argument>create-file-user</argument>
-                                <argument>--groups</argument>
-                                <argument>staff:mgr</argument>
-                                <argument>j2ee</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>08-Delete User javajoe</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>--passwordfile</argument>
-                                <argument>${project.basedir}/javajoe.pass</argument>
-                                <argument>delete-file-user</argument>
-                                <argument>javajoe</argument>
-                            </arguments>
-                            <successCodes>
-                                <successCode>0</successCode>
-                                <successCode>1</successCode>
-                            </successCodes>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>09-Add User javajoe</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>--passwordfile</argument>
-                                <argument>${project.basedir}/javajoe.pass</argument>
-                                <argument>create-file-user</argument>
-                                <argument>--groups</argument>
-                                <argument>guest</argument>
-                                <argument>javajoe</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>10-list users</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>list-file-users</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>11-StopDomain</id>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                        <phase>pre-integration-test</phase>
-                        <configuration>
-                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
-                            <arguments>
-                                <argument>stop-domain</argument>
-                            </arguments>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
                 <executions>
                     <execution>
@@ -327,6 +179,10 @@
                             <systemPropertyVariables>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                                <glassfish.maxHeapSize>2048m</glassfish.maxHeapSize>
+                                <glassfish.postBootCommands>create-file-user --groups staff:mgr:DIRECTOR --passwordfile ${project.build.directory}/../j2ee.pass j2ee
+                                create-file-user --groups guest:OTHERROLE --passwordfile ${project.build.directory}/../javajoe.pass javajoe
+                                set server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true</glassfish.postBootCommands>
                                 <servlet_adaptor>org.glassfish.jersey.servlet.ServletContainer</servlet_adaptor>
                                 <webServerHost>localhost</webServerHost>
                                 <webServerPort>8080</webServerPort>

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/jaxrs21/platform/providers/jsonb/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/jaxrs21/platform/providers/jsonb/JAXRSClientIT.java
@@ -38,6 +38,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -54,6 +55,9 @@ import org.junit.jupiter.api.AfterEach;
  * @since 2.1
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   private static final long serialVersionUID = 21L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/jaxrs21/platform/providers/jsonp/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/jaxrs21/platform/providers/jsonp/JAXRSClientIT.java
@@ -30,6 +30,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -44,6 +45,9 @@ import org.junit.jupiter.api.AfterEach;
  * @since 2.1
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   private static final long serialVersionUID = 21L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/annotation/JAXRSClientIT.java
@@ -31,6 +31,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -46,6 +47,9 @@ import org.junit.jupiter.api.AfterEach;
  * Test the interceptor is called when any entity provider is called
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   private static final long serialVersionUID = 6890833876230368627L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/constraintviolationexceptionmapper/JAXRSClientIT.java
@@ -49,6 +49,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +66,9 @@ import org.junit.jupiter.api.AfterEach;
  * @since 2.1.0
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   private static final long serialVersionUID = 210L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/beanvalidation/validationexceptionmapper/JAXRSClientIT.java
@@ -49,6 +49,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -65,6 +66,9 @@ import org.junit.jupiter.api.AfterEach;
  * @since 2.1.0
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   private static final long serialVersionUID = 210L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/container/asyncejb/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/container/asyncejb/JAXRSClientIT.java
@@ -29,6 +29,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 import java.io.IOException;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -45,6 +46,9 @@ import org.junit.jupiter.api.AfterEach;
  * Servlet 2.5 spec by default
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   private static final long serialVersionUID = 8849202370030024015L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/container/asyncresponse/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/container/asyncresponse/JAXRSClientIT.java
@@ -48,6 +48,7 @@ import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,6 +65,9 @@ import org.junit.jupiter.api.AfterEach;
  * Servlet 2.5 spec by default
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   private static final long serialVersionUID = 8496602126019947248L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/container/completioncallback/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/container/completioncallback/JAXRSClientIT.java
@@ -43,6 +43,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -58,6 +59,9 @@ import org.junit.jupiter.api.AfterEach;
  * Servlet 2.5 spec by default
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   private static final long serialVersionUID = -234268814434213796L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/ejbsingleton/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/ejbsingleton/JAXRSClientIT.java
@@ -28,6 +28,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -38,6 +39,9 @@ import org.junit.jupiter.api.AfterEach;
  *                     ts_home;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   private static final long serialVersionUID = 3478378142622976090L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/ejbstateless/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/ejbstateless/JAXRSClientIT.java
@@ -29,6 +29,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +40,9 @@ import org.junit.jupiter.api.AfterEach;
  *                     ts_home;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   private static final long serialVersionUID = -96529594720799580L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/environment/servlet/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/environment/servlet/JAXRSClientIT.java
@@ -28,6 +28,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,6 +40,9 @@ import org.junit.jupiter.api.AfterEach;
  *                     ts_home;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   private static final long serialVersionUID = 1L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/managedbean299/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/managedbean299/JAXRSClientIT.java
@@ -27,6 +27,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,9 @@ import org.junit.jupiter.api.AfterEach;
  *                     ts_home;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   private static final long serialVersionUID = 6991563942877137460L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/provider/jsonp/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/provider/jsonp/JAXRSClientIT.java
@@ -27,6 +27,7 @@ import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.container.test.api.Deployment;
@@ -43,6 +44,9 @@ import org.junit.jupiter.api.AfterEach;
  *                     ts_home;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JaxrsCommonClient {
 
   private static final long serialVersionUID = 7441792527287072853L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletapp/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletapp/JAXRSClientIT.java
@@ -30,12 +30,16 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   private static final long serialVersionUID = 7205591021053120767L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletapp1/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletapp1/JAXRSClientIT.java
@@ -30,12 +30,16 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   private static final long serialVersionUID = 6923197915131448633L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletapp2/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletapp2/JAXRSClientIT.java
@@ -32,12 +32,16 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   private static final long serialVersionUID = -7156949059075869559L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletconfig/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletconfig/JAXRSClientIT.java
@@ -30,12 +30,16 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   private static final long serialVersionUID = 2085396717523375907L;

--- a/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletnoapp/JAXRSClientIT.java
+++ b/jaxrs/src/main/java/com/sun/ts/tests/jaxrs/platform/servletnoapp/JAXRSClientIT.java
@@ -34,12 +34,16 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.fail;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.AfterEach;
 
 @ExtendWith(ArquillianExtension.class)
+@Tag("jaxrs")
+@Tag("platform")
+@Tag("web")
 public class JAXRSClientIT extends JAXRSCommonClient {
 
   private static final long serialVersionUID = -840563347622231491L;


### PR DESCRIPTION
**Describe the change**
- Use glassfish.postBootCommands instead of maven plugin in javaee/jaxrs modules
- Add Junit tags for jaxrs tests based on keyword.properties


