### PR TITLE
Persistence : Fix more of the appclient tests errors with CNFE

### DIFF
--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/EntityGraph/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/EntityGraph/ClientAppmanagedTest.java
@@ -86,7 +86,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.Entity
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             ee.jakarta.tck.persistence.core.EntityGraph.Employee3.class,
             ee.jakarta.tck.persistence.core.EntityGraph.Department.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client2AppmanagedTest.java
@@ -95,6 +95,7 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.Store
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.StoredProcedureQuery.Client.class,
+            ee.jakarta.tck.persistence.core.StoredProcedureQuery.Client2.class,
             Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateful3Test.java
@@ -83,6 +83,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateless3Test.java
@@ -90,6 +90,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.annotations.access.property.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_access_property_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/property/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annotations.access.property.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_access_property_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientAppmanagedTest.java
@@ -84,6 +84,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Client.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.PartTimeEmployee.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientAppmanagednotxTest.java
@@ -91,6 +91,8 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.PartTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientStateful3Test.java
@@ -90,6 +90,8 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.PartTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientStateless3Test.java
@@ -91,6 +91,8 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.PartTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.annotations.basic.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_basic_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.basic.Client.class
+            ee.jakarta.tck.persistence.core.annotations.basic.Client.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annotations.basic.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_basic_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.basic.Client.class
+            ee.jakarta.tck.persistence.core.annotations.basic.Client.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/discriminatorValue/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/discriminatorValue/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/discriminatorValue/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/discriminatorValue/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client1AppmanagedTest.java
@@ -82,7 +82,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.annotations.elementcollection.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_elementcollection_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,10 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.elementcollection.A.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annotations.elementcollection.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_elementcollection_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.elementcollection.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2AppmanagednotxTest.java
@@ -82,7 +82,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2Stateful3Test.java
@@ -82,7 +82,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/elementcollection/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annotations.elementcollection.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_elementcollection_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddable/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddable/ClientAppmanagedTest.java
@@ -94,7 +94,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddable/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddable/ClientStateful3Test.java
@@ -94,7 +94,10 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.embeddable.B.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddableMapValue/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddableMapValue/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddableMapValue/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/embeddableMapValue/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.entity.Coffee.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientAppmanagednotxTest.java
@@ -89,6 +89,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.entity.Coffee.class,
             ee.jakarta.tck.persistence.core.annotations.entity.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientStateless3Test.java
@@ -91,6 +91,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.entity.Coffee.class,
             ee.jakarta.tck.persistence.core.annotations.entity.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/id/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/lob/ClientStateful3Test.java
@@ -82,7 +82,10 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.lob.DataTypes.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagedTest.java
@@ -131,6 +131,7 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             Client1.class,
             Client1AppmanagedTest.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagedTest.java
@@ -131,7 +131,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagednotxTest.java
@@ -142,6 +142,7 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             Client1.class,
             Client1AppmanagednotxTest.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.annotations.mapkey.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_mapkey_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -131,7 +142,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1Stateful3Test.java
@@ -131,6 +131,7 @@ public class Client1Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client1.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1Stateless3Test.java
@@ -137,6 +137,7 @@ public class Client1Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client1.class,
             Client1Stateless3Test.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagedTest.java
@@ -142,6 +142,7 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client2.class,
             Client2AppmanagedTest.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annotations.mapkey.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_mapkey_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -131,7 +142,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagednotxTest.java
@@ -131,7 +131,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateful3Test.java
@@ -131,6 +131,7 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             Client2.class,
             Client2Stateful3Test.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateful3Test.java
@@ -131,7 +131,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annotations.mapkey.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_mapkey_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -131,7 +142,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyclass/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyclass/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyclass/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyclass/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagednotxTest.java
@@ -89,6 +89,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
@@ -83,6 +83,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagednotxTest.java
@@ -89,6 +89,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
@@ -83,6 +83,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateless3Test.java
@@ -91,6 +91,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyjoincolumn/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyjoincolumn/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyjoincolumn/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyjoincolumn/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagednotxTest.java
@@ -89,6 +89,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
@@ -83,6 +83,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateless3Test.java
@@ -91,6 +91,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapsid/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapsid/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapsid/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapsid/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/nativequery/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/nativequery/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/nativequery/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/nativequery/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/onexmanyuni/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/onexmanyuni/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/onexmanyuni/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/onexmanyuni/ClientStateful3Test.java
@@ -82,7 +82,10 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.onexmanyuni.Customer1.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client1AppmanagedTest.java
@@ -82,7 +82,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.annotations.orderby.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_orderby_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,10 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.orderby.Address.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annotations.orderby.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_orderby_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.orderby.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2AppmanagednotxTest.java
@@ -82,7 +82,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2Stateful3Test.java
@@ -82,7 +82,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annotations.orderby.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_orderby_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,10 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.orderby.Address.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client3AppmanagedTest.java
@@ -82,7 +82,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client3AppmanagednotxTest.java
@@ -82,7 +82,9 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/orderby/Client3Stateless3Test.java
@@ -82,7 +82,9 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client1AppmanagedTest.java
@@ -82,7 +82,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.annotations.ordercolumn.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_ordercolumn_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annotations.ordercolumn.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_ordercolumn_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.ordercolumn.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2AppmanagednotxTest.java
@@ -82,7 +82,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2Stateful3Test.java
@@ -82,7 +82,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/ordercolumn/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annotations.ordercolumn.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_ordercolumn_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_tableGenerator_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_tableGenerator_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_tableGenerator_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client3AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client3Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client3.class,
+            Client3Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client4.class,
+            Client4Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/tableGenerator/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class
+            ee.jakarta.tck.persistence.core.annotations.tableGenerator.Client.class,
+            Client4.class,
+            Client4Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/temporal/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/temporal/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/temporal/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/temporal/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.annotations.version.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_version_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annotations.version.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_version_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            ee.jakarta.tck.persistence.core.annotations.version.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annotations.version.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_annotations_version_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client3.class,
+            Client3Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client4.class,
+            Client4Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.annotations.version.Client.class
+            ee.jakarta.tck.persistence.core.annotations.version.Client.class,
+            Client4.class,
+            Client4Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/basic/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/basic/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.basic.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/basic/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/basic/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.basic.C
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.cache.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.cache.b
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientAppmanagednotxTest.java
@@ -89,6 +89,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.ca
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.inheritance.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientStateful3Test.java
@@ -83,6 +83,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/inheritance/ClientStateless3Test.java
@@ -91,6 +91,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.inheritance.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientAppmanagedTest.java
@@ -95,6 +95,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientAppmanagedTest.java
@@ -94,7 +94,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientAppmanagednotxTest.java
@@ -101,6 +101,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.ca
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.listener.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientStateful3Test.java
@@ -95,6 +95,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientStateful3Test.java
@@ -94,7 +94,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listener/ClientStateless3Test.java
@@ -103,6 +103,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.listener.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientAppmanagednotxTest.java
@@ -89,6 +89,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.ca
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.listeneroverride.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientStateful3Test.java
@@ -83,6 +83,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/listeneroverride/ClientStateless3Test.java
@@ -91,6 +91,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.listeneroverride.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientAppmanagedTest.java
@@ -95,6 +95,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientAppmanagedTest.java
@@ -94,7 +94,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientAppmanagednotxTest.java
@@ -101,6 +101,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.ca
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.method.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientStateful3Test.java
@@ -95,6 +95,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientStateful3Test.java
@@ -94,7 +94,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.criteriaapi.CriteriaBuilder.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriapia_CriteriaBuilder_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.criteriaapi.CriteriaBuilder.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriapia_CriteriaBuilder_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.CriteriaBuilder.Client2.class,
+            Client2AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.criteriaapi.CriteriaBuilder.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriapia_CriteriaBuilder_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client3AppmanagednotxTest.java
@@ -83,8 +83,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client3Stateless3Test.java
@@ -83,8 +83,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaDelete/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaDelete/ClientStateful3Test.java
@@ -83,7 +83,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.criteri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client1AppmanagedTest.java
@@ -84,7 +84,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.criteriaapi.CriteriaQuery.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_CriteriaQuery_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -84,7 +95,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.criteriaapi.CriteriaQuery.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_CriteriaQuery_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.CriteriaQuery.Client2.class,
+            Client2AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.criteriaapi.CriteriaQuery.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_CriteriaQuery_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client3AppmanagednotxTest.java
@@ -83,8 +83,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client3Stateless3Test.java
@@ -83,8 +83,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientStateful3Test.java
@@ -83,7 +83,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.criteri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.criteriaapi.From.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_From_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.criteriaapi.From.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_From_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.From.Client2.class,
+            Client2AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.criteriaapi.From.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_From_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3AppmanagedTest.java
@@ -84,7 +84,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3AppmanagednotxTest.java
@@ -84,8 +84,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3Stateless3Test.java
@@ -84,8 +84,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client1AppmanagedTest.java
@@ -83,9 +83,10 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
-            // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(resURL != null) {
               jpa_core_criteriaapi_Join_appmanaged_vehicle_client.addAsManifestResource(resURL, "application-client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.criteriaapi.Join.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_Join_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.criteriaapi.Join.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_Join_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -84,7 +95,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.Join.Client2.class,
+            Client2AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2AppmanagednotxTest.java
@@ -84,7 +84,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2Stateful3Test.java
@@ -84,7 +84,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.criteriaapi.Join.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_Join_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -84,7 +95,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client3AppmanagednotxTest.java
@@ -83,8 +83,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Join/Client3Stateless3Test.java
@@ -83,8 +83,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.criteriaapi.Root.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_Root_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.criteriaapi.Root.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_Root_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.Root.Client2.class,
+            Client2AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.criteriaapi.Root.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_Root_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client3AppmanagednotxTest.java
@@ -84,8 +84,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client3Stateless3Test.java
@@ -83,8 +83,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.criteriaapi.metamodelquery.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_metamodelquery_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.criteriaapi.metamodelquery.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_metamodelquery_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -84,7 +95,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.metamodelquery.Client2.class,
+            Client2AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2AppmanagednotxTest.java
@@ -84,7 +84,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateful3Test.java
@@ -84,7 +84,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.criteriaapi.metamodelquery.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_metamodelquery_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -84,7 +95,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client3AppmanagednotxTest.java
@@ -83,8 +83,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client3Stateless3Test.java
@@ -83,8 +83,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.criteriaapi.misc.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_misc_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.criteriaapi.misc.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_misc_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.misc.Client2.class,
+            Client2AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.criteriaapi.misc.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_misc_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client3AppmanagedTest.java
@@ -84,7 +84,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client3AppmanagednotxTest.java
@@ -84,8 +84,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/misc/Client3Stateless3Test.java
@@ -84,8 +84,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_parameter_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_parameter_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -84,7 +95,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2AppmanagednotxTest.java
@@ -84,7 +84,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_parameter_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -84,7 +95,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());;
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.criteriaapi.strquery.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_strquery_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.criteriaapi.strquery.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_strquery_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -84,7 +95,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.strquery.Client2.class,
+            Client2AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2AppmanagednotxTest.java
@@ -84,7 +84,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2Stateful3Test.java
@@ -84,7 +84,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.criteriaapi.strquery.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_criteriaapi_strquery_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -84,7 +95,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client3AppmanagednotxTest.java
@@ -83,8 +83,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client3Stateless3Test.java
@@ -83,8 +83,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1a/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1a/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1a/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1a/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1b/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1b/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1b/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex1b/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2a/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2a/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2a/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2a/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2b/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2b/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2b/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex2b/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3a/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3a/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3a/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3a/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3b/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3b/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3b/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex3b/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4a/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4a/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4a/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4a/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4b/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4b/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4b/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex4b/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5a/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5a/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5a/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5a/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5b/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5b/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5b/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex5b/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6a/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6a/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6a/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6a/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6b/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6b/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.derive
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6b/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/derivedid/ex6b/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.derived
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1AppmanagedTest.java
@@ -114,7 +114,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.entityManager.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_entityManager_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -114,7 +125,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.e
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.entityManager.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_entityManager_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -114,7 +125,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2Stateful3Test.java
@@ -114,7 +114,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.entityManager.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_entityManager_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -114,7 +125,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3AppmanagedTest.java
@@ -114,7 +114,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3AppmanagednotxTest.java
@@ -114,7 +114,9 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.e
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3Stateless3Test.java
@@ -114,7 +114,9 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.entityManager2.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_entityManager2_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -78,7 +89,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.e
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.entityManager2.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_entityManager2_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -78,7 +89,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client1AppmanagedTest.java
@@ -94,7 +94,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.entityManagerFactory.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_entityManagerFactory_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -94,7 +105,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.e
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.entityManagerFactory.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_entityManagerFactory_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -94,7 +105,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManagerFactory.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client2Stateful3Test.java
@@ -94,7 +94,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.entityManagerFactory.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_entityManagerFactory_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -94,7 +105,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3AppmanagedTest.java
@@ -94,7 +94,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3AppmanagednotxTest.java
@@ -94,7 +94,9 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.e
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactory/Client3Stateless3Test.java
@@ -94,7 +94,9 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityM
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/bigdecimal/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/biginteger/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXmany/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/oneXone/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/basic/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXmany/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/ClientAppmanagedTest.java
@@ -94,7 +94,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXmany/ClientStateful3Test.java
@@ -94,7 +94,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/oneXone/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/basic/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/basic/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/basic/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/basic/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXmany/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/remove/oneXone/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/enums/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/enums/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.enums.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/enums/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/enums/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.enums.C
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.inheri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientAppmanagednotxTest.java
@@ -96,7 +96,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.in
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.inheritance.abstractentity.Client.class,
-            ClientAppmanagednotxTest.class,
+            ee.jakarta.tck.persistence.core.inheritance.abstractentity.FullTimeEmployee.class,
             ClientAppmanagednotxTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.inherit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/annotation/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/annotation/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.inheri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/annotation/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/annotation/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.inherit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/descriptors/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/descriptors/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.inheri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/descriptors/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/mappedsc/descriptors/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.inherit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.inheri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/nonentity/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.inherit
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/attribute/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/attribute/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/attribute/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/attribute/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/basictype/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/basictype/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/basictype/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/basictype/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/bindable/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/collectionattribute/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/collectionattribute/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/collectionattribute/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/collectionattribute/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/embeddabletype/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/embeddabletype/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/embeddabletype/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/embeddabletype/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/entitytype/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/listattribute/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/listattribute/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/listattribute/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/listattribute/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/managedtype/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mapattribute/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mapattribute/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mapattribute/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mapattribute/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mappedsuperclasstype/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mappedsuperclasstype/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mappedsuperclasstype/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/mappedsuperclasstype/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/metamodel/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/pluralattribute/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/pluralattribute/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/pluralattribute/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/pluralattribute/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/setattribute/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/singularattribute/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/singularattribute/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/singularattribute/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/singularattribute/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/type/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/type/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/type/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/type/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.nested
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/nestedembedding/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.nestede
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/attributeoverride/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/attributeoverride/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/attributeoverride/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/attributeoverride/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/callbacklistener/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/callbacklistener/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/callbacklistener/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/callbacklistener/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/embeddable/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/embeddable/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/embeddable/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/embeddable/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entity/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entity/ClientAppmanagedTest.java
@@ -94,7 +94,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entity/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entity/ClientStateful3Test.java
@@ -94,7 +94,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/entitylistener/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/joincolumn/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/joincolumn/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/joincolumn/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/joincolumn/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/manytomany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/manytomany/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/manytomany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/manytomany/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagednotxTest.java
@@ -90,6 +90,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.ov
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.override.mapkey.Client.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
             ClientAppmanagednotxTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/nocallbacklistener/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/nocallbacklistener/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/nocallbacklistener/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/nocallbacklistener/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/table/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/table/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/table/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/table/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.overrid
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.persis
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUnitUtil/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.persist
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUtil/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUtil/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.persis
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUtil/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/persistenceUtil/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.persist
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.query.apitests.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_apitests_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -78,7 +89,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.query.apitests.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_apitests_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -78,7 +89,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3AppmanagednotxTest.java
@@ -78,7 +78,9 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3Stateless3Test.java
@@ -78,7 +78,9 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4AppmanagednotxTest.java
@@ -78,7 +78,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4Stateless3Test.java
@@ -78,7 +78,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.query.flushmode.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_flushmode_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -79,7 +90,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2AppmanagednotxTest.java
@@ -79,7 +79,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.query.flushmode.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_flushmode_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -79,7 +90,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client3AppmanagednotxTest.java
@@ -79,8 +79,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client3Stateless3Test.java
@@ -79,8 +79,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.query.language.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_language_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -122,7 +133,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
                 com.sun.ts.lib.harness.EETest.SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-                com.sun.ts.tests.common.vehicle.appmanagedNoTx.AppManagedNoTxVehicleBean.class
+                com.sun.ts.tests.common.vehicle.appmanagedNoTx.AppManagedNoTxVehicleBean.class,
+                Client1.class,
+                Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client1.class.getResource("//vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_ejb.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client1AppmanagednotxTest.java
@@ -94,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.query.language.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_language_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.query.language.Client2.class,
+            Client2AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.query.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.query.language.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_language_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client3AppmanagednotxTest.java
@@ -83,8 +83,10 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client3Stateless3Test.java
@@ -83,8 +83,10 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client3.class,
+            Client3Stateless3Test.class)
+            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client1AppmanagedTest.java
@@ -82,7 +82,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.query.parameter.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_parameter_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.query.parameter.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_parameter_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.query.parameter.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2Stateful3Test.java
@@ -82,7 +82,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.query.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/parameter/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.query.parameter.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_query_parameter_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/annotations/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxmany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxmany/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxmany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxmany/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxone/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxone/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxone/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidirmanyxone/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexmany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexmany/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexmany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexmany/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexone/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexone/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexone/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/bidironexone/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/defaults/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/descriptors/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxmany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxmany/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxmany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxmany/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxone/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxone/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxone/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unimanyxone/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexmany/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexmany/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexmany/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexmany/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexone/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexone/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.relati
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexone/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/relationship/unionexone/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.relatio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/auto/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/auto/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.types.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/auto/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/auto/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.types.a
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/field/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/field/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.types.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/field/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/field/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.types.f
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.types.generator.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_types_generator_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.t
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.types.generator.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_types_generator_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            ee.jakarta.tck.persistence.core.types.generator.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.t
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.types.
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.types.generator.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_types_generator_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -83,7 +94,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client3AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client3.class,
+            Client3AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client3AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.t
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client3.class,
+            Client3AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client3Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client3.class,
+            Client3Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client4.class,
+            Client4AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.t
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client4.class,
+            Client4AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.types.
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client4.class,
+            Client4Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client4Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.generator.Client.class
+            ee.jakarta.tck.persistence.core.types.generator.Client.class,
+            Client4.class,
+            Client4Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.types.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/primarykey/compound/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.types.p
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client1AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.types.property.Client1.class
+            ee.jakarta.tck.persistence.core.types.property.Client1.class,
+            Client1.class,
+            Client1AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client1AppmanagednotxTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.types.property.Client1 {
     static final String VEHICLE_ARCHIVE = "jpa_core_types_property_appmanagedNoTx_vehicle";
+
+    public static void main(String[] args) {
+      Client1AppmanagednotxTest theTests = new Client1AppmanagednotxTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.t
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client1.class,
+            Client1AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2AppmanagedTest.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.types.property.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_types_property_appmanaged_vehicle";
+
+    public static void main(String[] args) {
+      Client2AppmanagedTest theTests = new Client2AppmanagedTest();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.types.property.Client2.class,
+            Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2Stateful3Test.java
@@ -82,7 +82,9 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.types.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2Stateless3Test.java
@@ -21,7 +21,8 @@ import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 
 @ExtendWith(ArquillianExtension.class)
@@ -32,6 +33,16 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.types.property.Client2 {
     static final String VEHICLE_ARCHIVE = "jpa_core_types_property_stateless3_vehicle";
+
+    public static void main(String[] args) {
+      Client2Stateless3Test theTests = new Client2Stateless3Test();
+      Status s = theTests.run(args, System.out, System.err);
+      s.exit();
+    }
+
+    public void setup(String[] args, Properties p) throws Exception {
+        super.setup(args, p);
+    }
 
         /**
         EE10 Deployment Descriptors:
@@ -82,7 +93,9 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.types
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2Stateless3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/versioning/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/versioning/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.versio
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/entityManager/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/entityManager/ClientAppmanagedTest.java
@@ -91,7 +91,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.ee.entityMa
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/entityManager/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/entityManager/ClientStateful3Test.java
@@ -91,7 +91,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.ee.entityMan
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/entityManagerFactory/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/entityManagerFactory/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.ee.entityMa
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/entityManagerFactory/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/entityManagerFactory/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.ee.entityMan
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/pluggability/contracts/jta/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/pluggability/contracts/jta/ClientAppmanagedTest.java
@@ -75,7 +75,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.ee.pluggabi
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/pluggability/contracts/jta/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/pluggability/contracts/jta/ClientStateful3Test.java
@@ -75,7 +75,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.ee.pluggabil
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.entitytest.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/entitytest/persist/oneXmanyFetchEager/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.entitytest.p
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa/ee/packaging/jar/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa/ee/packaging/jar/ClientAppmanagedTest.java
@@ -81,7 +81,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.jpa.ee.pack
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa/ee/packaging/jar/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa/ee/packaging/jar/ClientStateful3Test.java
@@ -81,7 +81,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.jpa.ee.packa
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/generators/tablegenerators/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/generators/tablegenerators/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.jpa22.gener
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/generators/tablegenerators/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/generators/tablegenerators/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.jpa22.genera
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/query/stream/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/query/stream/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.jpa22.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/query/stream/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/query/stream/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.jpa22.query.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/attroverride/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/attroverride/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.jpa22.repea
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/attroverride/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/attroverride/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.jpa22.repeat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/joincolumn/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/joincolumn/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.jpa22.repea
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/joincolumn/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/joincolumn/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.jpa22.repeat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/mapkeyjoincolumn/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/mapkeyjoincolumn/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.jpa22.repea
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/mapkeyjoincolumn/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/mapkeyjoincolumn/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.jpa22.repeat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedentitygraph/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedentitygraph/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.jpa22.repea
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedentitygraph/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedentitygraph/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.jpa22.repeat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namednativequery/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namednativequery/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.jpa22.repea
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namednativequery/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namednativequery/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.jpa22.repeat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/ClientAppmanagedTest.java
@@ -82,7 +82,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.jpa22.repea
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa22/repeatable/namedstoredprocedurequery/ClientStateful3Test.java
@@ -82,7 +82,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.jpa22.repeat
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientStateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client2.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client2.java
@@ -20,9 +20,17 @@ package ee.jakarta.tck.persistence.core.annotations.basic;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Properties;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 public class Client2 extends Client {
+
+	public static void main(String[] args) {
+		Client2 theTests = new Client2();
+		Status s = theTests.run(args, System.out, System.err);
+		s.exit();
+	}
+  
 	
 	public Client2() {
 	}


### PR DESCRIPTION
**Describe the change**
- Add main class to client archive to fix errors like java.lang.ClassNotFoundException: <mainclass>
- Add missing classes from client archive causing CNFE.
- Add setup methods for several of the Client test files 

This is in continuation to the PR https://github.com/jakartaee/platform-tck/pull/1568.

cc @scottmarlow 