### PR TITLE
Move the arquillian protocol modules into platform-tck

### DIFF
--- a/arquillian/LICENSE
+++ b/arquillian/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/arquillian/README.md
+++ b/arquillian/README.md
@@ -1,0 +1,5 @@
+# Arquillian protocols for JavaTest migration to Arquillian/Junit5
+
+This set of modules define arquillian protocols for JavaTest migration to Arquillian/Junit5. This is a step in completing the migration of JavaTest to Arquillian/Junit5. As of EE11 there will be no dependency on JavaTest, but the vehicle framework used on top of JavaTest is still in place to minimize the impact of the migration.
+
+Future work will be to remove the vehicle framework and migrate the tests to more standard Arquillian protocols like servlet and REST.

--- a/arquillian/appclient/README.adoc
+++ b/arquillian/appclient/README.adoc
@@ -1,0 +1,6 @@
+= Jakarta EE 11 AppClient Protocol
+
+This is an Arquillian protocol used by the TCK appclient vehicle tests to
+run a Jakarta EE Application Client based test. The logic in the handling of
+the protocol as output to the console of the appclient process is based on how
+the CTS version of the Jakarta TCK in EE 10 behaves.

--- a/arquillian/appclient/pom.xml
+++ b/arquillian/appclient/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Parent -->
+    <parent>
+        <groupId>jakarta.tck</groupId>
+        <artifactId>tck.arquillian.parent</artifactId>
+        <version>11.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <groupId>jakarta.tck.arquillian</groupId>
+    <artifactId>arquillian-protocol-appclient</artifactId>
+    <name>Arquillian Protocol AppClient</name>
+    <description>Protocol handler for communicating using console output</description>
+
+    <!-- Properties -->
+    <properties>
+        <!-- Versioning -->
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
+
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- org.jboss.arquillian -->
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-impl-base</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-spi</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientArchiveName.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientArchiveName.java
@@ -1,0 +1,4 @@
+package tck.arquillian.protocol.appclient;
+
+public record AppClientArchiveName(String name) {
+}

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientCmd.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientCmd.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+package tck.arquillian.protocol.appclient;
+
+import org.jboss.arquillian.config.impl.extension.StringPropertyReplacer;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+
+/**
+ * A base class that uses the {@link Runtime#exec(String[], String[], File)} method to launch a Jakarta EE appclient.
+ * Vendors override this class to provide implementations of:
+ * {@link #getAppClientCommand()} - the command line expected to invoke your Application Client main
+ * {@link #getAppClientEnv()} - optional environment variables that should be provided when running the Application client
+ * {@link #getAppClientDir()} - optional directory from which the appclient process should run
+ */
+public class AppClientCmd {
+    private static final Logger LOGGER = Logger.getLogger(AppClientCmd.class.getName());
+
+    private static final String outThreadHame = "APPCLIENT-out";
+    private static final String errThreadHame = "APPCLIENT-err";
+
+    private Process appClientProcess;
+    private BufferedReader outputReader;
+    private BufferedReader errorReader;
+    private BlockingQueue<String> outputQueue = new LinkedBlockingQueue<String>();
+    private String[] clientCmdLine = {};
+    private String[] clientEnvp = null;
+    private File clientDir = null;
+    private String clientEarDir;
+    private CompletableFuture<Process> onExit;
+
+
+    /**
+     * Parse the provided configuration to determine the clientCmdLine, optional clientEnvp and optional clientDir.
+     * @param config
+     */
+    public AppClientCmd(AppClientProtocolConfiguration config) {
+        clientCmdLine = config.clientCmdLineAsArray();
+        clientEnvp = config.clientEnvAsArray();
+        clientDir = config.clientDirAsFile();
+        clientEarDir = config.getClientEarDir();
+    }
+
+    public boolean waitForExit(long timeout, TimeUnit units) throws InterruptedException {
+        return appClientProcess.waitFor(timeout, units);
+    }
+
+    /**
+     * Consumes all available output from App Client using the output queue filled by the process
+     * stanard out reader thread.
+     *
+     * @param timeout number of milliseconds to wait for each subsequent line
+     * @return array of App Client output lines
+     */
+    public String[] readAll(final long timeout) {
+        ArrayList<String> lines = new ArrayList<String>();
+        String line = null;
+        do {
+            try {
+                line = outputQueue.poll(100, TimeUnit.MILLISECONDS);
+                if (line != null)
+                    lines.add(line);
+            } catch (InterruptedException ioe) {
+            }
+
+        } while (onExit.isDone() == false);
+        return lines.toArray(new String[] {});
+    }
+
+    /**
+     * Kills the app client
+     *
+     * @throws Exception
+     */
+    public synchronized void quit() throws Exception {
+        appClientProcess.destroy();
+        try {
+            appClientProcess.waitFor();
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Starts the app client in a new process and creates two threads to read the process output
+     * and error streams.
+     * @param vehicleArchiveName - the name of the vehicle archive to pass to the app client
+     * @param clientAppArchive - the appclient archive
+     * @param additionalArgs - additional arguments passed to the app client process. The CTS appclient will
+     *                       pass in the name of the test to run using this.
+     * @throws Exception - on failure
+     */
+    public void run(String vehicleArchiveName, String clientAppArchive, String... additionalArgs) throws Exception {
+        
+        ArrayList<String> cmdList = new ArrayList<String>();
+
+
+        // Need to replace any property refs on command line
+        File earDir = new File(clientEarDir);
+        if(earDir.isAbsolute()) {
+            earDir = new File(clientDir, clientEarDir);
+        }
+        String[] cmdLine = Arrays.copyOf(clientCmdLine, clientCmdLine.length);
+        for (int n = 0; n < cmdLine.length; n ++) {
+            String arg = cmdLine[n];
+            if(arg.contains("${clientEarDir}")) {
+                arg = arg.replaceAll("\\$\\{clientEarDir}", earDir.getAbsolutePath());
+                cmdLine[n] = arg;
+            }
+            if(arg.contains("${vehicleArchiveName}")) {
+                arg = arg.replaceAll("\\$\\{vehicleArchiveName}", vehicleArchiveName);
+                cmdLine[n] = arg;
+            }
+            if(arg.contains("${clientAppArchive}")) {
+                arg = arg.replaceAll("\\$\\{clientAppArchive}", clientAppArchive);
+                cmdLine[n] = arg;
+            }
+
+        }
+
+        for (int n = 0; n < cmdLine.length; n ++) {
+            String arg = cmdLine[n];
+            cmdList.addAll(Arrays.asList(cmdLine[n].split(" ")));
+        }
+
+        if (additionalArgs != null) {
+            String[] newCmdLine = new String[cmdLine.length + additionalArgs.length];
+            System.arraycopy(cmdLine, 0, newCmdLine, 0, cmdLine.length);
+            System.arraycopy(additionalArgs, 0, newCmdLine, cmdLine.length, additionalArgs.length);
+            cmdLine = newCmdLine;
+            cmdList.addAll(Arrays.asList(additionalArgs));
+
+        }
+
+        appClientProcess = Runtime.getRuntime().exec(cmdList.toArray(new String[0]), clientEnvp, clientDir);
+        onExit = appClientProcess.onExit();
+        LOGGER.info("Created process" + appClientProcess.info());
+        LOGGER.info("process(%d).envp: %s".formatted(appClientProcess.pid(), Arrays.toString(clientEnvp)));
+        outputReader = new BufferedReader(new InputStreamReader(appClientProcess.getInputStream(), StandardCharsets.UTF_8));
+        errorReader = new BufferedReader(new InputStreamReader(appClientProcess.getErrorStream(), StandardCharsets.UTF_8));
+
+        final Thread readOutputThread = new Thread(this::readClientOut, outThreadHame);
+        readOutputThread.start();
+        final Thread readErrorThread = new Thread(this::readClientErr, errThreadHame);
+        readErrorThread.start();
+        LOGGER.info("Started process reader threads");
+    }
+
+    private void readClientOut() {
+        if (outputReader == null)
+            return;
+
+        readClientProcess(outputReader, false);
+        synchronized (this) {
+            outputReader = null;
+        }
+    }
+
+    private void readClientErr() {
+        if (errorReader == null)
+            return;
+        readClientProcess(errorReader, true);
+        synchronized (this) {
+            errorReader = null;
+        }
+    }
+
+    /**
+     * Loop
+     */
+    private void readClientProcess(BufferedReader reader, boolean errReader) {
+        LOGGER.info("Begin readClientProcess");
+        int count = 0;
+        try {
+            String line = reader.readLine();
+            // System.out.println("RCP: " + line);
+            while (line != null) {
+                count++;
+                if (errReader)
+                    errorLineReceived(line);
+                else
+                    outputLineReceived(line);
+                line = reader.readLine();
+            }
+        } catch (Throwable e) {
+            LOGGER.warning(formatException("error during read, caused by:\n", e));
+        }
+        LOGGER.info(String.format("Exiting(%s), read %d lines", errReader, count));
+    }
+
+    private synchronized void outputLineReceived(String line) {
+        LOGGER.info("[" + outThreadHame + "] " + line);
+        outputQueue.add(line);
+    }
+
+    private synchronized void errorLineReceived(String line) {
+        LOGGER.info("[" + errThreadHame + "] " + line);
+        outputQueue.add(line);
+    }
+
+    private static String formatException(String msg, Throwable e) {
+        StringWriter sw = new StringWriter();
+        sw.append(msg);
+        e.printStackTrace(new PrintWriter(sw, true));
+        return sw.toString();
+    }
+}

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientDeploymentPackager.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+package tck.arquillian.protocol.appclient;
+
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.ArchivePath;
+import org.jboss.shrinkwrap.api.Node;
+import org.jboss.shrinkwrap.api.asset.ArchiveAsset;
+import org.jboss.shrinkwrap.api.asset.Asset;
+import org.jboss.shrinkwrap.api.asset.FileAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.exporter.ZipExporter;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import tck.arquillian.protocol.common.ProtocolJarResolver;
+
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
+import java.util.Collection;
+import java.util.Map;
+import java.util.logging.Logger;
+
+/**
+ *
+ */
+public class AppClientDeploymentPackager implements DeploymentPackager {
+    static Logger log = Logger.getLogger(AppClientDeploymentPackager.class.getName());
+
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<AppClientArchiveName> appClientArchiveName;
+
+    @Override
+    public Archive<?> generateDeployment(TestDeployment testDeployment, Collection<ProtocolArchiveProcessor> processors) {
+        Archive<?> archive = testDeployment.getApplicationArchive();
+
+        Collection<Archive<?>> auxiliaryArchives = testDeployment.getAuxiliaryArchives();
+        EnterpriseArchive ear = (EnterpriseArchive) archive;
+        ear.addAsLibraries(auxiliaryArchives.toArray(new Archive<?>[0]));
+        // Include the protocol.jar in the deployment
+        File protocolJar = ProtocolJarResolver.resolveProtocolJar();
+        if(protocolJar == null) {
+            throw new RuntimeException("Failed to resolve protocol.jar. You either need a jakarta.tck.arquillian:arquillian-protocol-lib"+
+                    " dependency in the runner pom.xml or a downloaded target/protocol/protocol.jar file");
+        }
+        ear.addAsLibrary(protocolJar, "arquillian-protocol-lib.jar");
+
+        AppClientProtocolConfiguration config = (AppClientProtocolConfiguration) testDeployment.getProtocolConfiguration();
+        String mainClass = extractAppMainClient(ear);
+        log.info("mainClass: " + mainClass);
+
+        // Write out the ear with the test dependencies for use by the appclient launcher
+        String extractDir = config.getClientEarDir();
+        if(extractDir == null) {
+            extractDir = "target/appclient";
+        }
+        File appclient = new File(extractDir);
+        if(!appclient.exists()) {
+            if(appclient.mkdirs()) {
+                log.info("Created appclient directory: " + appclient.getAbsolutePath());
+            } else {
+                throw new RuntimeException("Failed to create appclient directory: " + appclient.getAbsolutePath());
+            }
+        }
+        File archiveOnDisk = new File(appclient, ear.getName());
+        final ZipExporter exporter = ear.as(ZipExporter.class);
+        exporter.exportTo(archiveOnDisk, true);
+        log.info("Exported test ear to: " + archiveOnDisk.getAbsolutePath());
+
+        if(config.isUnpackClientEar()) {
+            for (ArchivePath path : ear.getContent().keySet()) {
+                Node node = ear.get(path);
+                if (node.getAsset() instanceof ArchiveAsset) {
+                    ArchiveAsset asset = (ArchiveAsset) node.getAsset();
+                    File archiveFile = new File(appclient, path.get());
+                    if(!archiveFile.getParentFile().exists()) {
+                        archiveFile.getParentFile().mkdirs();
+                    }
+                    final ZipExporter zipExporter = asset.getArchive().as(ZipExporter.class);
+                    zipExporter.exportTo(archiveFile, true);
+                    log.info("Exported test ear content to: " + archiveFile.getAbsolutePath());
+                } else if(node.getAsset() instanceof FileAsset) {
+                    FileAsset asset = (FileAsset) node.getAsset();
+                    File file = new File(appclient, path.get());
+                    if(!file.getParentFile().exists()) {
+                        file.getParentFile().mkdirs();
+                    }
+                    try {
+                        Files.copy(asset.openStream(), file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+                        log.info("Exported test ear content to: " + file.getAbsolutePath());
+                    } catch (Exception e) {
+                        throw new RuntimeException("Failed to export test ear content to: " + file.getAbsolutePath(), e);
+                    }
+                }
+            }
+        }
+        return ear;
+    }
+
+    private String extractAppMainClient(EnterpriseArchive ear) {
+        String mainClass = null;
+        Map<ArchivePath, Node> contents = ear.getContent();
+        for (Node node : contents.values()) {
+            Asset asset = node.getAsset();
+            if (asset instanceof ArchiveAsset) {
+                ArchiveAsset jar = (ArchiveAsset) asset;
+                Node mfNode = jar.getArchive().get("META-INF/MANIFEST.MF");
+                if (mfNode == null)
+                    continue;
+
+                StringAsset manifest = (StringAsset) mfNode.getAsset();
+                String source = manifest.getSource();
+                String[] lines = source.split("\n");
+                for (String line : lines) {
+                    if (line.startsWith("Main-Class:")) {
+                        mainClass = line.substring(11).trim();
+                        appClientArchiveName.set(new AppClientArchiveName(jar.getArchive().getName()));
+                        break;
+                    }
+                }
+            }
+        }
+        return mainClass;
+    }
+}

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+package tck.arquillian.protocol.appclient;
+
+import org.jboss.arquillian.container.spi.client.deployment.Deployment;
+import org.jboss.arquillian.container.spi.context.annotation.DeploymentScoped;
+import org.jboss.arquillian.container.test.spi.ContainerMethodExecutor;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+import tck.arquillian.protocol.common.TsTestPropsBuilder;
+
+import java.io.IOException;
+import java.util.logging.Logger;
+
+public class AppClientMethodExecutor implements ContainerMethodExecutor {
+    static Logger log = Logger.getLogger(AppClientMethodExecutor.class.getName());
+    private AppClientCmd appClient;
+    private AppClientProtocolConfiguration config;
+    @Inject
+    @DeploymentScoped
+    private Instance<Deployment> deploymentInstance;
+    @Inject
+    @DeploymentScoped
+    private Instance<AppClientArchiveName> appClientArchiveName;
+
+    static enum MainStatus {
+        PASSED,
+        FAILED,
+        ERROR,
+        NOT_RUN;
+
+        static MainStatus parseStatus(String reason) {
+            MainStatus status = FAILED;
+            if (reason.contains("Passed.")) {
+                status = PASSED;
+            } else if (reason.contains("Error.")) {
+                status = ERROR;
+            } else if (reason.contains("Not run.")) {
+                status = NOT_RUN;
+            }
+            return status;
+        }
+    }
+
+    public AppClientMethodExecutor(AppClientCmd appClient, AppClientProtocolConfiguration config) {
+        this.appClient = appClient;
+        this.config = config;
+    }
+
+    @Override
+    public TestResult invoke(TestMethodExecutor testMethodExecutor) {
+        TestResult result = TestResult.passed();
+
+        // Run the appclient for the test if required
+        String testMethod = testMethodExecutor.getMethodName();
+        if (config.isRunClient()) {
+            log.info("Running appClient for: " + testMethod);
+            try {
+                Deployment deployment = deploymentInstance.get();
+                String appArchiveName = appClientArchiveName.get().name();
+                String vehicleArchiveName = TsTestPropsBuilder.vehicleArchiveName(deployment);
+                String[] additionalAgrs = TsTestPropsBuilder.runArgs(config, deployment, testMethodExecutor);
+                appClient.run(vehicleArchiveName, appArchiveName, additionalAgrs);
+            } catch (Exception ex) {
+                result = TestResult.failed(ex);
+                return result;
+            }
+        } else {
+            log.info("Not running appClient for: " + testMethod);
+        }
+        String[] lines = appClient.readAll(config.getClientTimeout());
+
+        log.info(String.format("AppClient(%s) readAll returned %d lines\n", testMethod, lines.length));
+        boolean sawStatus = false;
+        MainStatus status = MainStatus.NOT_RUN;
+        String reason = "None";
+        String description = "None";
+        for (String line : lines) {
+            System.out.println(line);
+            if (line.contains("STATUS:")) {
+                sawStatus = true;
+                description = line;
+                status = MainStatus.parseStatus(line);
+                // Format of line is STATUS:StatusText.Reason
+                // see com.sun.javatest.Status#exit()
+                int reasonStart = line.indexOf('.');
+                if (reasonStart > 0 && reasonStart < line.length() - 1) {
+                    reason = line.substring(reasonStart + 1);
+                }
+            }
+        }
+        if (!sawStatus) {
+            Throwable ex = new IllegalStateException("No STATUS: output seen from client");
+            result = TestResult.failed(ex);
+        } else {
+            switch (status) {
+                case PASSED:
+                    result = TestResult.passed(reason);
+                    break;
+                case ERROR:
+                case FAILED:
+                    result = TestResult.failed(new Exception(reason));
+                    break;
+                case NOT_RUN:
+                    result = TestResult.skipped(reason);
+                    break;
+            }
+            result.addDescription(description);
+        }
+
+        return result;
+    }
+}

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocol.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocol.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+package tck.arquillian.protocol.appclient;
+
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.test.spi.ContainerMethodExecutor;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+
+public class AppClientProtocol implements Protocol<AppClientProtocolConfiguration> {
+    @Inject
+    private Instance<Injector> injectorInstance;
+
+    @Override
+    public Class<AppClientProtocolConfiguration> getProtocolConfigurationClass() {
+        return AppClientProtocolConfiguration.class;
+    }
+
+    @Override
+    public ProtocolDescription getDescription() {
+        return new ProtocolDescription("appclient");
+    }
+
+    @Override
+    public DeploymentPackager getPackager() {
+        AppClientDeploymentPackager packager = new AppClientDeploymentPackager();
+        Injector injector = injectorInstance.get();
+        injector.inject(packager);
+
+        return packager;
+    }
+
+    @Override
+    public ContainerMethodExecutor getExecutor(AppClientProtocolConfiguration protocolConfiguration, ProtocolMetaData metaData,
+            CommandCallback callback) {
+
+        // Create the AppClientCmd and AppClientMethodExecutor instances and have arquillian inject the Deployment into the executor
+        AppClientCmd clientCmd = new AppClientCmd(protocolConfiguration);
+        AppClientMethodExecutor executor = new AppClientMethodExecutor(clientCmd, protocolConfiguration);
+        Injector injector = injectorInstance.get();
+        injector.inject(executor);
+        return executor;
+    }
+}

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolConfiguration.java
@@ -1,0 +1,218 @@
+package tck.arquillian.protocol.appclient;
+
+import org.jboss.arquillian.container.test.spi.client.protocol.ProtocolConfiguration;
+import tck.arquillian.protocol.common.ProtocolCommonConfig;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.ArrayList;
+
+/**
+ * Configuration for the AppClient protocol. This is used to configure the appclient process that will be launched to
+ * run the appclient main class for the test.
+ */
+public class AppClientProtocolConfiguration implements ProtocolConfiguration, ProtocolCommonConfig {
+    private boolean runClient = true;
+    /**
+     * Is this appclient being used as a runner for another vehicle type
+     */
+    private boolean runAsVehicle = false;
+    /**
+     * Provide an optional envp array to pass as is to {@link Runtime#exec(String[], String[])}
+     * @return a possibly empty string providing env1=value1;env2=value2 environment variable settings
+     */
+    private String clientEnvString;
+    /**
+     * A ';' (by default) separated string for the command line arguments to pass as the cmdarray to
+     * {@link Runtime#exec(String[], String[])}
+     */
+    private String clientCmdLineString;
+    /**
+     * The separator to use for splitting the clientCmdLineString
+     */
+    private String cmdLineArgSeparator = ";";
+    /**
+     * An optional directory string to use as the appclient process directory. This is passed as the dir arguemnt
+     * to {@link Runtime#exec(String[], String[], File)}
+     */
+    private String clientDir;
+    /**
+     * The directory to extract the final applclient ear test artifact
+     */
+    private String clientEarDir = "target/appclient";
+    // Timeout waiting for appclient process to exit in MS
+    private long clientTimeout = 60000;
+    // test working directory
+    private String workDir;
+    // EE10 type of ts.jte file location
+    private String tsJteFile;
+    // EE10 type of tssql.stmt file location
+    private String tsSqlStmtFile;
+    // harness.log.traceflag
+    private boolean trace;
+    private boolean unpackClientEar = false;
+
+    public boolean isAppClient() {
+        return true;
+    }
+    public boolean isRunClient() {
+        return runClient;
+    }
+    public void setRunClient(boolean runClient) {
+        this.runClient = runClient;
+    }
+
+    public boolean isRunAsVehicle() {
+        return runAsVehicle;
+    }
+    public void setRunAsVehicle(boolean runAsVehicle) {
+        this.runAsVehicle = runAsVehicle;
+    }
+    public boolean isTrace() {
+        return trace;
+    }
+    public void setTrace(boolean trace) {
+        this.trace = trace;
+    }
+
+    public String getWorkDir() {
+        return workDir;
+    }
+    public void setWorkDir(String workDir) {
+        this.workDir = workDir;
+    }
+
+    public String getTsJteFile() {
+        return tsJteFile;
+    }
+    public void setTsJteFile(String tsJteFile) {
+        this.tsJteFile = tsJteFile;
+    }
+
+    @Override
+    public String getTsSqlStmtFile() {
+        return tsSqlStmtFile;
+    }
+    @Override
+    public void setTsSqlStmtFile(String tsSqlStmtFile) {
+        this.tsSqlStmtFile = tsSqlStmtFile;
+    }
+
+    public String getClientEnvString() {
+        return clientEnvString;
+    }
+
+    public void setClientEnvString(String clientEnvString) {
+        this.clientEnvString = clientEnvString;
+    }
+
+    public String getClientCmdLineString() {
+        return clientCmdLineString;
+    }
+
+    /**
+     * Set the command line to use for launching the appclient. The individual arguments are separated by the cmdLineArgSeparator
+     * setting, which defaults to ';'. A long command line can be split across multiple lines in the arquillian.xml file because
+     * the parsed command line array elements are trimmed of leading and trailing whitespace.
+     * The command line should be filtered against the ts.jte file if it contains any property references. In addition
+     * to ts.jte property references, the command line can contain ${clientEarDir} which will be replaced with the
+     * #clientEarDir value. Any ${vehicleArchiveName} ref will be replaced with the vehicleArchiveName passed to the
+     * @param clientCmdLineString
+     */
+    public void setClientCmdLineString(String clientCmdLineString) {
+        this.clientCmdLineString = clientCmdLineString;
+    }
+
+    public String getCmdLineArgSeparator() {
+        return cmdLineArgSeparator;
+    }
+
+    /**
+     * Set the separator to use for splitting the clientCmdLineString
+     * @param cmdLineArgSeparator
+     */
+    public void setCmdLineArgSeparator(String cmdLineArgSeparator) {
+        this.cmdLineArgSeparator = cmdLineArgSeparator;
+    }
+
+    public String getClientDir() {
+        return clientDir;
+    }
+    public void setClientDir(String clientDir) {
+        this.clientDir = clientDir;
+    }
+
+    public String getClientEarDir() {
+        return clientEarDir;
+    }
+    public void setClientEarDir(String clientEarDir) {
+        this.clientEarDir = clientEarDir;
+    }
+
+    public boolean isUnpackClientEar() {
+        return unpackClientEar;
+    }
+
+    /**
+     * Set to true to unpack the client ear into the clientEarDir. The default is false. This is useful if the
+     * vendor appclient requires the ear to be exploded in order to access the appclient jar and bundled ear
+     * lib jars.
+     * @param unpackClientEar
+     */
+    public void setUnpackClientEar(boolean unpackClientEar) {
+        this.unpackClientEar = unpackClientEar;
+    }
+
+    public long getClientTimeout() {
+        return clientTimeout;
+    }
+
+    /**
+     * Set the timeout in milliseconds for waiting for the appclient process to exit. The default is 60000 (1 minute).
+     * @param clientTimeout
+     */
+    public void setClientTimeout(long clientTimeout) {
+        this.clientTimeout = clientTimeout;
+    }
+
+
+    /** Helper methods to turn the strings into the types used by Runtime#exec
+     * @return a File object for the clientDir
+     */
+    public File clientDirAsFile() {
+        File dir = null;
+        if (clientDir != null) {
+            dir = new File(clientDir);
+        }
+        return dir;
+    }
+
+    /**
+     * Parse the clientCmdLineString into an array of strings using the cmdLineArgSeparator. This calls String#split on the
+     * clientCmdLineString and then trims each element of the resulting array.
+     * @return a command line array of strings for use with Runtime#exec.
+     */
+    public String[] clientCmdLineAsArray() {
+        String[] cmdArray = clientCmdLineString.trim().split(cmdLineArgSeparator);
+        // Now trim each element
+        for (int i = 0; i < cmdArray.length; i++) {
+            cmdArray[i] = cmdArray[i].trim();
+        }
+        return cmdArray;
+    }
+    public String[] clientEnvAsArray() {
+        String[] envp = null;
+        if (clientEnvString != null) {
+            ArrayList<String> tmp = new ArrayList<String>();
+            // Split on the env1=value1 ; separator
+            envp = clientEnvString.trim().split(";");
+            // Now trim each element
+            for (int i = 0; i < envp.length; i++) {
+                envp[i] = envp[i].trim();
+            }
+
+        }
+        return envp;
+    }
+}

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolExtension.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientProtocolExtension.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2024 Red Hat, Inc., and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ */
+package tck.arquillian.protocol.appclient;
+
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+/**
+ * Arquillian extension for the AppClient protocol.
+ */
+public class AppClientProtocolExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(Protocol.class, AppClientProtocol.class);
+    }
+}

--- a/arquillian/appclient/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/arquillian/appclient/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+tck.arquillian.protocol.appclient.AppClientProtocolExtension

--- a/arquillian/appclient/src/test/java/org/jboss/arquillian/protocol/AppClientConfigTest.java
+++ b/arquillian/appclient/src/test/java/org/jboss/arquillian/protocol/AppClientConfigTest.java
@@ -1,0 +1,61 @@
+package org.jboss.arquillian.protocol;
+
+import org.jboss.arquillian.config.impl.extension.ConfigurationRegistrar;
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.container.test.impl.MapObject;
+import tck.arquillian.protocol.appclient.AppClientProtocolConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Map;
+
+public class AppClientConfigTest {
+    @Test
+    public void testFile() throws Exception {
+        File dir = new File(".");
+        System.out.println(dir.exists());
+        System.out.println(dir.isDirectory());
+        Process ls = Runtime.getRuntime().exec("/bin/ls", null, dir);
+        int exit = ls.waitFor();
+        System.out.println(exit);
+    }
+    @Test
+    public void testConfig1() throws Exception {
+        System.setProperty(ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY, "appclient1-arquillian.xml");
+        ConfigurationRegistrar registrar = new ConfigurationRegistrar();
+        ArquillianDescriptor descriptor = registrar.loadConfiguration();
+        Assert.assertNotNull(descriptor);
+        Assert.assertNotNull(descriptor.defaultProtocol("appclient"));
+        String type = descriptor.defaultProtocol("appclient").getType();
+        Assert.assertEquals("appclient", type);
+
+        Map<String, String> props = descriptor.defaultProtocol("appclient").getProperties();
+
+        AppClientProtocolConfiguration config = new AppClientProtocolConfiguration();
+        MapObject.populate(config, props);
+
+        // Raw strings
+        Assert.assertEquals("-p;/home/jakartaeetck/bin/xml/../../tmp/tstest.jte", config.getClientCmdLineString());
+        String expectedEnv = "JAVA_OPTS=-Djboss.modules.system.pkgs=com.sun.ts.lib,com.sun.javatest;CLASSPATH=${project.build.directory}/appclient/javatest.jar:${project.build.directory}/appclient/libutil.jar:${project.build.directory}/appclient/libcommon.jar";
+        Assert.assertEquals(expectedEnv, config.getClientEnvString());
+        Assert.assertTrue(config.isRunClient());
+        Assert.assertEquals(".", config.getClientDir());
+
+        // Parsed strings
+        String[] args = config.clientCmdLineAsArray();
+        Assert.assertEquals(2, args.length);
+        Assert.assertEquals("-p", args[0]);
+        Assert.assertEquals("/home/jakartaeetck/bin/xml/../../tmp/tstest.jte", args[1]);
+
+        String[] envp = config.clientEnvAsArray();
+        Assert.assertEquals(2, envp.length);
+        Assert.assertTrue(envp[0].startsWith("JAVA_OPTS="));
+        Assert.assertEquals("-Djboss.modules.system.pkgs=com.sun.ts.lib,com.sun.javatest", envp[0].substring(10));
+        Assert.assertTrue(envp[1].startsWith("CLASSPATH="));
+        String expectedCP = "${project.build.directory}/appclient/javatest.jar:${project.build.directory}/appclient/libutil.jar:${project.build.directory}/appclient/libcommon.jar";
+        Assert.assertEquals(expectedCP, envp[1].substring(10));
+        File expectedDir = new File(".");
+        Assert.assertEquals(expectedDir, config.clientDirAsFile());
+    }
+}

--- a/arquillian/appclient/src/test/resources/appclient1-arquillian.xml
+++ b/arquillian/appclient/src/test/resources/appclient1-arquillian.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+~ Copyright 2023 Red Hat, Inc.
+~
+~ Licensed under the Apache License, Version 2.0 (the "License");
+~ you may not use this file except in compliance with the License.
+~ You may obtain a copy of the License at
+~
+~   http://www.apache.org/licenses/LICENSE-2.0
+~
+~ Unless required by applicable law or agreed to in writing, software
+~ distributed under the License is distributed on an "AS IS" BASIS,
+~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+~ See the License for the specific language governing permissions and
+~ limitations under the License.
+-->
+
+<arquillian xmlns="http://jboss.org/schema/arquillian" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <defaultProtocol type="appclient">
+        <property name="runClient">true</property>
+        <property name="clientCmdLineString">-p;/home/jakartaeetck/bin/xml/../../tmp/tstest.jte</property>
+        <property name="clientEnvString">JAVA_OPTS=-Djboss.modules.system.pkgs=com.sun.ts.lib,com.sun.javatest;CLASSPATH=${project.build.directory}/appclient/javatest.jar:${project.build.directory}/appclient/libutil.jar:${project.build.directory}/appclient/libcommon.jar</property>
+        <property name="clientDir">.</property>
+    </defaultProtocol>
+
+    <container qualifier="jboss-client-ee11-tck" default="true">
+        <configuration>
+            <property name="jbossHome">${jboss.home}</property>
+            <property name="jbossArguments">-P=src/test/resources/testfile.properties</property>
+            <property name="javaVmArguments">${debug.vm.args} ${jvm.args}</property>
+            <property name="serverConfig">${wildfly.standalone.config}</property>
+            <property name="allowConnectingToRunningServer">false</property>
+
+            <!-- -->
+            <property name="clientAppEar">target/ejb3_bb_stateless_basic.ear</property>
+            <property name="clientArchiveName">ejb3_bb_stateless_basic_client.jar</property>
+        </configuration>
+    </container>
+
+</arquillian>

--- a/arquillian/common/pom.xml
+++ b/arquillian/common/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Parent -->
+    <parent>
+        <groupId>jakarta.tck</groupId>
+        <artifactId>tck.arquillian.parent</artifactId>
+        <version>11.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <groupId>jakarta.tck.arquillian</groupId>
+    <artifactId>arquillian-protocol-common</artifactId>
+    <name>Arquillian Protocol Common</name>
+    <description>Common classes used by the protocols</description>
+
+    <!-- Properties -->
+    <properties>
+        <!-- Versioning -->
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.test</groupId>
+            <artifactId>arquillian-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.resolver</groupId>
+            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/ProtocolCommonConfig.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/ProtocolCommonConfig.java
@@ -1,0 +1,19 @@
+package tck.arquillian.protocol.common;
+
+public interface ProtocolCommonConfig {
+    default boolean isAppClient() {
+        return false;
+    };
+
+    public boolean isTrace();
+    public void setTrace(boolean trace);
+
+    public String getWorkDir();
+    public void setWorkDir(String workDir);
+
+    public String getTsJteFile();
+    public void setTsJteFile(String tsJteFile);
+
+    public String getTsSqlStmtFile();
+    public void setTsSqlStmtFile(String tsJteFile);
+}

--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/ProtocolJarResolver.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/ProtocolJarResolver.java
@@ -1,0 +1,79 @@
+package tck.arquillian.protocol.common;
+
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
+
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.logging.Logger;
+
+public class ProtocolJarResolver {
+    static Logger log = Logger.getLogger(ProtocolJarResolver.class.getName());
+
+    /**
+     * Resolve the protocol.jar from the runner pom.xml dependencies
+     * @return The protocol.jar file if found, null otherwise
+     */
+    public static File resolveProtocolJar() {
+        File protocolJar = null;
+        String[] activeMavenProfiles = {"staging"};
+        String libGAV = "jakarta.tck.arquillian:arquillian-protocol-lib";
+        String version = versionInfo();
+        if(version != null && !version.isEmpty()) {
+            libGAV += ":" + version;
+        }
+        MavenResolvedArtifact protocolLib = null;
+        try {
+            MavenResolvedArtifact[] resolvedArtifacts = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                    .resolve(libGAV)
+                    .withTransitivity()
+                    .asResolvedArtifact();
+            for (MavenResolvedArtifact resolvedArtifact : resolvedArtifacts) {
+                MavenCoordinate gav = resolvedArtifact.getCoordinate();
+                if (gav.getGroupId().equals("jakarta.tck.arquillian") && gav.getArtifactId().equals("arquillian-protocol-lib")) {
+                    protocolLib = resolvedArtifact;
+                    break;
+                }
+            }
+        } catch (Exception e) {
+            log.warning("Failed to resolve jakarta.tck.arquillian:arquillian-protocol-lib: " + e.getMessage());
+        }
+
+        if(protocolLib != null) {
+            protocolJar = protocolLib.asFile();
+        } else {
+            log.warning("Failed to resolve jakarta.tck.arquillian:arquillian-protocol-lib, check the runner pom.xml dependencies");
+            // Fallback to the local unpacked protocol.jar
+            protocolJar = new File("target/protocol/protocol.jar");
+            if(!protocolJar.exists()) {
+                log.warning("Failed to find downloaded jakarta.tck.arquillian:arquillian-protocol-lib in target/protocol/protocol.jar");
+                protocolJar = null;
+            }
+        }
+        return protocolJar;
+    }
+
+    /**
+     * Read the javatest.version file to get the version of the protocol.jar
+     * @return
+     */
+    public static String versionInfo() {
+        URL versionURL = ProtocolJarResolver.class.getResource("/javatest.version");
+        String versionInfo = "";
+        try {
+            assert versionURL != null;
+            try(InputStream is = versionURL.openStream()) {
+                if(is != null) {
+                    byte[] info = is.readAllBytes();
+                    versionInfo = new String(info);
+                }
+            }
+        } catch (Exception e) {
+            log.warning("Failed to read javatest.version: " + e.getMessage());
+        }
+        return versionInfo;
+    }
+
+}

--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/TargetVehicle.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/TargetVehicle.java
@@ -1,0 +1,14 @@
+package tck.arquillian.protocol.common;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD})
+public @interface TargetVehicle {
+    String value();
+}

--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
@@ -1,0 +1,235 @@
+package tck.arquillian.protocol.common;
+
+import org.jboss.arquillian.container.spi.client.deployment.Deployment;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Modifier;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Properties;
+import java.util.logging.Logger;
+
+public class TsTestPropsBuilder {
+    static Logger log = Logger.getLogger(TsTestPropsBuilder.class.getName());
+
+    // Property names passed from the ts.jte file to the tstest.jte file
+    // Parsed from the test @class.setup_props: values + additional seen to be used by harness
+    static String[] tsJtePropNames = {
+            "Driver",
+            "authpassword",
+            "authuser",
+            "binarySize",
+            "cofSize",
+            "cofTypeSize",
+            "db.dml.file",
+            "db.supports.sequence",
+            "db1",
+            "db2",
+            "DriverManager",
+            "ftable",
+            "generateSQL",
+            "harness.log.port",
+            "harness.log.traceflag",
+            "harness.socket.retry.count",
+            "harness.temp.directory",
+            "imap.port",
+            "iofile",
+            "java.naming.factory.initial",
+            "javamail.mailbox",
+            "javamail.password",
+            "javamail.protocol",
+            "javamail.root.path",
+            "javamail.server",
+            "javamail.username",
+            "jdbc.db",
+            "jms_timeout",
+            "jstl.db.user",
+            "jstl.db.password",
+            "log.file.location",
+            "logical.hostname.servlet",
+            "longvarbinarySize",
+            "mailuser1",
+            "org.omg.CORBA.ORBClass",
+            "password",
+            "password.1",
+            "platform.mode",
+            "porting.ts.HttpsURLConnection.class.1",
+            "porting.ts.HttpsURLConnection.class.2",
+            "porting.ts.login.class.1",
+            "porting.ts.login.class.2",
+            "porting.ts.url.class.1",
+            "porting.ts.url.class.2",
+            "porting.ts.jms.class.1",
+            "porting.ts.jms.class.2",
+            // These two are probably not useful
+            "porting.ts.deploy.class.1",
+            "porting.ts.deploy.class.2",
+            "ptable",
+            "rapassword1",
+            "rapassword2",
+            "rauser1",
+            "rauser2",
+            "securedWebServicePort",
+            "sigTestClasspath",
+            "smtp.port",
+            "transport_protocol",
+            "ts_home",
+            "user",
+            "user1",
+            "varbinarySize",
+            "variable.mapper",
+            "vehicle_ear_name",
+            "webServerHost",
+            "webServerPort",
+            "whitebox-anno_no_md",
+            "whitebox-mdcomplete",
+            "whitebox-mixedmode",
+            "whitebox-multianno",
+            "whitebox-notx",
+            "whitebox-notx-param",
+            "whitebox-permissiondd",
+            "whitebox-tx",
+            "whitebox-tx-param",
+            "whitebox-xa",
+            "whitebox-xa-param",
+            "work.dir",
+            "ws_wait",
+    };
+
+    /**
+     * Get the deployment vehicle archive name from the deployment archive. This needs to be a vehicle deployment
+     * for the result to be value.
+     * @param deployment - current test deployment
+     * @return base vehicle archive name
+     */
+    public static String vehicleArchiveName(Deployment deployment) {
+        // Get deployment archive name and remove the .* suffix
+        String vehicleArchiveName = deployment.getDescription().getArchive().getName();
+        int dot = vehicleArchiveName.lastIndexOf('.');
+        if(dot != -1) {
+            vehicleArchiveName = vehicleArchiveName.substring(0, dot);
+        }
+        return vehicleArchiveName;
+    }
+
+    /**
+     * Get the test runs args for the vehicle or appclient. If this is a non-vehicle appclient tests, the args
+     * @param config
+     * @param deployment
+     * @param testMethodExecutor
+     * @return
+     * @throws IOException
+     */
+    public static String[] runArgs(ProtocolCommonConfig config, Deployment deployment,
+                                   TestMethodExecutor testMethodExecutor) throws IOException {
+        Class<?> testClass = testMethodExecutor.getMethod().getDeclaringClass();
+        Class<?> testSuperclass = testClass.getSuperclass();
+        TargetVehicle testVehicle = testMethodExecutor.getMethod().getAnnotation(TargetVehicle.class);
+        String testMethodName = testMethodExecutor.getMethod().getName();
+        // The none vehicle is a basic appclient test, not a vehicle based test
+        String vehicle = "none";
+        if (testVehicle != null) {
+            vehicle = testVehicle.value();
+        }
+
+        log.info(String.format("Base class: %s, vehicle: %s", testSuperclass.getName(), vehicle));
+        // Get deployment archive name and remove the .* suffix
+        String vehicleArchiveName = vehicleArchiveName(deployment);
+
+        // We need the JavaTest ts.jte file for now
+        Path tsJte = Paths.get(config.getTsJteFile());
+        Path tssqlStmt = null;
+        if (config.getTsSqlStmtFile() != null) {
+            tssqlStmt = Paths.get(config.getTsSqlStmtFile());
+        }
+        // Create a test properties file
+        String workDir = config.getWorkDir();
+        if(workDir == null) {
+             throw new IllegalStateException("Missing workDir value for test properties file");
+        }
+        Path workDirPath = Paths.get(workDir);
+        if(!workDirPath.toFile().exists()) {
+            log.info("Creating work directory: "+workDirPath.toAbsolutePath());
+            Files.createDirectory(workDirPath);
+        }
+        Path testProps = workDirPath.resolve("tstest.jte");
+
+        // Seed the test properties file with select ts.jte file settings
+        Properties tsJteProps = new Properties();
+        tsJteProps.load(new FileReader(tsJte.toFile()));
+        log.info("Read in ts.jte file: "+tsJte);
+        // The test specific properties file
+        Properties props = new Properties();
+        // A property set by the TSScript class
+        if(vehicle.equals("ejb") && config.isAppClient()) {
+            props.setProperty("finder", "jck");
+        } else {
+            props.setProperty("finder", "cts");
+        }
+        // Vehicle
+        props.setProperty("service_eetest.vehicles", vehicle);
+        props.setProperty("vehicle", vehicle);
+        props.setProperty("vehicle_archive_name", vehicleArchiveName);
+        //
+        props.setProperty("harness.log.delayseconds", "0");
+        if(config.isTrace()) {
+            // This overrides the ts.jte harness.log.traceflag value
+            props.setProperty("harness.log.traceflag", "true");
+        }
+        // Copy over common ts.jte settings
+        for (String propName : tsJtePropNames) {
+            String propValue = tsJteProps.getProperty(propName);
+            if(propValue != null) {
+                if(propValue.startsWith("${") && propValue.endsWith("}")) {
+                    String refName = propValue.substring(2, propValue.length() - 1);
+                    propValue = tsJteProps.getProperty(refName);
+                    if(propValue == null && refName != null) {
+                        propValue = System.getProperty(refName);
+                    }
+                    log.info(String.format("Setting property %s -> %s to %s", propName, refName, propValue));
+                }
+                if(propValue == null) {
+                    propValue = System.getProperty(propName);
+                }
+
+                if(propValue == null) {
+                    continue;
+                }
+                props.setProperty(propName, propValue);
+            }
+        }
+
+        // The vehicle harness operates on the legacy CTS superclass of the Junit5 class.
+        // unless the Junit5 test class directly extends the EETest/ServiceEETest class.
+        if(isAbstract(testSuperclass)) {
+            props.setProperty("test_classname", testClass.getName());
+        } else {
+            props.setProperty("test_classname", testSuperclass.getName());
+        }
+
+        // Write out the test properties file, overwriting any existing file
+        try(OutputStream out = Files.newOutputStream(testProps)) {
+            props.store(out, "Properties for test: "+testMethodName);
+            log.info(props.toString());
+        }
+
+        String[] args = {
+                // test props are needed by EETest.run
+                "-p", testProps.toFile().getAbsolutePath(),
+                "-ap", tssqlStmt != null ? tssqlStmt.toFile().getAbsolutePath() : "/dev/null",
+                "-classname", testMethodExecutor.getMethod().getDeclaringClass().getName(),
+                "-t", testMethodName,
+                "-vehicle", vehicle,
+        };
+        return args;
+    }
+
+    public static boolean isAbstract(Class<?> clazz) {
+        int modifiers = clazz.getModifiers();
+        return Modifier.isAbstract(modifiers);
+    }
+}

--- a/arquillian/common/src/main/resources/javatest.version
+++ b/arquillian/common/src/main/resources/javatest.version
@@ -1,0 +1,1 @@
+${project.version}

--- a/arquillian/javatest/pom.xml
+++ b/arquillian/javatest/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Parent -->
+    <parent>
+        <groupId>jakarta.tck</groupId>
+        <artifactId>tck.arquillian.parent</artifactId>
+        <version>11.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <groupId>jakarta.tck.arquillian</groupId>
+    <artifactId>arquillian-protocol-javatest</artifactId>
+    <name>Arquillian Protocol JavaTest</name>
+    <description>Protocol handler for communicating JavaTest CTS Vehicles</description>
+
+    <!-- Properties -->
+    <properties>
+        <!-- Versioning -->
+        <ee.tck.version>11.0.0-SNAPSHOT</ee.tck.version>
+        <!-- There are post SE 11 language features used -->
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
+
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-common</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <!-- org.jboss.arquillian -->
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-impl-base</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+            <artifactId>shrinkwrap-descriptors-spi</artifactId>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>common</artifactId>
+            <version>${ee.tck.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-lib</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-impl-base</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <filtering>true</filtering>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+    </build>
+</project>

--- a/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestDeploymentPackager.java
+++ b/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestDeploymentPackager.java
@@ -1,0 +1,43 @@
+package tck.arquillian.protocol.javatest;
+
+import org.jboss.arquillian.container.test.spi.TestDeployment;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.deployment.ProtocolArchiveProcessor;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import tck.arquillian.protocol.common.ProtocolJarResolver;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.logging.Logger;
+
+public class JavaTestDeploymentPackager implements DeploymentPackager {
+    static Logger log = Logger.getLogger(JavaTestDeploymentPackager.class.getName());
+
+    @Override
+    public Archive<?> generateDeployment(TestDeployment testDeployment, Collection<ProtocolArchiveProcessor> processors) {
+        Archive<?> archive = testDeployment.getApplicationArchive();
+
+        // Include the protocol.jar in the deployment
+        Collection<Archive<?>> auxiliaryArchives = testDeployment.getAuxiliaryArchives();
+        File protocolJar = ProtocolJarResolver.resolveProtocolJar();
+        if(protocolJar == null) {
+            throw new RuntimeException("Failed to resolve protocol.jar. You either need a jakarta.tck.arquillian:arquillian-protocol-lib"+
+                    " dependency in the runner pom.xml or a downloaded target/protocol/protocol.jar file");
+        }
+
+        if(archive instanceof EnterpriseArchive) {
+            EnterpriseArchive ear = (EnterpriseArchive) archive;
+            ear.addAsLibraries(auxiliaryArchives.toArray(new Archive<?>[0]));
+            ear.addAsLibraries(protocolJar);
+        } else if(archive instanceof WebArchive) {
+            WebArchive war = (WebArchive) archive;
+            war.addAsLibraries(auxiliaryArchives.toArray(new Archive<?>[0]));
+            war.addAsLibraries(protocolJar);
+        }
+
+        return archive;
+    }
+
+}

--- a/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestMethodExecutor.java
+++ b/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestMethodExecutor.java
@@ -1,0 +1,110 @@
+package tck.arquillian.protocol.javatest;
+
+import com.sun.ts.lib.harness.Status;
+import com.sun.ts.lib.harness.EETest;
+import com.sun.ts.tests.common.vehicle.VehicleClient;
+import org.jboss.arquillian.container.spi.client.deployment.Deployment;
+import org.jboss.arquillian.container.spi.context.annotation.DeploymentScoped;
+import org.jboss.arquillian.container.test.spi.ContainerMethodExecutor;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.spi.TestMethodExecutor;
+import org.jboss.arquillian.test.spi.TestResult;
+import tck.arquillian.protocol.common.TargetVehicle;
+import tck.arquillian.protocol.common.TsTestPropsBuilder;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.logging.Logger;
+
+/**
+ * A protocol that invokes that JavaTest CTS test client in the same JVM using the vehicle client or
+ * the non-vehicle client run method.
+ */
+public class JavaTestMethodExecutor implements ContainerMethodExecutor {
+    static Logger log = Logger.getLogger(JavaTestMethodExecutor.class.getName());
+    private JavaTestProtocolConfiguration config;
+    @Inject
+    @DeploymentScoped
+    private Instance<Deployment> deploymentInstance;
+
+    public JavaTestMethodExecutor(JavaTestProtocolConfiguration config) {
+        this.config = config;
+    }
+
+    @Override
+    public TestResult invoke(TestMethodExecutor testMethodExecutor) {
+        log.fine("Executing test method: " + testMethodExecutor.getMethod().getName());
+        long start = System.currentTimeMillis();
+        // Get deployment archive name and remove the .* suffix
+        Deployment deployment = deploymentInstance.get();
+        TargetVehicle testVehicle = testMethodExecutor.getMethod().getAnnotation(TargetVehicle.class);
+        String vehicle = "none";
+        if(testVehicle != null) {
+            vehicle = testVehicle.value();
+        }
+
+        String[] args;
+        try {
+            args = TsTestPropsBuilder.runArgs(config, deployment, testMethodExecutor);
+        } catch (IOException e) {
+            TestResult result = TestResult.failed(e);
+            result.addDescription("Failed to write test properties");
+            return result;
+        }
+
+        // We are running in the same JVM, JavaTest CTS runs in a separate JVM
+        Status status;
+        if(!vehicle.equals("none")) {
+            status = runVehicleClient(args);
+        } else {
+            status = runClient(testMethodExecutor.getInstance(), args);
+        }
+
+        TestResult result = switch (status.getType()) {
+            case Status.PASSED -> TestResult.passed(status.getReason());
+            case Status.FAILED -> TestResult.failed(new Exception(status.getReason()));
+            case Status.ERROR -> TestResult.failed(new EETest.Fault(status.getReason()));
+            case Status.NOT_RUN -> TestResult.skipped(status.getReason());
+            default -> TestResult.failed(new IllegalStateException("Unkown status type: " + status.getType()));
+        };
+        result.setStart(start);
+        result.setEnd(System.currentTimeMillis());
+        return result;
+    }
+
+    /**
+     * Run the vehicle client with the given arguments using the {@link VehicleClient} class.
+     * @param args - the arguments to pass to the client
+     * @return the status of the client run
+     */
+    Status runVehicleClient(String[] args) {
+        VehicleClient client = new VehicleClient();
+        return client.run(args, System.out, System.err);
+    }
+
+    /**
+     * Run a non-vehicle client with the given arguments using by invoking the run method on the client instance.
+     * @param client - the client instance to run
+     * @param args - the arguments to pass to the client
+     * @return the status of the client run
+     */
+    Status runClient(Object client, String[] args) {
+        try {
+            Class<?> baseTestClass = client.getClass();
+            MethodHandles.Lookup publicLookup = MethodHandles.publicLookup();
+            // Get the Status run(String[]) method from the base test class
+            MethodType methodType = MethodType.methodType(Status.class, String[].class, PrintWriter.class, PrintWriter.class);
+            MethodHandle run = publicLookup.findVirtual(baseTestClass, "run", methodType);
+            PrintWriter out = new PrintWriter(System.out, true);
+            PrintWriter err = new PrintWriter(System.err, true);
+            Status status = (Status) run.invoke(client, args, out, err);
+            return status;
+        } catch (Throwable e) {
+            return new Status(Status.ERROR, "Failed to run test client: " + e.getMessage());
+        }
+    }
+}

--- a/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestProtocol.java
+++ b/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestProtocol.java
@@ -1,0 +1,42 @@
+package tck.arquillian.protocol.javatest;
+
+import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.test.spi.ContainerMethodExecutor;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentPackager;
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.container.test.spi.command.CommandCallback;
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+
+public class JavaTestProtocol implements Protocol<JavaTestProtocolConfiguration> {
+    @Inject
+    private Instance<Injector> injectorInstance;
+
+    @Override
+    public Class<JavaTestProtocolConfiguration> getProtocolConfigurationClass() {
+        return JavaTestProtocolConfiguration.class;
+    }
+
+    @Override
+    public ProtocolDescription getDescription() {
+        return new ProtocolDescription("javatest");
+    }
+
+    @Override
+    public DeploymentPackager getPackager() {
+        return new JavaTestDeploymentPackager();
+    }
+
+    @Override
+    public ContainerMethodExecutor getExecutor(JavaTestProtocolConfiguration protocolConfiguration, ProtocolMetaData metaData,
+                                               CommandCallback callback) {
+
+        JavaTestMethodExecutor executor = new JavaTestMethodExecutor(protocolConfiguration);
+        Injector injector = injectorInstance.get();
+        injector.inject(executor);
+        return executor;
+    }
+}
+

--- a/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestProtocolConfiguration.java
+++ b/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestProtocolConfiguration.java
@@ -1,0 +1,60 @@
+package tck.arquillian.protocol.javatest;
+
+import org.jboss.arquillian.container.test.spi.client.protocol.ProtocolConfiguration;
+import tck.arquillian.protocol.common.ProtocolCommonConfig;
+
+import java.nio.file.Files;
+
+public class JavaTestProtocolConfiguration implements ProtocolConfiguration, ProtocolCommonConfig {
+    // test working directory
+    private String workDir;
+    // EE10 type of ts.jte file location
+    private String tsJteFile;
+    // EE10 type of tssql.stmt file location
+    private String tsSqlStmtFile;
+    // harness.log.traceflag
+    private boolean trace;
+    // Should the VehicleClient main be run in a separate JVM
+    private boolean fork;
+
+    public String getWorkDir() {
+        return workDir;
+    }
+
+    public void setWorkDir(String workDir) {
+        this.workDir = workDir;
+    }
+
+    public String getTsJteFile() {
+        return tsJteFile;
+    }
+
+    public void setTsJteFile(String tsJteFile) {
+        this.tsJteFile = tsJteFile;
+    }
+
+    @Override
+    public String getTsSqlStmtFile() {
+        return tsSqlStmtFile;
+    }
+    @Override
+    public void setTsSqlStmtFile(String tsSqlStmtFile) {
+        this.tsSqlStmtFile = tsSqlStmtFile;
+    }
+
+    public boolean isTrace() {
+        return trace;
+    }
+
+    public void setTrace(boolean trace) {
+        this.trace = trace;
+    }
+
+    public boolean isFork() {
+        return fork;
+    }
+
+    public void setFork(boolean fork) {
+        this.fork = fork;
+    }
+}

--- a/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestProtocolExtension.java
+++ b/arquillian/javatest/src/main/java/tck/arquillian/protocol/javatest/JavaTestProtocolExtension.java
@@ -1,0 +1,13 @@
+package tck.arquillian.protocol.javatest;
+
+import org.jboss.arquillian.container.test.spi.client.protocol.Protocol;
+import org.jboss.arquillian.core.spi.LoadableExtension;
+
+public class JavaTestProtocolExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.service(Protocol.class, JavaTestProtocol.class);
+    }
+
+}

--- a/arquillian/javatest/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/arquillian/javatest/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+tck.arquillian.protocol.javatest.JavaTestProtocolExtension

--- a/arquillian/javatest/src/main/resources/javatest.version
+++ b/arquillian/javatest/src/main/resources/javatest.version
@@ -1,0 +1,1 @@
+${project.version}

--- a/arquillian/javatest/src/test/java/shrinkwrap/LibResolveTest.java
+++ b/arquillian/javatest/src/test/java/shrinkwrap/LibResolveTest.java
@@ -1,0 +1,41 @@
+package shrinkwrap;
+
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
+import org.jboss.shrinkwrap.resolver.api.maven.MavenResolvedArtifact;
+import org.jboss.shrinkwrap.resolver.api.maven.coordinate.MavenCoordinate;
+import org.junit.jupiter.api.Test;
+import tck.arquillian.protocol.javatest.JavaTestDeploymentPackager;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+public class LibResolveTest {
+    @Test
+    public void testVersionInfo() throws IOException {
+        URL versionURL = JavaTestDeploymentPackager.class.getResource("/javatest.version");
+        System.out.println("Version URL: " + versionURL);
+        try(InputStream is = versionURL.openStream()) {
+            byte[] info = is.readAllBytes();
+            System.out.println("Version info: " + new String(info));
+        }
+    }
+
+    @Test
+    public void resolveProtocolLib() {
+        String[] activeMavenProfiles = {"staging"};
+        MavenResolvedArtifact[] resolvedArtifacts = Maven.resolver().loadPomFromFile("pom.xml", activeMavenProfiles)
+                .resolve("jakarta.tck.arquillian:arquillian-protocol-lib")
+                .withTransitivity()
+                .asResolvedArtifact();
+        MavenResolvedArtifact protocolLib = null;
+        for (MavenResolvedArtifact resolvedArtifact : resolvedArtifacts) {
+            MavenCoordinate gav = resolvedArtifact.getCoordinate();
+            if(gav.getGroupId().equals("jakarta.tck.arquillian") && gav.getArtifactId().equals("arquillian-protocol-lib")) {
+                protocolLib = resolvedArtifact;
+                break;
+            }
+        }
+        System.out.println("Resolved artifact: " + protocolLib);
+    }
+}

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Parent -->
+    <parent>
+        <groupId>jakarta.tck</groupId>
+        <artifactId>project</artifactId>
+        <version>11.0.0-SNAPSHOT</version>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <groupId>jakarta.tck</groupId>
+    <artifactId>tck.arquillian.parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Arquillian Jakarta TCK Parent</name>
+    <description>Protocols and testenrichers for Jakarta TCKs</description>
+
+    <modules>
+        <module>appclient</module>
+        <module>common</module>
+        <module>javatest</module>
+        <module>porting-lib</module>
+        <module>protocol-lib</module>
+    </modules>
+
+    <scm>
+        <connection>scm:git:https://github.com/eclipse-ee4j/jakartaee-tck-tools</connection>
+        <developerConnection>scm:git:https://github.com/eclipse-ee4j/jakartaee-tck-tools</developerConnection>
+        <tag>master</tag>
+        <url>https://github.com/eclipse-ee4j/jakartaee-tck-tools/tools/arquillian</url>
+    </scm>
+
+    <!-- Properties -->
+    <properties>
+
+        <maven.compiler.release>17</maven.compiler.release>
+        <!-- Versioning -->
+        <version.arquillian_core>1.9.1.Final</version.arquillian_core>
+        <version.shrinkwrap>3.2.1</version.shrinkwrap>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-bom</artifactId>
+                <version>${version.shrinkwrap}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>${version.arquillian_core}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-build</artifactId>
+                <version>${version.arquillian_core}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+</project>

--- a/arquillian/porting-lib/pom.xml
+++ b/arquillian/porting-lib/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Parent -->
+    <parent>
+        <groupId>jakarta.tck</groupId>
+        <artifactId>tck.arquillian.parent</artifactId>
+        <version>11.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <groupId>jakarta.tck.arquillian</groupId>
+    <artifactId>tck-porting-lib</artifactId>
+    <name>Jakarta TCK Porting Lib Common</name>
+    <description>Arquillian SPI classes used vendors to add implementation details</description>
+
+    <!-- Properties -->
+    <properties>
+        <!-- Versioning -->
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.test</groupId>
+            <artifactId>arquillian-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/arquillian/porting-lib/src/main/java/tck/arquillian/porting/lib/spi/AbstractTestArchiveProcessor.java
+++ b/arquillian/porting-lib/src/main/java/tck/arquillian/porting/lib/spi/AbstractTestArchiveProcessor.java
@@ -1,0 +1,39 @@
+package tck.arquillian.porting.lib.spi;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+
+/**
+ * A base class for {@link TestArchiveProcessor} implementations that also provides the required
+ * {@link ResourceProvider} implementation to be able to inject the {@link TestArchiveProcessor} instance.
+ */
+public abstract class AbstractTestArchiveProcessor implements TestArchiveProcessor, ResourceProvider {
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<TestArchiveProcessor> archiveProcessorProducer;
+
+    /**
+     * Called on completion of the Arquillian configuration. Subclasses that override this method must
+     * call super.initalize(descriptor) to ensure that the {@link TestArchiveProcessor} producer instance is set.
+     */
+    public void initalize(@Observes ArquillianDescriptor descriptor) {
+        archiveProcessorProducer.set(this);
+    }
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return type.isAssignableFrom(TestArchiveProcessor.class);
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        return archiveProcessorProducer.get();
+    }
+}

--- a/arquillian/porting-lib/src/main/java/tck/arquillian/porting/lib/spi/TestArchiveProcessor.java
+++ b/arquillian/porting-lib/src/main/java/tck/arquillian/porting/lib/spi/TestArchiveProcessor.java
@@ -1,0 +1,55 @@
+package tck.arquillian.porting.lib.spi;
+
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import java.net.URL;
+
+/**
+ * Interface that vendors implement to augment test archives with vendor specific deployment content.
+ */
+public interface TestArchiveProcessor {
+    /**
+     * Called to process a client archive (jar) that is part of the test deployment.
+     * @param clientArchive - the appclient archive
+     * @param testClass - the TCK test class
+     * @param sunXmlUrl - the URL to the sun-application-client.xml file
+     */
+    void processClientArchive(JavaArchive clientArchive, Class<?> testClass, URL sunXmlUrl);
+    /**
+     * Called to process a ejb archive (jar) that is part of the test deployment.
+     * @param ejbArchive - the ejb archive
+     * @param testClass - the TCK test class
+     * @param sunXmlUrl - the URL to the sun-ejb-jar.xml file
+     */
+    void processEjbArchive(JavaArchive ejbArchive, Class<?> testClass, URL sunXmlUrl);
+    /**
+     * Called to process a web archive (war) that is part of the test deployment.
+     * @param webArchive - the web archive
+     * @param testClass - the TCK test class
+     * @param sunXmlUrl - the URL to the sun-web.xml file
+     */
+    void processWebArchive(WebArchive webArchive, Class<?> testClass, URL sunXmlUrl);
+    /**
+     * Called to process a resource adaptor archive (rar) that is part of the test deployment.
+     * @param rarArchive - the resource archive
+     * @param testClass - the TCK test class
+     * @param sunXmlUrl - the URL to the sun-ra.xml file
+     */
+    void processRarArchive(JavaArchive rarArchive, Class<?> testClass, URL sunXmlUrl);
+    /**
+     * Called to process a persistence unit archive (par) that is part of the test deployment.
+     * @param parArchive - the resource archive
+     * @param testClass - the TCK test class
+     * @param persistenceXmlUrl - the URL to the sun-ra.xml file
+     */
+    void processParArchive(JavaArchive parArchive, Class<?> testClass, URL persistenceXmlUrl);
+    /**
+     * Called to process an enterprise archive (ear) that is part of the test deployment.
+     * @param earArchive - the application archive
+     * @param testClass - the TCK test class
+     * @param sunXmlUrl - the URL to the sun-application.xml file
+     */
+    void processEarArchive(EnterpriseArchive earArchive, Class<?> testClass, URL sunXmlUrl);
+}

--- a/arquillian/protocol-lib/pom.xml
+++ b/arquillian/protocol-lib/pom.xml
@@ -1,0 +1,109 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+    <!-- Model Version -->
+    <modelVersion>4.0.0</modelVersion>
+
+    <!-- Parent -->
+    <parent>
+        <groupId>jakarta.tck</groupId>
+        <artifactId>tck.arquillian.parent</artifactId>
+        <version>11.0.0-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <!-- Artifact Configuration -->
+    <groupId>jakarta.tck.arquillian</groupId>
+    <artifactId>arquillian-protocol-lib</artifactId>
+    <name>Arquillian Protocol Lib</name>
+
+    <properties>
+        <!-- Versioning -->
+        <ee.tck.version>11.0.0-SNAPSHOT</ee.tck.version>
+    </properties>
+
+    <!-- Dependencies -->
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>common</artifactId>
+            <version>${ee.tck.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>libutil</artifactId>
+            <version>${ee.tck.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <!-- TODO: either make a proper artifact or define this as a setup requirement
+        in the TCK user guide.
+
+        This combines the TCK vehicle related classes into a protocol.jar that is
+         included in the test deployments by the JavaTestDeploymentPackager class.
+         -->
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.6.1</version>
+                <executions>
+                    <execution>
+                        <id>src-dependencies</id>
+                        <goals>
+                            <!-- use copy-dependencies instead if you don't want to explode the sources -->
+                            <goal>unpack-dependencies</goal>
+                        </goals>
+                        <phase>process-sources</phase>
+                        <configuration>
+                            <classifier>sources</classifier>
+                            <outputDirectory>${project.build.directory}/sources</outputDirectory>
+                            <includeArtifactIds>libutil,common</includeArtifactIds>
+                            <excludes>**/module-info.java</excludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>unpack</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>process-classes</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>libutil</artifactId>
+                                    <version>${ee.tck.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                                    <includes>**/*.class,**/*.xml</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>common</artifactId>
+                                    <version>${ee.tck.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}/classes</outputDirectory>
+                                    <includes>**/*.class</includes>
+                                    <excludes>**/connector/**,**/jms/**,**/vehicle/**,**/whitebox/**</excludes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <configuration>
+                    <additionalOptions>-package</additionalOptions>
+                    <doclint>none</doclint>
+                    <sourcepath>${project.build.directory}/sources</sourcepath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/arquillian/protocol-lib/src/main/java/tck/arquillian/protocol/package-info.java
+++ b/arquillian/protocol-lib/src/main/java/tck/arquillian/protocol/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * A dummy package to hold the package-level javadoc.
+ */
+package tck.arquillian.protocol;

--- a/el/pom.xml
+++ b/el/pom.xml
@@ -36,7 +36,6 @@
         <arquillian.junit>1.9.1.Final</arquillian.junit>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
-        <version.jakarta.tck.arquillian>1.0.0-M15</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencies>
@@ -56,27 +55,27 @@
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-appclient</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-common</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-javatest</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>tck-porting-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/javamail/pom.xml
+++ b/javamail/pom.xml
@@ -45,7 +45,6 @@ EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
         <jakarta.ee.version>11.0.0-M1</jakarta.ee.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <maven.compiler.release>17</maven.compiler.release>
-        <version.jakarta.tck.arquillian>1.0.0-M16</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencies>
@@ -90,17 +89,17 @@ EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-appclient</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-javatest</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>tck-porting-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
 
         <!-- Junit5 -->

--- a/jsonb/pom.xml
+++ b/jsonb/pom.xml
@@ -38,7 +38,6 @@
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
-        <version.jakarta.tck.arquillian>1.0.0-M15</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencies>
@@ -83,27 +82,27 @@
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-appclient</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-javatest</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-common</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>tck-porting-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/jsonp/pom.xml
+++ b/jsonp/pom.xml
@@ -38,7 +38,6 @@
         <jakarta.json.bind-api.version>3.0.1</jakarta.json.bind-api.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
-        <version.jakarta.tck.arquillian>1.0.0-M15</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencies>
@@ -83,27 +82,27 @@
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-appclient</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-javatest</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-common</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>tck-porting-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
     </dependencies>
 

--- a/jta/pom.xml
+++ b/jta/pom.xml
@@ -36,7 +36,6 @@
         <arquillian.junit>1.9.1.Final</arquillian.junit>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
-        <version.jakarta.tck.arquillian>1.0.0-M16</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencyManagement>
@@ -88,27 +87,27 @@
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-appclient</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-common</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-javatest</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>tck-porting-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <modules>
         <module>appclient</module>
+        <module>arquillian</module>
         <module>assembly</module>
         <module>common</module>
         <module>connector</module>
@@ -81,7 +82,7 @@
     <properties>
         <ant.version>1.10.11</ant.version>
         <arquillian.container.se.api.version>1.0.2.Final</arquillian.container.se.api.version>
-        <arquillian.jakarta.tck.version>1.0.0-M17</arquillian.jakarta.tck.version>
+        <arquillian.jakarta.tck.version>${project.version}</arquillian.jakarta.tck.version>
         <arquillian.version>1.9.1.Final</arquillian.version>
         <!-- CDI -->
         <cdi-api.version>4.0.0</cdi-api.version>

--- a/xa/pom.xml
+++ b/xa/pom.xml
@@ -37,7 +37,6 @@
         <jakarta.ee.version>11.0.0-SNAPSHOT</jakarta.ee.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <maven.compiler.release>17</maven.compiler.release>
-        <version.jakarta.tck.arquillian>1.0.0-M16</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencies>
@@ -58,12 +57,12 @@
         <dependency>
             <groupId>${project.groupId}.arquillian</groupId>
             <artifactId>arquillian-protocol-common</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}.arquillian</groupId>
             <artifactId>arquillian-protocol-javatest</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.mail</groupId>
@@ -97,17 +96,17 @@
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-appclient</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-javatest</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>tck-porting-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
+            <version>${arquillian.jakarta.tck.version}</version>
         </dependency>
 
         <!-- Junit5 -->


### PR DESCRIPTION
- Move the arquillian protocol modules into platform-tck
- Change the version to same as the platform tck
- Update references to arquillian protocol version to use the parent pom property

Signed-off-by: Scott M Stark <starksm64@gmail.com>

**Fixes Issue**
#1566

**Describe the change**
The removes the need for synchornization between the arquillian protocols needed for the platform-tck

**Additional context**
Inconsistent views of the platform classes included in the arquillian deployment artifacts was occurring due to inclusion of snapshot dependencies. 

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
