### PR TITLE
Release Servlet 6.0.2 TCK for Exclude Servlet Cookie setMaxAgeZeroTest change

### DIFF
--- a/release/tools/servlet.xml
+++ b/release/tools/servlet.xml
@@ -23,7 +23,7 @@
 	<import file="../../bin/xml/ts.common.props.xml"/>
 
 	<property name="deliverable.version"  value="6.0"/>
-        <property name="deliverable.tck.version"  value="6.0.3"/>
+        <property name="deliverable.tck.version"  value="6.0.2"/>
 
 	<target name="init">
 		<mkdir dir="${deliverable.bundle.dir}/bin"/>


### PR DESCRIPTION
We never released Servlet 6.0.2 as we left https://github.com/jakartaee/specifications/pull/761 in draft mode so we can probably update that pr and actually do the promotion this time.

**Fixes Issue**
For https://github.com/jakartaee/servlet/issues/701
