### PR TITLE
Updates for the Core Profile TCK

### DIFF
--- a/core-profile-tck/ca-sigtest/pom.xml
+++ b/core-profile-tck/ca-sigtest/pom.xml
@@ -23,6 +23,11 @@
     <name>Common Annotations Signature Gen for Core Profile TCK</name>
     <description>This module contains is run to generate the signature test file</description>
 
+    <properties>
+        <sigtest.file.name>common-annotations-api.sig</sigtest.file.name>
+        <sigtest.path>${project.basedir}/src/main/resources/${sigtest.file.name}</sigtest.path>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>jakarta.annotation</groupId>
@@ -47,9 +52,9 @@
                         <configuration>
                             <artifacts>
                                 <artifact>
-                                    <file>src/main/resources/common-annotations-api-jdk11.sig</file>
+                                    <file>${sigtest.path}</file>
                                     <type>sig</type>
-                                    <classifier>sigtest-jdk11</classifier>
+                                    <classifier>sigtest</classifier>
                                 </artifact>
                             </artifacts>
                         </configuration>
@@ -102,12 +107,13 @@
                         <groupId>jakarta.tck</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
                         <configuration>
-                            <classes>${project.build.directory}/ca-api</classes>
+                            <classes>${project.build.directory}/ca-api/</classes>
                             <packages>jakarta.annotation,
                 jakarta.annotation.security,
                 jakarta.annotation.sql</packages>
                             <attach>false</attach>
-                            <sigfile>${project.build.directory}/common-annotations-api-jdk11.sig</sigfile>
+                            <sigfile>${sigtest.path}</sigfile>
+                            <release>${maven.compiler.release}</release>
                         </configuration>
                         <executions>
                             <execution>

--- a/core-profile-tck/ca-sigtest/pom.xml
+++ b/core-profile-tck/ca-sigtest/pom.xml
@@ -99,7 +99,7 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.netbeans.tools</groupId>
+                        <groupId>jakarta.tck</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
                         <configuration>
                             <classes>${project.build.directory}/ca-api</classes>

--- a/core-profile-tck/ca-sigtest/src/main/resources/common-annotations-api.sig
+++ b/core-profile-tck/ca-sigtest/src/main/resources/common-annotations-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 10.0.0-SNAPSHOT
+#Version 11.0.0-SNAPSHOT
 
 CLSS public abstract interface !annotation jakarta.annotation.Generated
  anno 0 java.lang.annotation.Documented()
@@ -9,13 +9,6 @@ intf java.lang.annotation.Annotation
 meth public abstract !hasdefault java.lang.String comments()
 meth public abstract !hasdefault java.lang.String date()
 meth public abstract java.lang.String[] value()
-
-CLSS public abstract interface !annotation jakarta.annotation.ManagedBean
- anno 0 java.lang.Deprecated(boolean forRemoval=false, java.lang.String since="")
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
-intf java.lang.annotation.Annotation
-meth public abstract !hasdefault java.lang.String value()
 
 CLSS public abstract interface !annotation jakarta.annotation.Nonnull
  anno 0 java.lang.annotation.Documented()
@@ -74,6 +67,8 @@ CLSS public abstract interface !annotation jakarta.annotation.Resources
 intf java.lang.annotation.Annotation
 meth public abstract jakarta.annotation.Resource[] value()
 
+CLSS abstract interface jakarta.annotation.package-info
+
 CLSS public abstract interface !annotation jakarta.annotation.security.DeclareRoles
  anno 0 java.lang.annotation.Documented()
  anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
@@ -106,6 +101,8 @@ CLSS public abstract interface !annotation jakarta.annotation.security.RunAs
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.String value()
+
+CLSS abstract interface jakarta.annotation.security.package-info
 
 CLSS public abstract interface !annotation jakarta.annotation.sql.DataSourceDefinition
  anno 0 java.lang.annotation.Repeatable(java.lang.Class<? extends java.lang.annotation.Annotation> value=class jakarta.annotation.sql.DataSourceDefinitions)
@@ -142,18 +139,12 @@ CLSS public abstract interface java.io.Serializable
 CLSS public abstract interface java.lang.Comparable<%0 extends java.lang.Object>
 meth public abstract int compareTo({java.lang.Comparable%0})
 
-CLSS public abstract interface !annotation java.lang.Deprecated
- anno 0 java.lang.annotation.Documented()
- anno 0 java.lang.annotation.Retention(java.lang.annotation.RetentionPolicy value=RUNTIME)
- anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[CONSTRUCTOR, FIELD, LOCAL_VARIABLE, METHOD, PACKAGE, MODULE, PARAMETER, TYPE])
-intf java.lang.annotation.Annotation
-meth public abstract !hasdefault boolean forRemoval()
-meth public abstract !hasdefault java.lang.String since()
-
 CLSS public abstract java.lang.Enum<%0 extends java.lang.Enum<{java.lang.Enum%0}>>
 cons protected init(java.lang.String,int)
+innr public final static EnumDesc
 intf java.io.Serializable
 intf java.lang.Comparable<{java.lang.Enum%0}>
+intf java.lang.constant.Constable
 meth protected final java.lang.Object clone() throws java.lang.CloneNotSupportedException
 meth protected final void finalize()
 meth public final boolean equals(java.lang.Object)
@@ -162,6 +153,7 @@ meth public final int hashCode()
 meth public final int ordinal()
 meth public final java.lang.Class<{java.lang.Enum%0}> getDeclaringClass()
 meth public final java.lang.String name()
+meth public final java.util.Optional<java.lang.Enum$EnumDesc<{java.lang.Enum%0}>> describeConstable()
 meth public java.lang.String toString()
 meth public static <%0 extends java.lang.Enum<{%%0}>> {%%0} valueOf(java.lang.Class<{%%0}>,java.lang.String)
 supr java.lang.Object
@@ -213,4 +205,7 @@ CLSS public abstract interface !annotation java.lang.annotation.Target
  anno 0 java.lang.annotation.Target(java.lang.annotation.ElementType[] value=[ANNOTATION_TYPE])
 intf java.lang.annotation.Annotation
 meth public abstract java.lang.annotation.ElementType[] value()
+
+CLSS public abstract interface java.lang.constant.Constable
+meth public abstract java.util.Optional<? extends java.lang.constant.ConstantDesc> describeConstable()
 

--- a/core-profile-tck/pom.xml
+++ b/core-profile-tck/pom.xml
@@ -77,7 +77,7 @@
     <properties>
 
         <!-- Jakarta EE APIs Core -->
-        <annotations.api.version>2.1.1</annotations.api.version>
+        <annotations.api.version>3.0.0</annotations.api.version>
         <apache.httpclient.version>3.1</apache.httpclient.version>
 
         <cdi.api.version>4.0.0</cdi.api.version>

--- a/core-profile-tck/pom.xml
+++ b/core-profile-tck/pom.xml
@@ -91,7 +91,7 @@
         <jsonb.api.version>3.0.0</jsonb.api.version>
         <jsonp.api.version>2.1.0</jsonp.api.version>
         <junit.version>5.8.2</junit.version>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <rest.api.version>3.1.0</rest.api.version>
         <rest.tck.version>3.1.1</rest.tck.version>
 

--- a/core-profile-tck/tck-dist/artifacts-pom.xml
+++ b/core-profile-tck/tck-dist/artifacts-pom.xml
@@ -183,8 +183,8 @@
               <artifactId>common-annotations</artifactId>
               <version>${project.version}</version>
               <packaging>sig</packaging>
-              <classifier>sigtest-jdk11</classifier>
-              <file>common-annotations-${project.version}-sigtest-jdk11.sig</file>
+              <classifier>sigtest</classifier>
+              <file>common-annotations-${project.version}-sigtest.sig</file>
               <generatePom>false</generatePom>
             </configuration>
           </execution>

--- a/core-profile-tck/tck-dist/pom.xml
+++ b/core-profile-tck/tck-dist/pom.xml
@@ -57,7 +57,7 @@
             <groupId>jakarta.ee.tck.coreprofile</groupId>
             <artifactId>common-annotations</artifactId>
             <version>${project.version}</version>
-            <classifier>sigtest-jdk11</classifier>
+            <classifier>sigtest</classifier>
             <type>sig</type>
         </dependency>
         <dependency>

--- a/el-tck/docs/userguide/src/main/jbake/content/config.inc
+++ b/el-tck/docs/userguide/src/main/jbake/content/config.inc
@@ -98,9 +98,9 @@ slashes as a path separator instead.
 [source,oac_no_warn]
 ----
       <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.4</version>
+            <version>2.2</version>
         </dependency>
 ----
 +

--- a/el-tck/docs/userguide/src/main/jbake/content/using-examples.inc
+++ b/el-tck/docs/userguide/src/main/jbake/content/using-examples.inc
@@ -22,9 +22,9 @@ sigtest-maven-plugin in the TCK runner as below.
 
 =======================================================================
 <plugin>
-    <groupId>org.netbeans.tools</groupId>
+    <groupId>jakarta.tck</groupId>
     <artifactId>sigtest-maven-plugin</artifactId>
-    <version>1.5</version>
+    <version>2.2</version>
     <configuration>
         <sigfile>path-to-sig-file-provided-with-TCK</sigfile>
         <packages>jakarta.el</packages>

--- a/glassfish-runner/annotations-tck/pom.xml
+++ b/glassfish-runner/annotations-tck/pom.xml
@@ -60,9 +60,8 @@
             <version>${tck.version}</version>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
         </dependency>
     </dependencies>
 
@@ -123,9 +122,9 @@
             </plugin>
 
             <!-- <plugin>
-                <groupId>org.netbeans.tools</groupId>
+                <groupId>jakarta.tck</groupId>
                 <artifactId>sigtest-maven-plugin</artifactId>
-                <version>1.5</version>
+                <version>2.2</version>
                 <configuration>
                     <sigfile>target/annotations-tck/jakarta.annotation.sig</sigfile>
                     <packages>jakarta.annotation,jakarta.annotation.security,jakarta.annotation.sql,akarta.annotation.Generated,jakarta.annotation.ManagedBean,jakarta.annotation.PostConstruct,jakarta.annotation.PreDestroy,jakarta.annotation.Priority,jakarta.annotation.Resource,jakarta.annotation.Resource$AuthenticationType,jakarta.annotation.Resources,jakarta.annotation.security.DeclareRoles,jakarta.annotation.security.DenyAll,jakarta.annotation.security.PermitAll,jakarta.annotation.security.RolesAllowed,jakarta.annotation.security.RunAs,jakarta.annotation.sql.DataSourceDefinition,jakarta.annotation.sql.DataSourceDefinitions</packages>

--- a/glassfish-runner/batch-tck/sigtests/pom.xml
+++ b/glassfish-runner/batch-tck/sigtests/pom.xml
@@ -103,9 +103,8 @@
                 </executions>
             </plugin>
             <plugin>
-                <groupId>org.netbeans.tools</groupId>
+                <groupId>jakarta.tck</groupId>
                 <artifactId>sigtest-maven-plugin</artifactId>
-                <version>1.6</version>
                 <configuration>
                     <action>strictcheck</action>
                     <failOnError>true</failOnError>
@@ -134,7 +133,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.netbeans.tools</groupId>
+                        <groupId>jakarta.tck</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
                         <configuration>
                             <sigfile>${project.build.directory}/sigtest-copy/sigtest/sigtest-1.6-batch.standalone.tck.sig-2.1-se11-OpenJDK-J9</sigfile>
@@ -152,7 +151,7 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.netbeans.tools</groupId>
+                        <groupId>jakarta.tck</groupId>
                         <artifactId>sigtest-maven-plugin</artifactId>
                         <configuration>
                             <sigfile>${project.build.directory}/sigtest-copy/sigtest/sigtest-1.6-batch.standalone.tck.sig-2.1-se17-TemurinHotSpot</sigfile>

--- a/glassfish-runner/concurrency-tck/pom.xml
+++ b/glassfish-runner/concurrency-tck/pom.xml
@@ -100,9 +100,8 @@
 
         <!--  Signature Test Plugin  -->
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
         </dependency>
     </dependencies>
 

--- a/glassfish-runner/jsonb-tck/pom.xml
+++ b/glassfish-runner/jsonb-tck/pom.xml
@@ -31,9 +31,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.6</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.weld.se</groupId>

--- a/glassfish-runner/jsonp-tck/json-tck-tests-pluggability/pom.xml
+++ b/glassfish-runner/jsonp-tck/json-tck-tests-pluggability/pom.xml
@@ -33,9 +33,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.6</version>
         </dependency>
     </dependencies>
 

--- a/glassfish-runner/jsonp-tck/json-tck-tests/pom.xml
+++ b/glassfish-runner/jsonp-tck/json-tck-tests/pom.xml
@@ -51,9 +51,8 @@
             </exclusions>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.6</version>
         </dependency>
     </dependencies>
 

--- a/glassfish-runner/rest-tck/pom.xml
+++ b/glassfish-runner/rest-tck/pom.xml
@@ -116,9 +116,8 @@ mvn clean install -Dgroups=security
         </dependency>
 
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
         </dependency>
 
         <dependency>

--- a/glassfish-runner/websocket-platform-tck/pom.xml
+++ b/glassfish-runner/websocket-platform-tck/pom.xml
@@ -113,9 +113,8 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
         </dependency>
     </dependencies>
     <build>

--- a/glassfish-runner/websocket-tck/websocket-tck-run/pom.xml
+++ b/glassfish-runner/websocket-tck/websocket-tck-run/pom.xml
@@ -100,9 +100,8 @@
         </dependency>
 
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
         </dependency>
 
         <dependency>

--- a/jpa-tck/pom.xml
+++ b/jpa-tck/pom.xml
@@ -81,9 +81,9 @@
             <version>4.0.0</version>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
+            <version>2.2</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/jpa/pom.xml
+++ b/jpa/pom.xml
@@ -82,9 +82,8 @@
             <version>4.0.0</version>
         </dependency>
         <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.7</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -552,6 +552,11 @@
                 <artifactId>jboss-rmi-api_1.0_spec</artifactId>
                 <version>1.0.6.Final</version>
             </dependency>
+            <dependency>
+                <groupId>jakarta.tck</groupId>
+                <artifactId>sigtest-maven-plugin</artifactId>
+                <version>2.2</version>
+            </dependency>
 
         </dependencies>
     </dependencyManagement>
@@ -622,9 +627,9 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <groupId>org.netbeans.tools</groupId>
+                    <groupId>jakarta.tck</groupId>
                     <artifactId>sigtest-maven-plugin</artifactId>
-                    <version>1.5</version>
+                    <version>2.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/websocket/docs/userguide/src/main/jbake/content/config.inc
+++ b/websocket/docs/userguide/src/main/jbake/content/config.inc
@@ -112,9 +112,9 @@ slashes as a path separator instead.
 [source,oac_no_warn]
 ----
       <dependency>
-            <groupId>org.netbeans.tools</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>sigtest-maven-plugin</artifactId>
-            <version>1.4</version>
+            <version>2.2</version>
         </dependency>
 ----
 +


### PR DESCRIPTION
**Fixes Issue**
resolves #1555 

**Describe the change**
Upgrades the Jakarta Annotations API to 3.0 for the core-profile-tck. Also, renames the signature test file to remove the `-jdk11` suffix. 

Migrate the `sigtest-maven-plugin` to the latest vresion.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
