### PR TITLE
TCK should not redefine table on single table inheritance subclass for TCK challenge https://github.com/jakartaee/persistence/issues/644

### DIFF
--- a/install/jakartaee/bin/ts.jtx
+++ b/install/jakartaee/bin/ts.jtx
@@ -211,6 +211,25 @@ com/sun/ts/tests/jpa/core/annotations/version/Client.java#timestampPropertyTest_
 com/sun/ts/tests/jpa/core/annotations/version/Client.java#timestampPropertyTest_from_stateful3
 com/sun/ts/tests/jpa/core/annotations/version/Client.java#timestampPropertyTest_from_stateless3
 
+# https://github.com/jakartaee/persistence/issues/644 TCK should not redefine table on single table inheritance subclass
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest1_from_appmanaged 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest1_from_appmanagedNoTx 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest1_from_pmservlet 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest1_from_puservlet 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest1_from_stateful3 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest1_from_stateless3 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest2_from_appmanaged 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest2_from_appmanagedNoTx 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest2_from_pmservlet 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest2_from_puservlet 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest2_from_stateful3 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest2_from_stateless3 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest3_from_appmanaged 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest3_from_appmanagedNoTx 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest3_from_pmservlet 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest3_from_puservlet 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest3_from_stateful3 
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest3_from_stateless3 
 
 ################
 # Security API

--- a/install/jpa/bin/ts.jtx
+++ b/install/jpa/bin/ts.jtx
@@ -67,3 +67,7 @@ com/sun/ts/tests/jpa/core/annotations/version/Client.java#shortPropertyTest_from
 com/sun/ts/tests/jpa/core/annotations/version/Client.java#timestampFieldTest_from_standalone
 com/sun/ts/tests/jpa/core/annotations/version/Client.java#timestampPropertyTest_from_standalone
 
+# https://github.com/jakartaee/persistence/issues/644 TCK should not redefine table on single table inheritance subclass
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest1_from_standalone
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest2_from_standalone
+com/sun/ts/tests/jpa/core/inheritance/abstractentity/Client.java#abstractEntityTest3_from_standalone

--- a/release/tools/jakartaee.xml
+++ b/release/tools/jakartaee.xml
@@ -30,7 +30,7 @@
     <property name="sjsas.internal.compat"         value="NULL"/>
     <property name="cts.internal.comment"          value=""/>
     <property name="deliverable.version"           value="10.0"/>
-    <property name="deliverable.tck.version"           value="10.0.5"/>
+    <property name="deliverable.tck.version"           value="10.0.6"/>
 
 	<property name="the.excludes" value="**/internal/**/*,
 	     **/jaxm/**/*, **/jaxm1.0.1/**/*,

--- a/release/tools/jpa.xml
+++ b/release/tools/jpa.xml
@@ -22,7 +22,7 @@
     <import file="../../bin/xml/ts.common.props.xml"/>
 
     <property name="deliverable.version" value="3.1"/>
-    <property name="deliverable.tck.version" value="3.1.5"/>
+    <property name="deliverable.tck.version" value="3.1.6"/>
 
     <target name="init">
         <mkdir dir="${deliverable.bundle.dir}/bin"/>


### PR DESCRIPTION
Address accepted TCK challenge https://github.com/jakartaee/persistence/issues/644

**Fixes Issue**
https://github.com/jakartaee/persistence/issues/644

**Describe the change**
See the long discussion in https://github.com/jakartaee/persistence/issues/644

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
