### PR TITLE
Fixed ENABLE_RERUN resolution

### DIFF
--- a/docker/run_jakartaeetck.sh
+++ b/docker/run_jakartaeetck.sh
@@ -454,8 +454,8 @@ else
   ant -f xml/impl/glassfish/s1as.xml run.cts -Dkeywords=\"${KEYWORDS}\" -Dant.opts="${CTS_ANT_OPTS} ${ANT_OPTS}" -Dtest.areas="${test_suite}"
 fi
 
-ENABLE_RERUN="${ENABLE_RERUN=true}"
-if [ "$ENABLE_RERUN" -eq "true" ]; then
+ENABLE_RERUN=${ENABLE_RERUN:=true}
+if [ "$ENABLE_RERUN" = "true" ]; then
   cd "$TS_HOME/bin";
   # Check if there are any failures in the test. If so, re-run those tests.
   FAILED_COUNT=0


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/pull/1681 created feature to enable/disable rerun of failed tests.
https://github.com/jakartaee/platform-tck/pull/1682 was intended to fix the issue but did not.

This is the correct fix - the behavior was tested on simplified script.
Special thanks to @pzygielo for quick catch of my mistake.

```
#!/bin/bash
ENABLE_RERUN=${ENABLE_RERUN:=true}
echo $ENABLE_RERUN;
if [ "$ENABLE_RERUN" = "true" ]; then
  echo "This is true in qm"
fi
if [ "$ENABLE_RERUN" != "true" ]; then
  echo "This is NOT true in qm"
fi
```

```
dmatej@dmatej-hp-victus:~$ ./test.sh 
false
This is NOT true in qm
dmatej@dmatej-hp-victus:~$ export ENABLE_RERUN=false
dmatej@dmatej-hp-victus:~$ ./test.sh 
false
This is NOT true in qm
dmatej@dmatej-hp-victus:~$ export ENABLE_RERUN=true
dmatej@dmatej-hp-victus:~$ ./test.sh 
true
This is true in qm
dmatej@dmatej-hp-victus:~$ unset ENABLE_RERUN
dmatej@dmatej-hp-victus:~$ ./test.sh 
true
This is true in qm
dmatej@dmatej-hp-victus:~$ export ENABLE_RERUN="true"
dmatej@dmatej-hp-victus:~$ ./test.sh 
true
This is true in qm
dmatej@dmatej-hp-victus:~$ export ENABLE_RERUN="false"
dmatej@dmatej-hp-victus:~$ ./test.sh 
false
This is NOT true in qm
```
CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
