### PR TITLE
Fix 6 failing ejb vehicle tests in jta(com/sun/ts/tests/jta/ee/txpropagationtest/ClientEjbTest)

### DIFF
--- a/glassfish-runner/jta-platform-tck/src/main/java/org/glassfish/transactions/tck/GlassfishTestArchiveProcessor.java
+++ b/glassfish-runner/jta-platform-tck/src/main/java/org/glassfish/transactions/tck/GlassfishTestArchiveProcessor.java
@@ -84,7 +84,7 @@ public class GlassfishTestArchiveProcessor extends AbstractTestArchiveProcessor 
     @Override
     public void processWebArchive(WebArchive webArchive, Class<?> testClass, URL sunXmlURL) {
         String name = webArchive.getName();
-        addDescriptors(name, webArchive, testClass);
+        // addDescriptors(name, webArchive, testClass);
     }
 
     @Override

--- a/jta/src/main/java/com/sun/ts/tests/jta/ee/txpropagationtest/ClientEjbTest.java
+++ b/jta/src/main/java/com/sun/ts/tests/jta/ee/txpropagationtest/ClientEjbTest.java
@@ -24,7 +24,8 @@ import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
 
 import java.lang.System.Logger;
-
+import com.sun.ts.lib.harness.Status;
+import java.util.Properties;
 
 @ExtendWith(ArquillianExtension.class)
 @Tag("jta")
@@ -36,6 +37,13 @@ public class ClientEjbTest extends com.sun.ts.tests.jta.ee.txpropagationtest.Cli
     private static String packagePath = ClientEjbTest.class.getPackageName().replace(".", "/");
 
     private static final Logger logger = System.getLogger(ClientEjbTest.class.getName());
+
+    public static void main(String args[]) {
+      ClientEjbTest tests = new ClientEjbTest();
+      Status s = tests.run(args, System.out, System.err);
+      s.exit();
+    }
+  
 
     @BeforeEach
     void logStartTest(TestInfo testInfo) {
@@ -82,7 +90,8 @@ public class ClientEjbTest extends com.sun.ts.tests.jta.ee.txpropagationtest.Cli
         if(resURL != null) {
           jta_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
         }
-        jta_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + ClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+        jta_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"),
+				"MANIFEST.MF");
         archiveProcessor.processClientArchive(jta_ejb_vehicle_client, ClientEjbTest.class, resURL);
 
 
@@ -114,8 +123,6 @@ public class ClientEjbTest extends com.sun.ts.tests.jta.ee.txpropagationtest.Cli
         if(ejbResURL != null) {
           jta_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
         }
-        jta_ejb_vehicle_ejb.addAsManifestResource(new StringAsset("Main-Class: " + ClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
-
         archiveProcessor.processEjbArchive(jta_ejb_vehicle_ejb, ClientEjbTest.class, ejbResURL);
 
 
@@ -124,6 +131,7 @@ public class ClientEjbTest extends com.sun.ts.tests.jta.ee.txpropagationtest.Cli
         jta_ee_txpropagate1_ejb.addClasses(
             com.sun.ts.tests.jta.ee.txpropagationtest.TxBean.class,
             com.sun.ts.tests.jta.ee.txpropagationtest.TxBeanEJB.class
+            
         );
         // The ejb-jar.xml descriptor
         URL ejbJarResURL = ClientEjbTest.class.getClassLoader().getResource(packagePath+"/jta_ee_txpropagate1_ejb.xml");
@@ -135,7 +143,6 @@ public class ClientEjbTest extends com.sun.ts.tests.jta.ee.txpropagationtest.Cli
         if(ejbJarResURL != null) {
           jta_ee_txpropagate1_ejb.addAsManifestResource(ejbJarResURL, "sun-ejb-jar.xml");
         }
-        jta_ee_txpropagate1_ejb.addAsManifestResource(new StringAsset("Main-Class: " + ClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
         archiveProcessor.processEjbArchive(jta_ee_txpropagate1_ejb, ClientEjbTest.class, ejbJarResURL);
 
 
@@ -143,7 +150,6 @@ public class ClientEjbTest extends com.sun.ts.tests.jta.ee.txpropagationtest.Cli
         jta_ejb_vehicle_ear.addAsModule(jta_ee_txpropagate1_ejb);
         jta_ejb_vehicle_ear.addAsModule(jta_ejb_vehicle_ejb);
         jta_ejb_vehicle_ear.addAsModule(jta_ejb_vehicle_client);
-        jta_ejb_vehicle_ear.addAsManifestResource(new StringAsset("Main-Class: " + ClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
 
         return jta_ejb_vehicle_ear;
     }

--- a/jta/src/main/resources/com/sun/ts/tests/jta/ee/txpropagationtest/jta_ee_txpropagate1_ejb.jar.sun-ejb-jar.xml
+++ b/jta/src/main/resources/com/sun/ts/tests/jta/ee/txpropagationtest/jta_ee_txpropagate1_ejb.jar.sun-ejb-jar.xml
@@ -28,8 +28,8 @@
         <res-ref-name>jdbc/DB1</res-ref-name>
         <jndi-name>jdbc/DB1</jndi-name>
         <default-resource-principal>
-          <name>user1</name>
-          <password>password1</password>
+          <name>cts1</name>
+          <password>cts1</password>
         </default-resource-principal>
       </resource-ref>
       <pass-by-reference>false</pass-by-reference>

--- a/jta/src/main/resources/com/sun/ts/tests/jta/ee/txpropagationtest/jta_ejb_vehicle_ejb.jar.sun-ejb-jar.xml
+++ b/jta/src/main/resources/com/sun/ts/tests/jta/ee/txpropagationtest/jta_ejb_vehicle_ejb.jar.sun-ejb-jar.xml
@@ -32,8 +32,8 @@
         <res-ref-name>jdbc/DB1</res-ref-name>
         <jndi-name>jdbc/DB1</jndi-name>
         <default-resource-principal>
-          <name>user1</name>
-          <password>password1</password>
+          <name>cts1</name>
+          <password>cts1</password>
         </default-resource-principal>
       </resource-ref>
       <pass-by-reference>false</pass-by-reference>


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1375

**Describe the change**
- use com.sun.ts.tests.common.vehicle.VehicleClient as Mainclass in client archive manifest
- Use the user1/password1 as cts1/cts1 as schema credentials in glassfish DD files
- The 6 tests in com/sun/ts/tests/jta/ee/txpropagationtest/ClientEjbTest passes with this change