### PR TITLE
Update lingering references to assembly into assembly-tck

### DIFF
--- a/appclient/pom.xml
+++ b/appclient/pom.xml
@@ -47,7 +47,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>assembly</artifactId>
+            <artifactId>assembly-tck</artifactId>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -150,7 +150,7 @@
 
             <dependency>
                 <groupId>${project.groupId}</groupId>
-                <artifactId>assembly</artifactId>
+                <artifactId>assembly-tck</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>assembly</artifactId>
+            <artifactId>assembly-tck</artifactId>
             <version>${project.version}</version>
         </dependency>
         <dependency>


### PR DESCRIPTION
assembly module was renamed to assembly-tck, but some references to assembly were still there.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
