### PR TITLE
Fix Pages platform tests failing with glassfish 

### DIFF
--- a/glassfish-runner/jsp-platform-tck/pom.xml
+++ b/glassfish-runner/jsp-platform-tck/pom.xml
@@ -47,7 +47,7 @@
         <derby.url>jdbc:derby://${derby.server}:${derby.port}/${derby.dbName};create=true</derby.url>
         <derby.user>cts1</derby.user>
         <exec.asadmin>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</exec.asadmin>
-        <glassfish.container.version>8.0.0-JDK17-M5</glassfish.container.version>
+        <glassfish.container.version>8.0.0-JDK17-M7</glassfish.container.version>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <jakarta.platform.version>11.0.0-M1</jakarta.platform.version>
         <jdbc.maxpoolsize>30</jdbc.maxpoolsize>
@@ -222,7 +222,7 @@
                                 create-jms-resource --restype jakarta.jms.QueueConnectionFactory jms/QueueConnectionFactory
                                 create-jms-resource --restype jakarta.jms.TopicConnectionFactory jms/TopicConnectionFactory
                                 create-jms-resource --restype jakarta.jms.ConnectionFactory --property name=cFactory jms/ConnectionFactory
-                                create-custom-resource --restype java.net.URL --factoryclass javax.naming.spi.ObjectFactory --property name=myUrl "http\://webServerHost\:webServerPort"</glassfish.postBootCommands>
+                                list-jndi-entries</glassfish.postBootCommands>
                                 <GLASSFISH_HOME>${project.build.directory}/${glassfish.toplevel.dir}</GLASSFISH_HOME>
                                 <webServerHome>${project.build.directory}/${glassfish.toplevel.dir}/glassfish</webServerHome>
                                 <webServerHost>localhost</webServerHost>

--- a/glassfish-runner/jsp-platform-tck/src/main/resources/jsp_tagext_resource_httplistener_web.war.sun-web.xml
+++ b/glassfish-runner/jsp-platform-tck/src/main/resources/jsp_tagext_resource_httplistener_web.war.sun-web.xml
@@ -57,7 +57,7 @@
     </resource-ref>
     <resource-ref>
       <res-ref-name>myUrl</res-ref-name>
-      <jndi-name>http://webServerHost:webServerPort</jndi-name>
+      <jndi-name>http://localhost:8080</jndi-name>
     </resource-ref>
     <message-destination-ref>
       <message-destination-ref-name>myQueue</message-destination-ref-name>

--- a/glassfish-runner/jsp-platform-tck/src/main/resources/jsp_tagext_resource_listener_web.war.sun-web.xml
+++ b/glassfish-runner/jsp-platform-tck/src/main/resources/jsp_tagext_resource_listener_web.war.sun-web.xml
@@ -57,7 +57,7 @@
     </resource-ref>
     <resource-ref>
       <res-ref-name>myUrl</res-ref-name>
-      <jndi-name>http://webServerHost:webServerPort</jndi-name>
+      <jndi-name>http://localhost:8080</jndi-name>
     </resource-ref>
     <message-destination-ref>
       <message-destination-ref-name>myQueue</message-destination-ref-name>

--- a/glassfish-runner/jsp-platform-tck/src/main/resources/jsp_tagext_resource_taghandler_web.war.sun-web.xml
+++ b/glassfish-runner/jsp-platform-tck/src/main/resources/jsp_tagext_resource_taghandler_web.war.sun-web.xml
@@ -57,7 +57,7 @@
       </resource-ref>
       <resource-ref>
         <res-ref-name>myUrl</res-ref-name>
-        <jndi-name>http://webServerHost:webServerPort</jndi-name>
+        <jndi-name>http://localhost:8080</jndi-name>
       </resource-ref>
     <message-destination-ref>
       <message-destination-ref-name>myQueue</message-destination-ref-name>


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1374 

**Describe the change**
- Hardcode the webserverHost and port number used in the glassfish descriptor files. The values need to be replaced with the host and port number of glassfish server.
- This will pass the remaining 10 failing tests in jsp module (ee.jakarta.tck.pages.spec.tagext.resource).