### PR TITLE
Cleanup the shrinkwrap dependencies

### DIFF
--- a/arquillian/appclient/pom.xml
+++ b/arquillian/appclient/pom.xml
@@ -61,11 +61,6 @@
             <artifactId>shrinkwrap-impl-base</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/arquillian/appclient/src/test/java/org/jboss/arquillian/protocol/AppClientConfigTest.java
+++ b/arquillian/appclient/src/test/java/org/jboss/arquillian/protocol/AppClientConfigTest.java
@@ -3,9 +3,9 @@ package org.jboss.arquillian.protocol;
 import org.jboss.arquillian.config.impl.extension.ConfigurationRegistrar;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.container.test.impl.MapObject;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 import tck.arquillian.protocol.appclient.AppClientProtocolConfiguration;
-import org.junit.Assert;
-import org.junit.Test;
 
 import java.io.File;
 import java.util.Map;
@@ -25,10 +25,11 @@ public class AppClientConfigTest {
         System.setProperty(ConfigurationRegistrar.ARQUILLIAN_XML_PROPERTY, "appclient1-arquillian.xml");
         ConfigurationRegistrar registrar = new ConfigurationRegistrar();
         ArquillianDescriptor descriptor = registrar.loadConfiguration();
-        Assert.assertNotNull(descriptor);
-        Assert.assertNotNull(descriptor.defaultProtocol("appclient"));
+        
+        Assertions.assertNotNull(descriptor);
+        Assertions.assertNotNull(descriptor.defaultProtocol("appclient"));
         String type = descriptor.defaultProtocol("appclient").getType();
-        Assert.assertEquals("appclient", type);
+        Assertions.assertEquals("appclient", type);
 
         Map<String, String> props = descriptor.defaultProtocol("appclient").getProperties();
 
@@ -36,26 +37,26 @@ public class AppClientConfigTest {
         MapObject.populate(config, props);
 
         // Raw strings
-        Assert.assertEquals("-p;/home/jakartaeetck/bin/xml/../../tmp/tstest.jte", config.getClientCmdLineString());
+        Assertions.assertEquals("-p;/home/jakartaeetck/bin/xml/../../tmp/tstest.jte", config.getClientCmdLineString());
         String expectedEnv = "JAVA_OPTS=-Djboss.modules.system.pkgs=com.sun.ts.lib,com.sun.javatest;CLASSPATH=${project.build.directory}/appclient/javatest.jar:${project.build.directory}/appclient/libutil.jar:${project.build.directory}/appclient/libcommon.jar";
-        Assert.assertEquals(expectedEnv, config.getClientEnvString());
-        Assert.assertTrue(config.isRunClient());
-        Assert.assertEquals(".", config.getClientDir());
+        Assertions.assertEquals(expectedEnv, config.getClientEnvString());
+        Assertions.assertTrue(config.isRunClient());
+        Assertions.assertEquals(".", config.getClientDir());
 
         // Parsed strings
         String[] args = config.clientCmdLineAsArray();
-        Assert.assertEquals(2, args.length);
-        Assert.assertEquals("-p", args[0]);
-        Assert.assertEquals("/home/jakartaeetck/bin/xml/../../tmp/tstest.jte", args[1]);
+        Assertions.assertEquals(2, args.length);
+        Assertions.assertEquals("-p", args[0]);
+        Assertions.assertEquals("/home/jakartaeetck/bin/xml/../../tmp/tstest.jte", args[1]);
 
         String[] envp = config.clientEnvAsArray();
-        Assert.assertEquals(2, envp.length);
-        Assert.assertTrue(envp[0].startsWith("JAVA_OPTS="));
-        Assert.assertEquals("-Djboss.modules.system.pkgs=com.sun.ts.lib,com.sun.javatest", envp[0].substring(10));
-        Assert.assertTrue(envp[1].startsWith("CLASSPATH="));
+        Assertions.assertEquals(2, envp.length);
+        Assertions.assertTrue(envp[0].startsWith("JAVA_OPTS="));
+        Assertions.assertEquals("-Djboss.modules.system.pkgs=com.sun.ts.lib,com.sun.javatest", envp[0].substring(10));
+        Assertions.assertTrue(envp[1].startsWith("CLASSPATH="));
         String expectedCP = "${project.build.directory}/appclient/javatest.jar:${project.build.directory}/appclient/libutil.jar:${project.build.directory}/appclient/libcommon.jar";
-        Assert.assertEquals(expectedCP, envp[1].substring(10));
+        Assertions.assertEquals(expectedCP, envp[1].substring(10));
         File expectedDir = new File(".");
-        Assert.assertEquals(expectedDir, config.clientDirAsFile());
+        Assertions.assertEquals(expectedDir, config.clientDirAsFile());
     }
 }

--- a/arquillian/common/pom.xml
+++ b/arquillian/common/pom.xml
@@ -39,12 +39,6 @@
             <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
             <scope>compile</scope>
         </dependency>
-
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
     <build>

--- a/arquillian/javatest/pom.xml
+++ b/arquillian/javatest/pom.xml
@@ -56,6 +56,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-spi</artifactId>
+            <version>${shrinkwrap.descriptors.version}</version>
             <scope>compile</scope>
         </dependency>
 
@@ -73,11 +74,6 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-impl-base</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -39,33 +39,6 @@
         <maven.compiler.release>17</maven.compiler.release>
         <!-- Versioning -->
         <version.arquillian_core>1.9.1.Final</version.arquillian_core>
-        <version.shrinkwrap>3.2.1</version.shrinkwrap>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.jboss.shrinkwrap.resolver</groupId>
-                <artifactId>shrinkwrap-resolver-bom</artifactId>
-                <version>${version.shrinkwrap}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-bom</artifactId>
-                <version>${version.arquillian_core}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>org.jboss.arquillian</groupId>
-                <artifactId>arquillian-build</artifactId>
-                <version>${version.arquillian_core}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
 
 </project>

--- a/arquillian/porting-lib/pom.xml
+++ b/arquillian/porting-lib/pom.xml
@@ -34,11 +34,6 @@
             <groupId>org.jboss.arquillian.container</groupId>
             <artifactId>arquillian-container-spi</artifactId>
         </dependency>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -128,8 +128,9 @@
         <maven.compiler.testRelease>${maven.compiler.release}</maven.compiler.testRelease>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <shrinkwrap.api.version>2.0.0-beta-1</shrinkwrap.api.version>
-        <shrinkwrap.version>3.3.1</shrinkwrap.version>
+        <shrinkwrap.api.version>2.0.0-beta-2</shrinkwrap.api.version>
+        <shrinkwrap.descriptors.version>2.0.0</shrinkwrap.descriptors.version>
+        <shrinkwrap.resolver.version>3.3.1</shrinkwrap.resolver.version>
         <slf4j.version>2.0.0</slf4j.version>
         <surefire.failIfNoSpecifiedTests>false</surefire.failIfNoSpecifiedTests>
         <!-- Jakarta WebSocket -->
@@ -377,20 +378,30 @@
 
             <dependency>
                 <groupId>org.jboss.shrinkwrap</groupId>
-                <artifactId>shrinkwrap-api</artifactId>
+                <artifactId>shrinkwrap-bom</artifactId>
                 <version>${shrinkwrap.api.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+                <artifactId>shrinkwrap-descriptors-bom</artifactId>
+                <version>${shrinkwrap.descriptors.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-depchain</artifactId>
-                <version>${shrinkwrap.version}</version>
+                <version>${shrinkwrap.resolver.version}</version>
                 <type>pom</type>
             </dependency>
 
             <dependency>
                 <groupId>org.jboss.shrinkwrap.resolver</groupId>
                 <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-                <version>${shrinkwrap.version}</version>
+                <version>${shrinkwrap.resolver.version}</version>
             </dependency>
 
             <dependency>

--- a/websocket/pom.xml
+++ b/websocket/pom.xml
@@ -24,6 +24,7 @@
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
         <version>1.0.9</version>
+        <relativePath></relativePath>
     </parent>
     <groupId>jakarta.tck</groupId>
     <artifactId>websocket-tck</artifactId>


### PR DESCRIPTION
Remove the shrinkwrap versions from the arquillian submodule
Clarify the shrinkwrap version var names
Convert junit tests to junit5 and remove junit dependencies
Fix the relativePath in websocket/pom.xml


**Fixes Issue**
Fixes #1575

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
