### PR TITLE
JSONP : Fix 1 failing jsonp PatchEjbTest (ejb vehicle)

### DIFF
--- a/glassfish-runner/jsonp-platform-tck/pom.xml
+++ b/glassfish-runner/jsonp-platform-tck/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
     Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
     This program and the accompanying materials are made available under the
@@ -378,7 +379,7 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
                             </additionalClasspathElements>
                             <includes>
-                                <include>com/sun/ts/tests/jsonp/api/patchtests/**Test*.java</include>
+                                <include>com/sun/ts/tests/jsonp/api/patchtests/*Test*.java</include>
                             </includes>
                             <!-- Select the @Tag("tck-appclient") tests -->
                             <groups>tck-appclient</groups>
@@ -409,7 +410,7 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/parsson.jar</additionalClasspathElement>
                             </additionalClasspathElements>
                             <includes>
-                                <include>com/sun/ts/tests/jsonp/api/patchtests/**Test*.java</include>
+                                <include>com/sun/ts/tests/jsonp/api/patchtests/*Test*.java</include>
                             </includes>
                             <!-- Select the @Tag("tck-javatest") tests -->
                             <groups>tck-javatest</groups>

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchAppclientTest.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchAppclientTest.java
@@ -130,7 +130,7 @@ public class PatchAppclientTest extends ServiceEETest {
 
     EnterpriseArchive patchtests_appclient_vehicle_client_ear = ShrinkWrap.create(EnterpriseArchive.class, "patchtests_appclient_vehicle.ear");
     patchtests_appclient_vehicle_client_ear.addAsModule(patchtests_appclient_vehicle_client);
-    patchtests_appclient_vehicle_client_ear.addAsManifestResource(new StringAsset("Main-Class: " + PatchAppclientTest.class.getName() + "\n"), "MANIFEST.MF");
+    // patchtests_appclient_vehicle_client_ear.addAsManifestResource(new StringAsset("Main-Class: " + PatchAppclientTest.class.getName() + "\n"), "MANIFEST.MF");
 
     return patchtests_appclient_vehicle_client_ear;
 

--- a/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchEjbTest.java
+++ b/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchEjbTest.java
@@ -108,6 +108,17 @@ public class PatchEjbTest extends ServiceEETest {
         com.sun.ts.lib.harness.EETest.Fault.class,
         com.sun.ts.lib.harness.EETest.SetupException.class,
         com.sun.ts.lib.harness.ServiceEETest.class,
+        com.sun.ts.tests.jsonp.api.common.ArrayBuilder.class,
+        com.sun.ts.tests.jsonp.api.common.JsonAssert.class,
+        com.sun.ts.tests.jsonp.api.common.JsonIO.class,
+        com.sun.ts.tests.jsonp.api.common.JsonPTest.class,
+        com.sun.ts.tests.jsonp.api.common.JsonValueType.class,
+        com.sun.ts.tests.jsonp.api.common.MergeRFCObject.class,
+        com.sun.ts.tests.jsonp.api.common.ObjectBuilder.class,
+        com.sun.ts.tests.jsonp.api.common.PointerRFCObject.class,
+        com.sun.ts.tests.jsonp.api.common.SimpleValues.class,
+        com.sun.ts.tests.jsonp.api.common.TestFail.class,
+        com.sun.ts.tests.jsonp.api.common.TestResult.class,
         CommonOperation.class,
         PatchCreate.class,
         PatchEjbTest.class
@@ -158,7 +169,7 @@ public class PatchEjbTest extends ServiceEETest {
     if(ejbResURL != null) {
       patchtests_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
     }
-    patchtests_ejb_vehicle_ejb.addAsManifestResource(new StringAsset("Main-Class: " + PatchEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+    // patchtests_ejb_vehicle_ejb.addAsManifestResource(new StringAsset("Main-Class: " + PatchEjbTest.class.getName() + "\n"), "MANIFEST.MF");
 
     ejbResURL = PatchEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_ejb.jar.sun-ejb-jar.xml");
     if(ejbResURL != null) {
@@ -168,7 +179,7 @@ public class PatchEjbTest extends ServiceEETest {
 
 
     EnterpriseArchive patchtests_ejb_vehicle_client_ear = ShrinkWrap.create(EnterpriseArchive.class, "patchtests_ejb_vehicle.ear");
-    patchtests_ejb_vehicle_client_ear.addAsManifestResource(new StringAsset("Main-Class: " + PatchEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+    // patchtests_ejb_vehicle_client_ear.addAsManifestResource(new StringAsset("Main-Class: " + PatchEjbTest.class.getName() + "\n"), "MANIFEST.MF");
     patchtests_ejb_vehicle_client_ear.addAsModule(patchtests_ejb_vehicle_client);
     patchtests_ejb_vehicle_client_ear.addAsModule(patchtests_ejb_vehicle_ejb);
     return patchtests_ejb_vehicle_client_ear;


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1372

**Describe the change**
- add missing classes in client jar for com/sun/ts/tests/jsonp/api/patchtests/PatchEjbTest
- keep manifest file in client jar only 