### PR TITLE
Persistence : Fix more of the appclient tests errors with CNFE/NCDF - Part 3

### DIFF
--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagedTest.java
@@ -84,6 +84,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagedTest.java
@@ -84,8 +84,10 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.PartTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.AbstractPersonnel.class,
             ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagednotxTest.java
@@ -90,6 +90,8 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Employee.class,
             ClientAppmanagednotxTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientAppmanagednotxTest.java
@@ -91,7 +91,9 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.PartTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.AbstractPersonnel.class,
             ClientAppmanagednotxTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateful3Test.java
@@ -84,6 +84,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateful3Test.java
@@ -84,7 +84,9 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.PartTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.AbstractPersonnel.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateless3Test.java
@@ -91,7 +91,9 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.PartTimeEmployee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.AbstractPersonnel.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/access/mappedsc/ClientStateless3Test.java
@@ -91,6 +91,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.access.mappedsc.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientAppmanagedTest.java
@@ -86,6 +86,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Client.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.PartTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.Address.class,
             ClientAppmanagedTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientAppmanagednotxTest.java
@@ -93,6 +93,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.PartTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.Address.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientStateful3Test.java
@@ -92,6 +92,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.PartTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.Address.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/assocoverride/ClientStateless3Test.java
@@ -93,6 +93,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.PartTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.annotations.assocoverride.Address.class,
             ee.jakarta.tck.persistence.core.annotations.assocoverride.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/entity/ClientStateful3Test.java
@@ -83,6 +83,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.entity.Coffee.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagedTest.java
@@ -132,6 +132,7 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             Client1.class,
             Client1AppmanagedTest.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1AppmanagednotxTest.java
@@ -143,6 +143,7 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             Client1.class,
             Client1AppmanagednotxTest.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1Stateful3Test.java
@@ -133,7 +133,9 @@ public class Client1Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
-            ee.jakarta.tck.persistence.core.annotations.mapkey.Client1.class
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Client1.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Employee.class,
+            Client1Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client1Stateless3Test.java
@@ -138,6 +138,7 @@ public class Client1Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client1.class,
             Client1Stateless3Test.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagedTest.java
@@ -143,6 +143,7 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client2.class,
             Client2AppmanagedTest.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2AppmanagednotxTest.java
@@ -131,6 +131,8 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.a
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             Client2.class,
             Client2AppmanagednotxTest.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateful3Test.java
@@ -132,6 +132,7 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             Client2.class,
             Client2Stateful3Test.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkey/Client2Stateless3Test.java
@@ -142,6 +142,8 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.annot
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkey.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkey.Client.class,
             Client2.class,
             Client2Stateless3Test.class

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
@@ -85,6 +85,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department2.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
@@ -84,6 +84,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagednotxTest.java
@@ -90,6 +90,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagednotxTest.java
@@ -91,6 +91,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department2.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
@@ -85,6 +85,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department2.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
@@ -84,6 +84,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateless3Test.java
@@ -94,6 +94,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Client.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department2.class,
             ClientStateless3Test.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateless3Test.java
@@ -92,6 +92,8 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Client.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
             ClientStateless3Test.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
@@ -84,6 +84,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee2.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
@@ -85,6 +85,8 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee2.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee3.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee4.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagednotxTest.java
@@ -90,6 +90,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee2.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagednotxTest.java
@@ -91,6 +91,8 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee2.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee3.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee4.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
@@ -84,6 +84,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee2.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
@@ -85,6 +85,8 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee2.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee3.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee4.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateless3Test.java
@@ -93,6 +93,8 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee2.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee3.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee4.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateless3Test.java
@@ -92,6 +92,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Employee2.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
@@ -85,6 +85,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee2.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee4.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
@@ -84,6 +84,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee2.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagednotxTest.java
@@ -90,6 +90,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee2.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagednotxTest.java
@@ -91,6 +91,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.an
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee2.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee4.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
@@ -84,6 +84,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee2.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
@@ -85,6 +85,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee2.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee4.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateless3Test.java
@@ -93,6 +93,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee2.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee4.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateless3Test.java
@@ -92,6 +92,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Employee2.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/method/ClientStateless3Test.java
@@ -103,6 +103,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.method.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientAppmanagednotxTest.java
@@ -89,6 +89,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.ca
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.methodoverride.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientStateful3Test.java
@@ -83,6 +83,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/methodoverride/ClientStateless3Test.java
@@ -91,6 +91,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.methodoverride.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientAppmanagedTest.java
@@ -83,6 +83,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientAppmanagednotxTest.java
@@ -89,6 +89,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.ca
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.xml.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientStateful3Test.java
@@ -83,6 +83,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.callbac
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/callback/xml/ClientStateless3Test.java
@@ -91,6 +91,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.callba
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.callback.common.EntityCallbackClientBase.class,
             ee.jakarta.tck.persistence.core.callback.xml.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client5AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client5AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client5AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client5AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client5AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client5AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client5Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client5Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client5Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6AppmanagedTest.java
@@ -84,7 +84,9 @@ public class Client6AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6AppmanagednotxTest.java
@@ -84,7 +84,9 @@ public class Client6AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6Stateful3Test.java
@@ -84,7 +84,9 @@ public class Client6Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client6Stateless3Test.java
@@ -84,7 +84,9 @@ public class Client6Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client7AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client7AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client7AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client7.class,
+            Client7AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client7.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client7Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client7Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client7Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client7.class,
+            Client7Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client7.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client8AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client8.class,
+            Client8AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client8.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client8AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client8.class,
+            Client8AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client8.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client8Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client8.class,
+            Client8Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client8.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/Client8Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client8Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client8.class,
+            Client8Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client8.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaDelete/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaDelete/ClientAppmanagedTest.java
@@ -83,7 +83,9 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client.class,
+            ClientAppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.CriteriaQuery.Client4.class,
+            Client4Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5AppmanagedTest.java
@@ -84,7 +84,9 @@ public class Client5AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5AppmanagednotxTest.java
@@ -84,7 +84,9 @@ public class Client5AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5Stateful3Test.java
@@ -84,7 +84,9 @@ public class Client5Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client5Stateless3Test.java
@@ -84,7 +84,9 @@ public class Client5Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client6AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client6AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client6Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client6Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client6Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client7AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client7AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client7AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client7.class,
+            Client7AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client7.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client7Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client7Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client7Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client7.class,
+            Client7Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client7.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/Root/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateless3Test.java
@@ -96,8 +96,8 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            Client1.class,
-            Client1AppmanagednotxTest.class
+            Client2.class,
+            Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client5AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client5AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client5Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client5Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client5Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client6AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client6AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client6Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client6Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client6Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client7AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client7AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client7AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client7.class,
+            Client7AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client7.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client7Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client7Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client7Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client7.class,
+            Client7Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client7.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1AppmanagedTest.java
@@ -84,6 +84,7 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Employee.class,
             Client1.class,
             Client1AppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1AppmanagednotxTest.java
@@ -95,6 +95,7 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Employee.class,
             Client1.class,
             Client1AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1Stateful3Test.java
@@ -84,7 +84,9 @@ public class Client1Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
-            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client1.class
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client1.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Employee.class,
+            Client1Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client1Stateless3Test.java
@@ -91,6 +91,7 @@ public class Client1Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
             ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client1.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Employee.class,
             Client1Stateless3Test.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2AppmanagedTest.java
@@ -97,6 +97,7 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
             ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client2.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Employee.class,
             Client2AppmanagedTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2AppmanagednotxTest.java
@@ -85,6 +85,7 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Employee.class,
             Client2.class,
             Client2AppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/parameter/Client2Stateless3Test.java
@@ -96,6 +96,7 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.parameter.Client.class,
+            ee.jakarta.tck.persistence.core.criteriaapi.parameter.Employee.class,
             Client2.class,
             Client2Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());;

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client5AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client5AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client5Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/strquery/Client5Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client5Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1AppmanagedTest.java
@@ -115,6 +115,8 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager.Order.class,
+            ee.jakarta.tck.persistence.core.entityManager.Employee.class,
             Client1.class,
             Client1AppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1AppmanagednotxTest.java
@@ -126,6 +126,8 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.e
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager.Order.class,
+            ee.jakarta.tck.persistence.core.entityManager.Employee.class,
             Client1.class,
             Client1AppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1Stateful3Test.java
@@ -115,7 +115,10 @@ public class Client1Stateful3Test extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.entityManager.Client1.class
+            ee.jakarta.tck.persistence.core.entityManager.Client1.class,
+            ee.jakarta.tck.persistence.core.entityManager.Order.class,
+            ee.jakarta.tck.persistence.core.entityManager.Employee.class,
+            Client1Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client1Stateless3Test.java
@@ -121,6 +121,8 @@ public class Client1Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager.Order.class,
+            ee.jakarta.tck.persistence.core.entityManager.Employee.class,
             ee.jakarta.tck.persistence.core.entityManager.Client1.class,
             Client1Stateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2AppmanagedTest.java
@@ -128,7 +128,7 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.entityManager.Client2.class,
             Client2AppmanagedTest.class
-            );
+            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2Stateful3Test.java
@@ -117,7 +117,7 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client2.class,
             Client2Stateful3Test.class
-            );
+            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client2Stateless3Test.java
@@ -128,7 +128,7 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client2.class,
             Client2Stateless3Test.class
-            );
+            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3AppmanagedTest.java
@@ -115,6 +115,8 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager.Order.class,
+            ee.jakarta.tck.persistence.core.entityManager.Employee.class,
             Client3.class,
             Client3AppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3AppmanagednotxTest.java
@@ -115,6 +115,8 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.e
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager.Order.class,
+            ee.jakarta.tck.persistence.core.entityManager.Employee.class,
             Client3.class,
             Client3AppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3Stateful3Test.java
@@ -115,7 +115,10 @@ public class Client3Stateful3Test extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
-            ee.jakarta.tck.persistence.core.entityManager.Client3.class
+            ee.jakarta.tck.persistence.core.entityManager.Order.class,
+            ee.jakarta.tck.persistence.core.entityManager.Employee.class,
+            ee.jakarta.tck.persistence.core.entityManager.Client3.class,
+            Client3Stateful3Test.class
             );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager/Client3Stateless3Test.java
@@ -115,6 +115,8 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager.Order.class,
+            ee.jakarta.tck.persistence.core.entityManager.Employee.class,
             Client3.class,
             Client3Stateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client1AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client1AppmanagednotxTest.java
@@ -90,6 +90,8 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.e
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager2.Employee.class,
+            ee.jakarta.tck.persistence.core.entityManager2.Order.class,
             Client1.class,
             Client1AppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client1Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client1Stateless3Test.java
@@ -85,6 +85,8 @@ public class Client1Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager2.Employee.class,
+            ee.jakarta.tck.persistence.core.entityManager2.Order.class,
             ee.jakarta.tck.persistence.core.entityManager2.Client1.class,
             Client1Stateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2Stateless3Test.java
@@ -90,6 +90,8 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.entit
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entityManager2.Employee.class,
+            ee.jakarta.tck.persistence.core.entityManager2.Order.class,
             Client2.class,
             Client2Stateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientAppmanagedTest.java
@@ -83,6 +83,8 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Coffee.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Foo.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientAppmanagednotxTest.java
@@ -89,6 +89,8 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.en
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Coffee.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Foo.class,
             ee.jakarta.tck.persistence.core.entitytest.apitests.Client.class,
             ClientAppmanagednotxTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientStateful3Test.java
@@ -83,6 +83,8 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Coffee.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Foo.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientStateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/apitests/ClientStateless3Test.java
@@ -91,6 +91,8 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.entity
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Coffee.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Foo.class,
             ee.jakarta.tck.persistence.core.entitytest.apitests.Client.class,
             ClientStateless3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientAppmanagedTest.java
@@ -83,6 +83,8 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.inheri
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Coffee.class,
+            ee.jakarta.tck.persistence.core.entitytest.apitests.Foo.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientAppmanagednotxTest.java
@@ -97,6 +97,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.in
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.inheritance.abstractentity.Client.class,
             ee.jakarta.tck.persistence.core.inheritance.abstractentity.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.inheritance.abstractentity.Employee.class,
             ClientAppmanagednotxTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientStateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/inheritance/abstractentity/ClientStateful3Test.java
@@ -83,6 +83,8 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.inherit
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            ee.jakarta.tck.persistence.core.inheritance.abstractentity.FullTimeEmployee.class,
+            ee.jakarta.tck.persistence.core.inheritance.abstractentity.Employee.class,
             Client.class,
             ClientStateful3Test.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagedTest.java
@@ -84,6 +84,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.overri
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
             Client.class,
             ClientAppmanagedTest.class
             );

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/override/mapkey/ClientAppmanagednotxTest.java
@@ -91,6 +91,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.ov
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.override.mapkey.Client.class,
             ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Employee.class,
+            ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.Department.class,
             ClientAppmanagednotxTest.class
             );
             // The application-client.xml descriptor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client4Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.query.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client4.class,
+            Client4Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client5AppmanagedTest extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client5AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client5Stateful3Test extends ee.jakarta.tck.persistence.core.query.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client5Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client5Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client5.class,
+            Client5Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client5.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6AppmanagedTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6AppmanagedTest.java
@@ -83,7 +83,9 @@ public class Client6AppmanagedTest extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6AppmanagedTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6AppmanagednotxTest.java
@@ -83,7 +83,9 @@ public class Client6AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6AppmanagednotxTest.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6Stateful3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6Stateful3Test.java
@@ -83,7 +83,9 @@ public class Client6Stateful3Test extends ee.jakarta.tck.persistence.core.query.
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6Stateful3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6Stateless3Test.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6Stateless3Test.java
@@ -83,7 +83,9 @@ public class Client6Stateless3Test extends ee.jakarta.tck.persistence.core.query
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client6.class,
+            Client6Stateless3Test.class
             ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The application-client.xml descriptor
             URL resURL = Client6.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2AppmanagednotxTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/property/Client2AppmanagednotxTest.java
@@ -82,7 +82,9 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.t
             com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
             com.sun.ts.lib.harness.EETest.SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
+            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
+            Client2.class,
+            Client2AppmanagednotxTest.class
             );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");


### PR DESCRIPTION
**Describe the change**
- Add main class to client archive to fix errors like java.lang.ClassNotFoundException:
- Add missing classes from client archive causing CNFE.

**Additional context**
This is part 3 of the below series of PRs 
https://github.com/jakartaee/platform-tck/pull/1568 
https://github.com/jakartaee/platform-tck/pull/1576

