### PR TITLE
The spotless plugin seems to mess up the Maven reactor when sortModul…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -733,8 +733,6 @@
                             <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
                             <!-- Sort properties -->
                             <sortProperties>true</sortProperties>
-                            <!-- Sort modules -->
-                            <sortModules>true</sortModules>
                             <!-- Sort plugin executions -->
                             <sortExecutions>true</sortExecutions>
                         </sortPom>
@@ -747,6 +745,21 @@
                             <goal>check</goal>
                         </goals>
                         <phase>validate</phase>
+                        <configuration>
+                            <pom combine.children="append">
+                                <sortPom combine.children="append">
+                                    <nrOfIndentSpace>4</nrOfIndentSpace>
+                                    <!-- default see https://github.com/Ekryd/sortpom/wiki/PredefinedSortOrderProfiles -->
+                                    <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
+                                    <!-- Sort properties -->
+                                    <sortProperties>true</sortProperties>
+                                    <!-- Sort modules -->
+                                    <sortModules>true</sortModules>
+                                    <!-- Sort plugin executions -->
+                                    <sortExecutions>true</sortExecutions>
+                                </sortPom>
+                            </pom>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>


### PR DESCRIPTION
…es is set to true. This is okay for the check goal, but not apply. Add the configuration to the check executions and remove sortModules from the default configuration.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
