### PR TITLE
Address #1545 by revert "Bump jakarta.annotation:jakarta.annotation-api from 2.1.1 to 3.0.0 (#1467)" until we address #1184

### DIFF
--- a/core-profile-tck/pom.xml
+++ b/core-profile-tck/pom.xml
@@ -77,7 +77,7 @@
     <properties>
 
         <!-- Jakarta EE APIs Core -->
-        <annotations.api.version>3.0.0</annotations.api.version>
+        <annotations.api.version>2.1.1</annotations.api.version>
         <apache.httpclient.version>3.1</apache.httpclient.version>
 
         <cdi.api.version>4.0.0</cdi.api.version>

--- a/jsp/pom.xml
+++ b/jsp/pom.xml
@@ -34,7 +34,7 @@
     <description>JSP Tests for Jakarta EE Platform</description>
 
     <properties>
-        <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
+        <jakarta.annotation-api.version>3.0.0-M1</jakarta.annotation-api.version>
         <jakarta.el-api.version>6.0.0-RC1</jakarta.el-api.version>
         <jakarta.mail-api.version>2.1.2</jakarta.mail-api.version>
         <jakarta.servlet-api.version>6.1.0-M2</jakarta.servlet-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <jakarta-persistence-api.version>3.2.0</jakarta-persistence-api.version>
         <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
 
-        <jakarta.annotation-api.version>3.0.0</jakarta.annotation-api.version>
+        <jakarta.annotation-api.version>2.1.1</jakarta.annotation-api.version>
         <jakarta.authentication-api.version>3.1.0</jakarta.authentication-api.version>
         <jakarta.authorization-api.version>3.0.0</jakarta.authorization-api.version>
         <!-- Jakarta Batch -->


### PR DESCRIPTION


This reverts commit dfa720aa774bb4c670353d3afe89427f55a9d177.

Fixes compilation failure https://github.com/jakartaee/platform-tck/issues/1545