### PR TITLE
EL- Use system property when setup not invoked

### DIFF
--- a/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/variablemapper/ELClientTest.java
+++ b/el/src/main/java/com/sun/ts/tests/el/api/jakarta_el/variablemapper/ELClientTest.java
@@ -48,7 +48,7 @@ public class ELClientTest extends ServiceEETest {
 
   private static final Logger logger = System.getLogger(ELClientTest.class.getName());
 
-  private Properties testProps;
+  private Properties testProps = System.getProperties();
 
   public static void main(String[] args) {
     ELClientTest theTests = new ELClientTest();

--- a/el/src/main/java/com/sun/ts/tests/el/spec/mapper/ELClientTest.java
+++ b/el/src/main/java/com/sun/ts/tests/el/spec/mapper/ELClientTest.java
@@ -61,7 +61,7 @@ public class ELClientTest extends ServiceEETest {
       logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
   }
 
-  Properties testProps;
+  Properties testProps = System.getProperties();
 
   public static void main(String[] args) {
     ELClientTest theTests = new ELClientTest();


### PR DESCRIPTION
**Describe the change**
- setup() method is not invoked For EL Tests that does not require a deployment. Will use System properties for these tests.

CC @starksm64 @gurunrao 
