### PR TITLE
Switch back to the Java 17 version of Derby by reverting "Bump derby.jdbc.version from 10.15.2.0 to 10.17.1.0 (#1691)"

### DIFF
--- a/jpa-tck/spec-tests/pom.xml
+++ b/jpa-tck/spec-tests/pom.xml
@@ -149,7 +149,7 @@
         <profile>
             <id>derby</id>
             <properties>
-                <derby.jdbc.version>10.17.1.0</derby.jdbc.version>
+                <derby.jdbc.version>10.15.2.0</derby.jdbc.version>
             </properties>
             <dependencies>
                 <dependency>

--- a/jpa/spec-tests/pom.xml
+++ b/jpa/spec-tests/pom.xml
@@ -157,7 +157,7 @@
         <profile>
             <id>derby</id>
             <properties>
-                <derby.jdbc.version>10.17.1.0</derby.jdbc.version>
+                <derby.jdbc.version>10.15.2.0</derby.jdbc.version>
             </properties>
             <dependencies>
                 <dependency>


### PR DESCRIPTION
This reverts commit ee0de9ef23944acd976773295926997cb957435f.

