### PR TITLE
Add ability to add ear lib to appclient classpath

### DIFF
--- a/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
+++ b/arquillian/common/src/main/java/tck/arquillian/protocol/common/TsTestPropsBuilder.java
@@ -104,7 +104,7 @@ public class TsTestPropsBuilder {
 
     /**
      * Get the deployment vehicle archive name from the deployment archive. This needs to be a vehicle deployment
-     * for the result to be value.
+     * for the result to be valid.
      * @param deployment - current test deployment
      * @return base vehicle archive name
      */

--- a/glassfish-runner/assembly-tck/pom.xml
+++ b/glassfish-runner/assembly-tck/pom.xml
@@ -30,19 +30,19 @@
     <properties>
         <arquillian.junit>1.9.1.Final</arquillian.junit>
         <exec.asadmin>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</exec.asadmin>
-        <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
-        <glassfish.version>8.0.0-JDK17-M7</glassfish.version>
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
         <!-- Use JDK21 to run with GF 8.0.0-M5 -->
         <!-- <glassfish.version>8.0.0-M5</glassfish.version> -->
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
+        <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
+        <glassfish.version>8.0.0-JDK17-M7</glassfish.version>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <tck.artifactId>assembly-tck</tck.artifactId>
         <tck.version>11.0.0-SNAPSHOT</tck.version>
         <ts.home>./jakartaeetck</ts.home>
         <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
-        <version.jakarta.tck.arquillian>1.0.0-M17</version.jakarta.tck.arquillian>
+        <version.jakarta.tck.arquillian>${project.version}</version.jakarta.tck.arquillian>
     </properties>
 
     <dependencyManagement>

--- a/glassfish-runner/assembly-tck/src/test/resources/appclient-arquillian.xml
+++ b/glassfish-runner/assembly-tck/src/test/resources/appclient-arquillian.xml
@@ -55,7 +55,7 @@
             <!-- <property name="clientEnvString">PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
                 APPCPATH=${glassfish.home}/glassfish/lib/arquillian-protocol-lib.jar:${glassfish.home}/glassfish/lib/tck-porting-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${glassfish.home}/glassfish/modules/security.jar</property> -->
             <property name="clientEnvString">AS_JAVA=${env.JAVA_HOME};PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
-                 APPCPATH=target/lib/libutil.jar:target/lib/arquillian-protocol-lib.jar:target/lib/tck-porting-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${glassfish.home}/glassfish/modules/security.jar:${glassfish.home}/glassfish/lib/gf-client.jar</property>
+                 APPCPATH=${clientEarLibClasspath}:target/lib/libutil.jar:target/lib/arquillian-protocol-lib.jar:target/lib/tck-porting-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${glassfish.home}/glassfish/modules/security.jar:${glassfish.home}/glassfish/lib/gf-client.jar</property>
             <property name="clientDir">${project.basedir}</property>
             <property name="workDir">/tmp</property>
             <property name="tsJteFile">jakartaeetck/bin/ts.jte</property>


### PR DESCRIPTION
**Fixes Issue**
#1650 

**Describe the change**
This adds a ${clientEarLibClasspath} variable that can be added to the appclient arquillian.xml in either the clientCmdLineString or clientEnvString appclient protocol configuration settings.

**Additional context**

with this change the com.sun.ts.tests.assembly.classpath.appclient.Client passes:

```bash
starksm@Scotts-Mac-Studio assembly-tck % mvn -Dit.test=com.sun.ts.tests.assembly.classpath.appclient.Client integration-test
[INFO] Cache configuration is not available at configured path /Users/starksm/Dev/Jakarta/platform-tck/.mvn/maven-build-cache-config.xml, cache is enabled with defaults
[INFO] Using XX hash algorithm for cache
[INFO] Scanning for projects...
...
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
```

There still are several other failures.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
