### PR TITLE
Derby 10.16.1.1 is the latest version of Derby that supports Java 17

### DIFF
--- a/libutil/pom.xml
+++ b/libutil/pom.xml
@@ -43,7 +43,7 @@
         <dependency>
             <groupId>org.apache.derby</groupId>
             <artifactId>derbynet</artifactId>
-            <version>10.17.1.0</version>
+            <version>10.16.1.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
**Fixes Issue**
Specify the issue (link) that is solved with this pull request.

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
A clear and concise description of the change.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
