### PR TITLE
Update component specification API and TCK versions to latest

### DIFF
--- a/core-profile-tck/ca-sigtest/pom.xml
+++ b/core-profile-tck/ca-sigtest/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.0-M2</version>
+        <version>11.0.0-M3</version>
     </parent>
     <artifactId>common-annotations</artifactId>
 

--- a/core-profile-tck/ca-sigtest/src/main/resources/common-annotations-api.sig
+++ b/core-profile-tck/ca-sigtest/src/main/resources/common-annotations-api.sig
@@ -1,5 +1,5 @@
 #Signature file v4.1
-#Version 11.0.0-SNAPSHOT
+#Version 11.0.0-M3
 
 CLSS public abstract interface !annotation jakarta.annotation.Generated
  anno 0 java.lang.annotation.Documented()

--- a/core-profile-tck/cdi-tck-suite/pom.xml
+++ b/core-profile-tck/cdi-tck-suite/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.0-M2</version>
+        <version>11.0.0-M3</version>
     </parent>
 
     <artifactId>cdi-lite-tck-suite</artifactId>

--- a/core-profile-tck/jsonp-tck-ext/pom.xml
+++ b/core-profile-tck/jsonp-tck-ext/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.0-M2</version>
+        <version>11.0.0-M3</version>
     </parent>
 
     <artifactId>core-tck-jsonp-extension</artifactId>

--- a/core-profile-tck/pom.xml
+++ b/core-profile-tck/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>jakarta.tck.coreprofile</groupId>
     <artifactId>core-tck-parent</artifactId>
-    <version>11.0.0-M2</version>
+    <version>11.0.0-M3</version>
     <packaging>pom</packaging>
     <name>Jakarta Core TCK</name>
 
@@ -90,18 +90,18 @@
 
         <!-- Required for distribution build, should be overriden for each build. -->
         <core.tck.version>${project.version}</core.tck.version>
-        <el.api.version>6.0.0</el.api.version>
+        <el.api.version>6.0.1</el.api.version>
         <inject.api.version>2.0.1</inject.api.version>
         <inject.tck.version>2.0.2</inject.tck.version>
         <interceptors.api.version>2.2.0</interceptors.api.version>
-        <jsonb.api.version>3.0.0</jsonb.api.version>
+        <jsonb.api.version>3.0.1</jsonb.api.version>
         <jsonb.tck.version>3.0.0</jsonb.tck.version>
-        <jsonp.api.version>2.1.0</jsonp.api.version>
-        <jsonp.tck.version>2.1.0</jsonp.tck.version>
+        <jsonp.api.version>2.1.3</jsonp.api.version>
+        <jsonp.tck.version>2.1.1</jsonp.tck.version>
         <junit.version>5.8.2</junit.version>
         <maven.compiler.release>17</maven.compiler.release>
         <rest.api.version>4.0.0</rest.api.version>
-        <rest.tck.version>4.0.0</rest.tck.version>
+        <rest.tck.version>4.0.1</rest.tck.version>
 
         <!-- Test tools/dependencies -->
         <testng.version>7.10.2</testng.version>

--- a/core-profile-tck/restful-tck-suite/pom.xml
+++ b/core-profile-tck/restful-tck-suite/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.0-M2</version>
+        <version>11.0.0-M3</version>
     </parent>
 
     <artifactId>rest-tck-suite</artifactId>

--- a/core-profile-tck/tck-dist/RELEASE-NOTES.adoc
+++ b/core-profile-tck/tck-dist/RELEASE-NOTES.adoc
@@ -1,5 +1,8 @@
 = Jakarta Core Profile TCK Release notes
 
+== Version 11.0.0-M3
+* Update component specification API and TCK versions to the latest service releases
+
 == Version 11.0.0-M2
 * Fix the artifacts-pom.xml failing to be updated for the new EE 11 component TCKs
 

--- a/core-profile-tck/tck-dist/pom.xml
+++ b/core-profile-tck/tck-dist/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.0-M2</version>
+        <version>11.0.0-M3</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/core-profile-tck/tck/pom.xml
+++ b/core-profile-tck/tck/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.0-M2</version>
+        <version>11.0.0-M3</version>
     </parent>
     <artifactId>core-profile-tck-impl</artifactId>
     <name>Jakarta Core Profile TCK Test Suite</name>


### PR DESCRIPTION
- Update API and TCK versions to latest for component specifications like what was done with inject.  This includes updates for el, jsonb, jsonp and rest.
- Update to move from M2 to M3.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
