### PR TITLE
Keep only the artifacts of the last 2 builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,7 +105,7 @@ def generateStandaloneTCKStage(job) {
 pipeline {
   options {
     durabilityHint('PERFORMANCE_OPTIMIZED')
-    buildDiscarder(logRotator(numToKeepStr: '15', artifactDaysToKeepStr: '15'))
+    buildDiscarder(logRotator(numToKeepStr: '15', artifactDaysToKeepStr: '15', artifactNumToKeepStr: '2'))
     timeout(time: 15, unit: 'HOURS')
   }
   agent {


### PR DESCRIPTION
To save disk space, the number of builds to keep with artifacts should be limited to 2.

This change should be applied to all branches.

**Fixes Issue**
Specify the issue (link) that is solved with this pull request.

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
A clear and concise description of the change.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
