### PR TITLE
Fix qualifier for CTS-EM2

### DIFF
--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/cdi/CtsEm2Qualifier.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/cdi/CtsEm2Qualifier.java
@@ -1,0 +1,21 @@
+package ee.jakarta.tck.persistence.ee.cdi;
+
+import jakarta.inject.Qualifier;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Qualifier for selecting the CTS-EM2 persistence unit.
+ */
+@Qualifier
+@Documented
+@Retention(RUNTIME)
+@Target({ FIELD, METHOD })
+public @interface CtsEm2Qualifier {
+}

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/cdi/ServletEMLookupTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/cdi/ServletEMLookupTest.java
@@ -30,7 +30,7 @@ public class ServletEMLookupTest {
     @Deployment(name = "jpa-cdi-em-inject", testable = false)
     public static WebArchive deployment(@ArquillianResource TestArchiveProcessor archiveProcessor) {
         WebArchive war = ShrinkWrap.create(WebArchive.class)
-                .addClasses(CtsEmQualifier.class, CtsEmNoTxQualifier.class, JaxRsActivator.class,
+                .addClasses(CtsEmQualifier.class, CtsEm2Qualifier.class, CtsEmNoTxQualifier.class, JaxRsActivator.class,
                         TestBeanEM.class, RestEndpoint.class);
 
         // Par

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/cdi/persistence.xml
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/cdi/persistence.xml
@@ -27,12 +27,14 @@
     <jta-data-source>jdbc/DB1</jta-data-source>
     <class>ee.jakarta.tck.persistence.ee.entityManager.Order</class>
   </persistence-unit>
+  
   <persistence-unit name="CTS-EM2" transaction-type="JTA">
     <description>Persistence Unit for CTS Vehicle Tests</description>
-    <qualifier>ee.jakarta.tck.persistence.ee.cdi.CtsEmQualifier</qualifier>
+    <qualifier>ee.jakarta.tck.persistence.ee.cdi.CtsEm2Qualifier</qualifier>
     <jta-data-source>jdbc/DB1</jta-data-source>
     <class>ee.jakarta.tck.persistence.ee.entityManager.Order</class>
   </persistence-unit>
+  
   <persistence-unit name="CTS-EM-NOTX" transaction-type="RESOURCE_LOCAL">
     <description>The persistence.xml file may be used to designate
                   more than one persistence unit within the same scope.


### PR DESCRIPTION
Two persistence units used the same qualifier, leading to ambiguity.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
