### PR TITLE
arquillian/appclient wip progress logging changes

### DIFF
--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
@@ -61,6 +61,8 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
     @Override
     public TestResult invoke(TestMethodExecutor testMethodExecutor) {
         TestResult result = TestResult.passed();
+        String appArchiveName = null;
+        String vehicleArchiveName = null;
 
         // Run the appclient for the test if required
         String testMethod = testMethodExecutor.getMethodName();
@@ -68,8 +70,8 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
             log.info("Running appClient for: " + testMethod);
             try {
                 Deployment deployment = deploymentInstance.get();
-                String appArchiveName = appClientArchiveName.get().name();
-                String vehicleArchiveName = TsTestPropsBuilder.vehicleArchiveName(deployment);
+                appArchiveName = appClientArchiveName.get().name();
+                vehicleArchiveName = TsTestPropsBuilder.vehicleArchiveName(deployment);
                 String[] additionalAgrs = TsTestPropsBuilder.runArgs(config, deployment, testMethodExecutor);
                 appClient.run(vehicleArchiveName, appArchiveName, additionalAgrs);
             } catch (Exception ex) {
@@ -81,13 +83,13 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
         }
         String[] lines = appClient.readAll(config.getClientTimeout());
 
-        log.info(String.format("AppClient(%s) readAll returned %d lines\n", testMethod, lines.length));
+        log.fine(String.format("AppClient(%s) readAll returned %d lines\n", testMethod, lines.length));
         boolean sawStatus = false;
         MainStatus status = MainStatus.NOT_RUN;
         String reason = "None";
         String description = "None";
         for (String line : lines) {
-            System.out.println(line);
+            log.finer(line);
             if (line.contains("STATUS:")) {
                 sawStatus = true;
                 description = line;
@@ -117,6 +119,7 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
                     break;
             }
             result.addDescription(description);
+            log.info(result.toString() + ": " + description + ": " + vehicleArchiveName + ": " + appArchiveName);
         }
 
         return result;

--- a/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
+++ b/arquillian/appclient/src/main/java/tck/arquillian/protocol/appclient/AppClientMethodExecutor.java
@@ -21,6 +21,7 @@ import org.jboss.arquillian.test.spi.TestResult;
 import tck.arquillian.protocol.common.TsTestPropsBuilder;
 
 import java.io.IOException;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class AppClientMethodExecutor implements ContainerMethodExecutor {
@@ -67,7 +68,7 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
         // Run the appclient for the test if required
         String testMethod = testMethodExecutor.getMethodName();
         if (config.isRunClient()) {
-            log.info("Running appClient for: " + testMethod);
+            log.fine("Running appClient for: " + testMethod);
             try {
                 Deployment deployment = deploymentInstance.get();
                 appArchiveName = appClientArchiveName.get().name();
@@ -79,7 +80,7 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
                 return result;
             }
         } else {
-            log.info("Not running appClient for: " + testMethod);
+            log.fine("Not running appClient for %s: " + testMethod);
         }
         String[] lines = appClient.readAll(config.getClientTimeout());
 
@@ -119,7 +120,7 @@ public class AppClientMethodExecutor implements ContainerMethodExecutor {
                     break;
             }
             result.addDescription(description);
-            log.info(result.toString() + ": " + description + ": " + vehicleArchiveName + ": " + appArchiveName);
+            log.log(Level.FINE, String.format("[%s] %s : %s", result.getStatus(), description, result));
         }
 
         return result;

--- a/glassfish-runner/persistence-platform-tck/jakartaeetck/bin/ts.jte
+++ b/glassfish-runner/persistence-platform-tck/jakartaeetck/bin/ts.jte
@@ -1429,7 +1429,7 @@ optional.tech.packages.to.ignore=jakarta.xml.bind
 ########################################################################
 harness.temp.directory=${ts.home}/tmp
 harness.log.port=2000
-harness.log.traceflag=true
+harness.log.traceflag=false
 harness.executeMode=0
 harness.socket.retry.count=10
 harness.log.delayseconds=1


### PR DESCRIPTION
Make the appclient logging a little less verbose by default at line 86.  

I'm not yet sure why the logged information at 122 doesn't show the ear deployment file name (instead it seems to show the client jar (which is part of the ear).  It would be nice to show the top level deployment as well.