### PR TITLE
Fix datasource for Derby in ejb-jar.xml

### DIFF
--- a/ejb30/src/main/java/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/stateful/ejb-jar.xml
+++ b/ejb30/src/main/java/com/sun/ts/tests/ejb30/lite/packaging/war/datasource/stateful/ejb-jar.xml
@@ -28,8 +28,7 @@
         <class-name>org.apache.derby.jdbc.ClientDataSource</class-name>
         <server-name>localhost</server-name>
         <port-number>1527</port-number>
-        <database-name>derbyDB</database-name>
-        <url>jdbc:derby://localhost:1527/derbyDB;create=true</url>
+        <database-name>derbyDB;create=true</database-name>
         <user>cts1</user>
         <password>cts1</password>
 
@@ -58,8 +57,7 @@
         <class-name>org.apache.derby.jdbc.ClientDataSource</class-name>
         <server-name>localhost</server-name>
         <port-number>1527</port-number>
-        <database-name>derbyDB</database-name>
-        <url>jdbc:derby://localhost:1527/derbyDB;create=true</url>
+        <database-name>derbyDB;create=true</database-name>
         <user>cts1</user>
         <password>cts1</password>
 
@@ -88,8 +86,7 @@
         <class-name>org.apache.derby.jdbc.ClientDataSource</class-name>
         <server-name>localhost</server-name>
         <port-number>1527</port-number>
-        <database-name>derbyDB</database-name>
-        <url>jdbc:derby://localhost:1527/derbyDB;create=true</url>
+        <database-name>derbyDB;create=true</database-name>
         <user>cts1</user>
         <password>cts1</password>
 


### PR DESCRIPTION
**Describe the change**
URL is not used by Derby, and name was missing create property. This causes the DB not to be found (as it was never created).

**Additional context**
Running EJB30 tests

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
