### PR TITLE
Fix jpa tests missing setup calls

### DIFF
--- a/common/src/main/java/com/sun/ts/tests/common/vehicle/pmservlet/PMServletVehicle.java
+++ b/common/src/main/java/com/sun/ts/tests/common/vehicle/pmservlet/PMServletVehicle.java
@@ -40,6 +40,9 @@ import jakarta.persistence.PersistenceContexts;
 import jakarta.persistence.PersistenceUnit;
 import jakarta.transaction.UserTransaction;
 
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
 @PersistenceContexts({
     @PersistenceContext(name = "persistence/CTS-EM", unitName = "CTS-EM"),
     @PersistenceContext(name = "persistence/CTS-EM2", unitName = "CTS-EM2") })
@@ -114,9 +117,13 @@ public class PMServletVehicle extends ServletVehicle {
         System.out.println("Test running in pmservlet vehicle failed");
       }
     } catch (Throwable e) {
-      sTestStatus = new RemoteStatus(
-          Status.failed("Test running in pmservlet vehicle failed"));
-      e.printStackTrace();
+      StringBuilder sb = new StringBuilder();
+        sb.append("Test running in pmservlet vehicle failed: ");
+      StringWriter sw = new StringWriter();
+      e.printStackTrace(new PrintWriter(sw));
+      sb.append(sw.toString());
+      sTestStatus = new RemoteStatus(Status.failed(sb.toString()));
+      TestUtil.logErr("Test running in pmservlet vehicle failed", e);
     }
 
     return sTestStatus;

--- a/glassfish-runner/persistence-platform-tck/jakartaeetck/bin/ts.jte
+++ b/glassfish-runner/persistence-platform-tck/jakartaeetck/bin/ts.jte
@@ -2097,7 +2097,7 @@ ts.standard.deployment.server.classpath=${ant.jars}:${pathsep}${ts.run.classpath
 
 harness.deployment.server.port=2002
 
-java.naming.factory.initial=foo
+java.naming.factory.initial=com.sun.enterprise.naming.impl.SerialInitContextFactory
 org.omg.CORBA.ORBClass=foo
 undeploy_redeploy_apps=${UNDEPLOY_REDEPLOY_FLAG}
 

--- a/glassfish-runner/persistence-platform-tck/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/pom.xml
@@ -446,7 +446,8 @@
                         </goals>
                         <configuration>
                             <includes>
-                                <include>ee/jakarta/tck/persistence/**/*Test.java</include>
+
+                                <include>ee/jakarta/tck/persistence/core/types/generator/Client1PmservletTest.java</include>
                             </includes>
                             <!-- Select the @Tag("tck-javatest") tests -->
                             <groups>tck-javatest</groups>

--- a/glassfish-runner/persistence-platform-tck/sql/derby/derby.ddl.persistence.sprocs.sql
+++ b/glassfish-runner/persistence-platform-tck/sql/derby/derby.ddl.persistence.sprocs.sql
@@ -1,0 +1,26 @@
+DROP PROCEDURE GetEmpOneFirstNameFromOut;
+CREATE PROCEDURE GetEmpOneFirstNameFromOut (out OUT_PARAM VARCHAR(255)) language java external name 'ee.jakarta.tck.persistence.storedprocedures.CS_Procs.GetEmpOneFirstNameFromOut' parameter style java;
+
+DROP PROCEDURE GetEmpFirstNameFromOut;
+CREATE PROCEDURE GetEmpFirstNameFromOut (in IN_PARAM INTEGER, out OUT_PARAM VARCHAR(255)) language java external name 'ee.jakarta.tck.persistence.storedprocedures.CS_Procs.GetEmpFirstNameFromOut' parameter style java;
+
+DROP PROCEDURE GetEmpLastNameFromInOut;
+CREATE PROCEDURE GetEmpLastNameFromInOut (inout INOUT_PARAM VARCHAR(255)) language java external name 'ee.jakarta.tck.persistence.storedprocedures.CS_Procs.GetEmpLastNameFromInOut' parameter style java;
+
+DROP PROCEDURE GetEmpASCFromRS;
+CREATE PROCEDURE GetEmpASCFromRS() language java dynamic result sets 1 external name 'ee.jakarta.tck.persistence.storedprocedures.CS_Procs.GetEmpASCFromRS' parameter style java;
+
+DROP PROCEDURE GetEmpIdFNameLNameFromRS;
+CREATE PROCEDURE GetEmpIdFNameLNameFromRS (in IN_PARAM INTEGER) language java dynamic result sets 1 external name 'ee.jakarta.tck.persistence.storedprocedures.CS_Procs.GetEmpIdFNameLNameFromRS' parameter style java;
+
+DROP PROCEDURE GetEmpIdUsingHireDateFromOut;
+CREATE PROCEDURE GetEmpIdUsingHireDateFromOut (in IN_PARAM DATE, out OUT_PARAM INTEGER) language java external name 'ee.jakarta.tck.persistence.storedprocedures.CS_Procs.GetEmpIdUsingHireDateFromOut' parameter style java;
+
+DROP PROCEDURE UpdateEmpSalaryColumn;
+CREATE PROCEDURE UpdateEmpSalaryColumn() language java external name 'ee.jakarta.tck.persistence.storedprocedures.CS_Procs.UpdateEmpSalaryColumn' parameter style java;
+
+DROP PROCEDURE DeleteAllEmp;
+CREATE PROCEDURE DeleteAllEmp() language java external name 'ee.jakarta.tck.persistence.storedprocedures.CS_Procs.DeleteAllEmp' parameter style java;
+
+DROP FUNCTION REPLACE;
+CREATE FUNCTION REPLACE (origin_string VARCHAR(255), old_string VARCHAR(255), new_string VARCHAR(255)) RETURNS VARCHAR(255) language java external name 'ee.jakarta.tck.persistence.storedprocedures.CS_Procs.ReplaceString' parameter style java;

--- a/jpa/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
+++ b/jpa/common/src/main/java/ee/jakarta/tck/persistence/common/PMClientBase.java
@@ -181,6 +181,10 @@ abstract public class PMClientBase extends ServiceEETest implements UseEntityMan
         if (JAKARTA_EE.equalsIgnoreCase(mode)) {
             logTrace(MODE_PROP + " is set to " + mode
                     + ", so tests are running in JakartaEE environment.");
+            // Propagate all properties to the system properties
+            for (String name : p.stringPropertyNames()) {
+                System.setProperty(name, p.getProperty(name));
+            }
         } else if (STANDALONE_MODE.equalsIgnoreCase(mode)) {
             logTrace(MODE_PROP + " is set to " + mode
                     + ", so tests are running in J2SE environment standalone mode."

--- a/jpa/common/src/main/java/ee/jakarta/tck/persistence/common/pluggability/altprovider/implementation/PersistenceProvider.java
+++ b/jpa/common/src/main/java/ee/jakarta/tck/persistence/common/pluggability/altprovider/implementation/PersistenceProvider.java
@@ -44,7 +44,7 @@ public class PersistenceProvider
 	protected TSLogger logger;
 
 	public PersistenceProvider() {
-		// logger = TSLogger.getInstance();
+		callLogger("PersistenceProvider.ctor");
 	}
 
 	private void callLogger(String s) {

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1PmservletTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1PmservletTest.java
@@ -90,11 +90,6 @@ public class Client1PmservletTest extends ee.jakarta.tck.persistence.core.annota
             if(warResURL != null) {
               jpa_core_annotations_version_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
             }
-            // The sun-web.xml descriptor
-            warResURL = Client1.class.getResource("//com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.war.sun-web.xml");
-            if(warResURL != null) {
-              jpa_core_annotations_version_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
-            }
 
             // Any libraries added to the war
 
@@ -102,10 +97,6 @@ public class Client1PmservletTest extends ee.jakarta.tck.persistence.core.annota
             warResURL = Client1.class.getResource("/com/sun/ts/tests/jpa/core/annotations/version/jpa_core_annotations_version.jar");
             if(warResURL != null) {
               jpa_core_annotations_version_pmservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/lib/jpa_core_annotations_version.jar");
-            }
-            warResURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
-            if(warResURL != null) {
-              jpa_core_annotations_version_pmservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/pmservlet_vehicle_web.xml");
             }
 
            // Call the archive processor

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2PmservletTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2PmservletTest.java
@@ -86,23 +86,9 @@ public class Client2PmservletTest extends ee.jakarta.tck.persistence.core.query.
             if(warResURL != null) {
               jpa_core_query_flushmode_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
             }
-            // The sun-web.xml descriptor
-            warResURL = Client2.class.getResource("//com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.war.sun-web.xml");
-            if(warResURL != null) {
-              jpa_core_query_flushmode_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
-            }
 
             // Any libraries added to the war
 
-            // Web content
-            warResURL = Client2.class.getResource("/com/sun/ts/tests/jpa/core/query/flushmode/jpa_core_query_flushmode.jar");
-            if(warResURL != null) {
-              jpa_core_query_flushmode_pmservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/lib/jpa_core_query_flushmode.jar");
-            }
-            warResURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
-            if(warResURL != null) {
-              jpa_core_query_flushmode_pmservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/pmservlet_vehicle_web.xml");
-            }
 
            // Call the archive processor
            archiveProcessor.processWebArchive(jpa_core_query_flushmode_pmservlet_vehicle_web, Client2.class, warResURL);
@@ -137,25 +123,10 @@ public class Client2PmservletTest extends ee.jakarta.tck.persistence.core.query.
             if(parURL != null) {
               jpa_core_query_flushmode.addAsManifestResource(parURL, "persistence.xml");
             }
-            // Add the Persistence mapping-file
-            URL mappingURL = Client2.class.getResource("myMappingFile.xml");
-            if(mappingURL != null) {
-              jpa_core_query_flushmode.addAsResource(mappingURL, "myMappingFile.xml");
-            }
-            mappingURL = Client2.class.getResource("myMappingFile1.xml");
-            if(mappingURL != null) {
-              jpa_core_query_flushmode.addAsResource(mappingURL, "myMappingFile1.xml");
-            }
-            mappingURL = Client2.class.getResource("myMappingFile2.xml");
-            if(mappingURL != null) {
-              jpa_core_query_flushmode.addAsResource(mappingURL, "myMappingFile2.xml");
-            }
             // Call the archive processor
             archiveProcessor.processParArchive(jpa_core_query_flushmode, Client2.class, parURL);
-            parURL = Client2.class.getResource("orm.xml");
-            if(parURL != null) {
-              jpa_core_query_flushmode.addAsManifestResource(parURL, "orm.xml");
-            }
+
+            jpa_core_query_flushmode_pmservlet_vehicle_web.addAsLibrary(jpa_core_query_flushmode);
 
         // Ear
             EnterpriseArchive jpa_core_query_flushmode_vehicles_ear = ShrinkWrap.create(EnterpriseArchive.class, "jpa_core_query_flushmode_vehicles.ear");

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client1PmservletTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/Client1PmservletTest.java
@@ -1,16 +1,12 @@
 package ee.jakarta.tck.persistence.core.types.generator;
 
-import ee.jakarta.tck.persistence.core.types.generator.Client1;
 import java.net.URL;
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.OverProtocol;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -90,27 +86,11 @@ public class Client1PmservletTest extends ee.jakarta.tck.persistence.core.types.
             if(warResURL != null) {
               jpa_core_types_generator_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
             }
-            // The sun-web.xml descriptor
-            warResURL = Client1.class.getResource("//com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.war.sun-web.xml");
-            if(warResURL != null) {
-              jpa_core_types_generator_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
-            }
 
             // Any libraries added to the war
 
-            // Web content
-            warResURL = Client1.class.getResource("/com/sun/ts/tests/jpa/core/types/generator/jpa_core_types_generator.jar");
-            if(warResURL != null) {
-              jpa_core_types_generator_pmservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/lib/jpa_core_types_generator.jar");
-            }
-            warResURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
-            if(warResURL != null) {
-              jpa_core_types_generator_pmservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/pmservlet_vehicle_web.xml");
-            }
-
            // Call the archive processor
            archiveProcessor.processWebArchive(jpa_core_types_generator_pmservlet_vehicle_web, Client1.class, warResURL);
-
 
         // Par
             // the jar with the correct archive name
@@ -123,29 +103,11 @@ public class Client1PmservletTest extends ee.jakarta.tck.persistence.core.types.
                 ee.jakarta.tck.persistence.core.types.generator.DataTypes4.class
             );
             // The persistence.xml descriptor
-            URL parURL = Client1.class.getResource("persistence.xml");
+            URL parURL = Client1.class.getResource("/ee/jakarta/tck/persistence/common/template/persistence.xml");
             if(parURL != null) {
               jpa_core_types_generator.addAsManifestResource(parURL, "persistence.xml");
             }
-            // Add the Persistence mapping-file
-            URL mappingURL = Client1.class.getResource("myMappingFile.xml");
-            if(mappingURL != null) {
-              jpa_core_types_generator.addAsResource(mappingURL, "myMappingFile.xml");
-            }
-            mappingURL = Client1.class.getResource("myMappingFile1.xml");
-            if(mappingURL != null) {
-              jpa_core_types_generator.addAsResource(mappingURL, "myMappingFile1.xml");
-            }
-            mappingURL = Client1.class.getResource("myMappingFile2.xml");
-            if(mappingURL != null) {
-              jpa_core_types_generator.addAsResource(mappingURL, "myMappingFile2.xml");
-            }
-            // Call the archive processor
-            archiveProcessor.processParArchive(jpa_core_types_generator, Client1.class, parURL);
-            parURL = Client1.class.getResource("orm.xml");
-            if(parURL != null) {
-              jpa_core_types_generator.addAsManifestResource(parURL, "orm.xml");
-            }
+
 
         // Ear
             EnterpriseArchive jpa_core_types_generator_vehicles_ear = ShrinkWrap.create(EnterpriseArchive.class, "jpa_core_types_generator_vehicles.ear");
@@ -161,11 +123,6 @@ public class Client1PmservletTest extends ee.jakarta.tck.persistence.core.types.
 
             // The application.xml descriptor
             URL earResURL = null;
-            // The sun-application.xml descriptor
-            earResURL = Client1.class.getResource("/.ear.sun-application.xml");
-            if(earResURL != null) {
-              jpa_core_types_generator_vehicles_ear.addAsManifestResource(earResURL, "sun-application.xml");
-            }
             // Call the archive processor
             archiveProcessor.processEarArchive(jpa_core_types_generator_vehicles_ear, Client1.class, earResURL);
         return jpa_core_types_generator_vehicles_ear;

--- a/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/pluggability/contracts/jta/ClientPmservletTest.java
+++ b/jpa/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/pluggability/contracts/jta/ClientPmservletTest.java
@@ -96,11 +96,14 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.ee.pluggabil
                 }
                 // Call the archive processor
                 archiveProcessor.processParArchive(jpa_ee_pluggability_contracts_jta, Client.class, parURL);
-                // The orm.xml file
+                // The orm.xml and mapping files
                 parURL = Client.class.getResource("orm.xml");
-                if(parURL != null) {
-                  jpa_ee_pluggability_contracts_jta.addAsManifestResource(parURL, "orm.xml");
-                }
+                jpa_ee_pluggability_contracts_jta.addAsManifestResource(parURL, "orm.xml");
+                parURL = Client.class.getResource("myMappingFile1.xml");
+                jpa_ee_pluggability_contracts_jta.addAsManifestResource(parURL, "myMappingFile1.xml");
+                parURL = Client.class.getResource("myMappingFile2.xml");
+                jpa_ee_pluggability_contracts_jta.addAsManifestResource(parURL, "myMappingFile2.xml");
+
             JavaArchive jpa_alternate_provider = ShrinkWrap.create(JavaArchive.class,"jpa_alternate_provider.jar");
             jpa_alternate_provider.addClasses(
                     ee.jakarta.tck.persistence.common.pluggability.altprovider.implementation.CacheImpl.class,

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client.java
@@ -22,11 +22,22 @@ import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 import java.util.Properties;
+import java.util.Set;
 
+import com.sun.ts.lib.harness.SetupMethod;
 import com.sun.ts.lib.harness.Status;
 
 import ee.jakarta.tck.persistence.common.PMClientBase;
+import jakarta.persistence.FlushModeType;
+import jakarta.persistence.LockModeType;
+import jakarta.persistence.NoResultException;
+import jakarta.persistence.NonUniqueResultException;
+import jakarta.persistence.Parameter;
+import jakarta.persistence.ParameterMode;
+import jakarta.persistence.Query;
 import jakarta.persistence.StoredProcedureQuery;
+import jakarta.persistence.TemporalType;
+import jakarta.persistence.TransactionRequiredException;
 
 public class Client extends PMClientBase {
 
@@ -67,6 +78,65 @@ public class Client extends PMClientBase {
 		createEmployeeTestData();
 		dataBaseName = p.getProperty("jdbc.db");
 	}
+
+  /*
+   * setupEmployee2Data() is called before each test
+   *
+   * @class.setup_props: jdbc.db;
+   */
+  public void setupEmployee2Data(String[] args, Properties p) throws Exception {
+    logTrace("setup");
+    try {
+      super.setup(args, p);
+      removeTestData();
+      createEmployee2TestData();
+      dataBaseName = p.getProperty("jdbc.db");
+    } catch (Exception e) {
+      logErr("Exception: ", e);
+      throw new Exception("Setup failed:", e);
+    }
+  }
+
+	void createEmployee2TestData() {
+
+		try {
+			getEntityTransaction().begin();
+
+			logMsg( "Creating Employee2");
+
+			final Calendar d2 = getCalDate(2001, 06, 27);
+			final Calendar d3 = getCalDate(2002, 07, 07);
+			final Calendar d4 = getCalDate(2003, 03, 03);
+			final Calendar d5 = getCalDate();
+
+			emp2 = new Employee2(1, "Alan", "Frechette", calDate, (float) 35000.0);
+			empRef2.add(emp2);
+			empRef2.add(new Employee2(2, "Arthur", "Frechette", d2, (float) 35000.0));
+			empRef2.add(new Employee2(3, "Shelly", "McGowan", d3, (float) 50000.0));
+			empRef2.add(new Employee2(4, "Robert", "Bissett", d4, (float) 55000.0));
+			empRef2.add(new Employee2(5, "Stephen", "DMilla", d5, (float) 25000.0));
+			for (Employee2 e : empRef2) {
+				if (e != null) {
+					getEntityManager().persist(e);
+					logTrace( "persisted Employee2:" + e);
+				}
+			}
+
+			getEntityManager().flush();
+			getEntityTransaction().commit();
+		} catch (Exception e) {
+			logErr( "Unexpected exception occurred", e);
+		} finally {
+			try {
+				if (getEntityTransaction().isActive()) {
+					getEntityTransaction().rollback();
+				}
+			} catch (Exception fe) {
+				logErr( "Unexpected exception rolling back TX:", fe);
+			}
+		}
+	}
+
 
 	public void cleanup() throws Exception {
 		logTrace( "Cleanup data");
@@ -197,6 +267,2471 @@ public class Client extends PMClientBase {
 		}
 		return result;
 	}
+
+  /*
+   * @testName: executeTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1557; PERSISTENCE:SPEC:1515;
+   * PERSISTENCE:SPEC:1566; PERSISTENCE:SPEC:1568; PERSISTENCE:SPEC:1565;
+   * PERSISTENCE:SPEC:1572; PERSISTENCE:SPEC:1576; PERSISTENCE:SPEC:1577;
+   * PERSISTENCE:SPEC:1578; PERSISTENCE:SPEC:1580;
+   *
+   * @test_Strategy:
+   *
+   */
+  public void executeTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    boolean pass3 = false;
+
+    try {
+      getEntityTransaction().begin();
+      try {
+        logMsg("Testing using name,class");
+        clearCache();
+        StoredProcedureQuery spq = getEntityManager()
+            .createStoredProcedureQuery("GetEmpASCFromRS", Employee.class);
+        if (dataBaseName.equalsIgnoreCase(ORACLE)
+            || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+          logTrace("register refcursor parameter");
+          spq.registerStoredProcedureParameter(1, void.class,
+              ParameterMode.REF_CURSOR);
+        }
+        logTrace("executing:" + spq.toString());
+        if (spq.execute()) {
+
+          List<List> listOfList = getResultSetsFromStoredProcedure(spq);
+          if (listOfList.size() == 1) {
+            List<Integer> expected = new ArrayList<Integer>();
+            for (Employee e : empRef) {
+              expected.add(e.getId());
+            }
+            pass1 = verifyEmployeeIds(expected, listOfList);
+          } else {
+            logErr(
+                "Did not get the correct number of result sets returned, expected: 1, actual:"
+                    + listOfList.size());
+          }
+        } else {
+          logErr("Expected execute() to return true, actual: false");
+        }
+      } catch (Exception ex) {
+        logErr("Received unexpected exception:", ex);
+      }
+      try {
+        logMsg("Testing using name,result mapping");
+        clearCache();
+        StoredProcedureQuery spq = getEntityManager()
+            .createStoredProcedureQuery("GetEmpIdFNameLNameFromRS",
+                "id-firstname-lastname");
+        spq.registerStoredProcedureParameter(1, Integer.class,
+            ParameterMode.IN);
+        if (dataBaseName.equalsIgnoreCase(ORACLE)
+            || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+          logTrace("register refcursor parameter");
+          spq.registerStoredProcedureParameter(2, void.class,
+              ParameterMode.REF_CURSOR);
+        }
+        spq.setParameter(1, 1);
+        if (spq.execute()) {
+
+          List<List> listOfList = getResultSetsFromStoredProcedure(spq);
+          if (listOfList.size() == 1) {
+            List<Employee> expected = new ArrayList<Employee>();
+            expected.add(new Employee(emp0.getId(), emp0.getFirstName(),
+                emp0.getLastName()));
+            pass2 = verifyListOfListEmployees(expected, listOfList);
+          } else {
+            logErr(
+                "Did not get the correct number of result sets returned, expected: 1, actual:"
+                    + listOfList.size());
+          }
+        } else {
+          logErr("Expected execute() to return false, actual: true");
+        }
+      } catch (Exception ex) {
+        logErr("Received unexpected exception:", ex);
+      }
+      try {
+        logMsg("Testing using named stored procedure");
+        clearCache();
+        StoredProcedureQuery spq;
+        if (dataBaseName.equalsIgnoreCase(ORACLE)
+            || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+          logTrace(
+              "Calling refcursor specific named stored procedure query");
+          spq = getEntityManager().createNamedStoredProcedureQuery(
+              "get-id-firstname-lastname-refcursor");
+        } else {
+          spq = getEntityManager()
+              .createNamedStoredProcedureQuery("get-id-firstname-lastname");
+        }
+        spq.setParameter(1, 1);
+        if (spq.execute()) {
+          List<List> listOfList = getResultSetsFromStoredProcedure(spq);
+          if (listOfList.size() == 1) {
+            List<Employee> expected = new ArrayList<Employee>();
+            expected.add(new Employee(emp0.getId(), emp0.getFirstName(),
+                emp0.getLastName()));
+            pass3 = verifyListOfListEmployees(expected, listOfList);
+          } else {
+            logErr(
+                "Did not get the correct number of result sets returned, expected: 1, actual:"
+                    + listOfList.size());
+          }
+        } else {
+          logErr("Expected execute() to return false, actual: true");
+        }
+      } catch (Exception ex) {
+        logErr("Received unexpected exception:", ex);
+      }
+
+      getEntityTransaction().commit();
+
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+
+    if (!pass1 || !pass2 || !pass3) {
+      throw new Exception("executeTest failed");
+    }
+
+  }
+
+  /*
+   * @testName: getOutputParameterValueIntTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1547; PERSISTENCE:SPEC:1569;
+   * PERSISTENCE:SPEC:1570; PERSISTENCE:SPEC:1583;
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void getOutputParameterValueIntTest() throws Exception {
+    boolean pass2 = false;
+    boolean pass4 = false;
+    boolean pass6 = false;
+
+    Object oActual = null;
+    try {
+      getEntityTransaction().begin();
+
+      logMsg("Get the value from an OUT only parameter");
+      StoredProcedureQuery spq3 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpOneFirstNameFromOut");
+      spq3.registerStoredProcedureParameter(1, String.class, ParameterMode.OUT);
+      if (!spq3.execute()) {
+
+        oActual = spq3.getOutputParameterValue(1);
+        if (oActual instanceof String) {
+          String actual = (String) oActual;
+          if (actual.equals(emp0.getFirstName())) {
+            logTrace("Received expected result:" + actual);
+            pass6 = true;
+          } else {
+            logErr("Expected result: " + emp0.getFirstName()
+                + ", actual:" + actual);
+          }
+        } else {
+          logErr("Did not get instance of String, instead:" + oActual);
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+    try {
+      logMsg("Get the value from an IN and OUT parameter");
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq1.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq1.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq1.setParameter(1, 1);
+      if (!spq1.execute()) {
+
+        oActual = spq1.getOutputParameterValue(2);
+        if (oActual instanceof String) {
+          String actual = (String) oActual;
+          if (actual.equals(emp0.getFirstName())) {
+            logTrace("Received expected result:" + actual);
+            pass2 = true;
+          } else {
+            logErr("Expected result: " + emp0.getFirstName()
+                + ", actual:" + actual);
+          }
+        } else {
+          logErr("Did not get instance of String, instead:" + oActual);
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+    try {
+      logMsg("Get the value from an INOUT parameter");
+      StoredProcedureQuery spq2 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpLastNameFromInOut");
+      spq2.registerStoredProcedureParameter(1, String.class,
+          ParameterMode.INOUT);
+      spq2.setParameter(1, "1");
+
+      if (!spq2.execute()) {
+
+        oActual = spq2.getOutputParameterValue(1);
+        if (oActual instanceof String) {
+          String actual = (String) oActual;
+          if (actual.equals(emp0.getLastName())) {
+            logTrace("Received expected result:" + actual);
+            pass4 = true;
+          } else {
+            logErr("Expected result: " + emp0.getLastName()
+                + ", actual:" + actual);
+          }
+        } else {
+          logErr("Expected Integer to be returned, actual:" + oActual);
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+
+    if (!pass2 || !pass4 || !pass6) {
+      throw new Exception("getOutputParameterValueIntTest failed");
+    }
+
+  }
+
+  /*
+   * @testName: getOutputParameterValueIntIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1548; PERSISTENCE:SPEC:1302.4;
+   *
+   * @test_Strategy:
+   *
+   */
+  public void getOutputParameterValueIntIllegalArgumentExceptionTest()
+      throws Exception {
+    boolean pass2 = false;
+    boolean pass4 = false;
+
+    try {
+      getEntityTransaction().begin();
+
+      logMsg("Get a value that does not exist");
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq1.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq1.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq1.setParameter(1, 1);
+
+      if (!spq1.execute()) {
+        try {
+          spq1.getOutputParameterValue(99);
+          logErr("Did not throw IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
+          logTrace("Received expected IllegalArgumentException");
+          if (getEntityTransaction().getRollbackOnly() != true) {
+            pass2 = true;
+            logTrace("Transaction was not marked for rollback");
+          } else {
+            logErr(
+                "Transaction was marked for rollback and should not have been");
+          }
+        } catch (Exception e) {
+          logErr("Caught unexpected exception", e);
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      logMsg("Get the value from an IN parameter");
+      StoredProcedureQuery spq2 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpLastNameFromInOut");
+      spq2.registerStoredProcedureParameter(1, String.class,
+          ParameterMode.INOUT);
+      spq2.setParameter(1, "1");
+
+      if (!spq2.execute()) {
+        try {
+          spq2.getOutputParameterValue(99);
+          logErr("Did not throw IllegalArgumentException");
+        } catch (IllegalArgumentException iae) {
+          logTrace("Received expected IllegalArgumentException");
+          pass4 = true;
+        } catch (Exception e) {
+          logErr("Caught unexpected exception", e);
+        }
+
+        if (getEntityTransaction().isActive()) {
+          getEntityTransaction().rollback();
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+
+    if (!pass2 || !pass4) {
+      throw new Exception(
+          "getOutputParameterValueIntIllegalArgumentExceptionTest failed");
+    }
+
+  }
+
+  /*
+   * @testName: getFirstResultTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1585; PERSISTENCE:JAVADOC:3482;
+   * PERSISTENCE:SPEC:1515;
+   *
+   * @test_Strategy:
+   *
+   */
+  public void getFirstResultTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    boolean pass3 = false;
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpASCFromRS", Employee.class);
+      if (dataBaseName.equalsIgnoreCase(ORACLE)
+          || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+        logTrace("register refcursor parameter");
+        spq.registerStoredProcedureParameter(1, void.class,
+            ParameterMode.REF_CURSOR);
+      }
+      int num = spq.getFirstResult();
+      if (num == 0) {
+
+            logTrace("Received expected first result when none is set:" + num);
+        pass1 = true;
+      } else {
+
+            logErr("Expected first result when none is set: 0, actual:" + num);
+      }
+
+      List<Employee> actual = spq.getResultList();
+      num = spq.getFirstResult();
+      if (num == 0) {
+        logTrace(
+            "Received expected first result:" + num + " after getResultList");
+        pass2 = true;
+      } else {
+        logErr(
+            "Expected first result: 0, actual:" + num + " after getResultList");
+      }
+      if (actual.size() > 0) {
+        pass3 = verifyListEmployees(empRef, actual);
+      } else {
+        logErr("getResultList() returned 0 results");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+
+    if (!pass1 || !pass2 || !pass3) {
+      throw new Exception("getFirstResultTest failed");
+    }
+
+  }
+
+  /*
+   * @testName: getMaxResultsTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1590;
+   * 
+   * @test_Strategy:
+   *
+   */
+  public void getMaxResultsTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    boolean pass3 = false;
+
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpASCFromRS", Employee.class);
+      if (dataBaseName.equalsIgnoreCase(ORACLE)
+          || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+        logTrace("register refcursor parameter");
+        spq.registerStoredProcedureParameter(1, void.class,
+            ParameterMode.REF_CURSOR);
+      }
+      int num = spq.getMaxResults();
+      if (num == Integer.MAX_VALUE) {
+        logTrace("Received expected max result:" + num);
+        pass1 = true;
+      } else {
+        logErr(
+            "Expected max result: " + Integer.MAX_VALUE + ", actual:" + num);
+      }
+      List<Employee> actual = spq.getResultList();
+      num = spq.getMaxResults();
+      if (num == Integer.MAX_VALUE) {
+        logTrace(
+            "Received expected max result:" + num + " after getResultList");
+        pass2 = true;
+      } else {
+        logErr("Expected max result:" + Integer.MAX_VALUE + ", actual:"
+            + num + " after getResultList");
+      }
+      if (actual.size() > 0) {
+        pass3 = verifyListEmployees(empRef, actual);
+      } else {
+        logErr("getResultList() returned 0 results");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+
+    if (!pass1 || !pass2 || !pass3) {
+      throw new Exception("getMaxResultsTest failed");
+    }
+
+  }
+
+  /*
+   * @testName: getSingleResultTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:3482; PERSISTENCE:SPEC:1515;
+   * 
+   * @test_Strategy: Get single result from returned resultset.
+   *
+   */
+  public void getSingleResultTest() throws Exception {
+    boolean pass = false;
+
+    try {
+      getEntityTransaction().begin();
+      clearCache();
+
+      StoredProcedureQuery spq = getEntityManager().createStoredProcedureQuery(
+          "GetEmpIdFNameLNameFromRS", "id-firstname-lastname");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      if (dataBaseName.equalsIgnoreCase(ORACLE)
+          || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+        logTrace("register refcursor parameter");
+        spq.registerStoredProcedureParameter(2, void.class,
+            ParameterMode.REF_CURSOR);
+      }
+      spq.setParameter(1, 1);
+      Employee expected = new Employee(emp0.getId(), emp0.getFirstName(),
+          emp0.getLastName());
+      Object o = spq.getSingleResult();
+      if (o instanceof Employee) {
+        Employee actual = (Employee) o;
+        if (actual.equals(expected)) {
+          logTrace("Received expected result:" + actual);
+          pass = true;
+        } else {
+          logErr("Expected result:" + expected + ", actual:" + actual);
+        }
+      } else {
+        logErr("Did not get Integer result:" + o);
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+
+    if (!pass) {
+      throw new Exception("getSingleResultTest failed");
+    }
+
+  }
+
+  /*
+   * @testName: getSingleResultNoResultExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:3483
+   * 
+   * @test_Strategy: Get single result from returned resultset that is empty
+   *
+   */
+  public void getSingleResultNoResultExceptionTest() throws Exception {
+    boolean pass = false;
+
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdFNameLNameFromRS");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      if (dataBaseName.equalsIgnoreCase(ORACLE)
+          || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+        logTrace("register refcursor parameter");
+        spq.registerStoredProcedureParameter(2, void.class,
+            ParameterMode.REF_CURSOR);
+      }
+      spq.setParameter(1, 99);
+      try {
+        spq.getSingleResult();
+        logErr("Did not throw NoResultException");
+      } catch (NoResultException nre) {
+        logTrace("Received expected NoResultException");
+        pass = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+
+      }
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+
+    if (!pass) {
+      throw new Exception("getSingleResultNoResultExceptionTest failed");
+    }
+
+  }
+
+  /*
+   * @testName: getSingleResultNonUniqueResultExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:3484
+   * 
+   * @test_Strategy: Get single result from returned resultset that contains
+   * multiple values
+   *
+   */
+  public void getSingleResultNonUniqueResultExceptionTest() throws Exception {
+    boolean pass = false;
+
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpASCFromRS", Employee.class);
+      if (dataBaseName.equalsIgnoreCase(ORACLE)
+          || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+        logTrace("register refcursor parameter");
+        spq.registerStoredProcedureParameter(1, void.class,
+            ParameterMode.REF_CURSOR);
+      }
+      try {
+        spq.getSingleResult();
+        logErr("Did not throw NonUniqueResultException");
+      } catch (NonUniqueResultException nure) {
+        logTrace("Received expected NonUniqueResultException");
+        pass = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+
+    if (!pass) {
+      throw new Exception("getSingleResultNonUniqueResultExceptionTest failed");
+    }
+
+  }
+
+  /*
+   * @testName: setgetFlushModeTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1586; PERSISTENCE:JAVADOC:1559;
+   * 
+   * @test_Strategy: Set and Get the various flushModes of a Query
+   */
+
+  public void setgetFlushModeTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+
+    try {
+      logMsg("Testing StoredProcedureQuery");
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpASCFromRS", Employee.class);
+      if (dataBaseName.equalsIgnoreCase(ORACLE)
+          || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+        logTrace("register refcursor parameter");
+        spq.registerStoredProcedureParameter(1, void.class,
+            ParameterMode.REF_CURSOR);
+      }
+      FlushModeType fmt = spq.getFlushMode();
+      if (fmt != null) {
+        if (fmt.equals(getEntityManager().getFlushMode())) {
+          logTrace("Setting mode to returned default mode");
+          spq.setFlushMode(fmt);
+          logTrace("Setting mode to FlushModeType.COMMIT");
+          spq.setFlushMode(FlushModeType.COMMIT);
+          fmt = spq.getFlushMode();
+          if (fmt.equals(FlushModeType.COMMIT)) {
+            logTrace("Setting mode to FlushModeType.AUTO");
+            spq.setFlushMode(FlushModeType.AUTO);
+            fmt = spq.getFlushMode();
+            if (fmt.equals(FlushModeType.AUTO)) {
+              logTrace("Query object returned from setFlushMode");
+              Query q = spq.setFlushMode(FlushModeType.COMMIT);
+              fmt = q.getFlushMode();
+              if (fmt.equals(FlushModeType.COMMIT)) {
+                logTrace(
+                    "Received expected Query FlushModeType:" + fmt.name());
+                pass1 = true;
+              } else {
+                logErr("Expected a value of:"
+                    + FlushModeType.COMMIT.name() + ", actual:" + fmt.name());
+              }
+            } else {
+              logErr("Expected a value of:" + FlushModeType.AUTO.name()
+                  + ", actual:" + fmt.name());
+            }
+          } else {
+            logErr("Expected a default value of:"
+                + FlushModeType.COMMIT.name() + ", actual:" + fmt.name());
+          }
+        } else {
+          logErr("Expected EntityManager value of:"
+              + getEntityManager().getFlushMode() + ", actual:" + fmt.name());
+        }
+      } else {
+        logErr("getFlushMode return null");
+      }
+
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+    }
+    try {
+      logMsg("Testing Query object returned from setFlushMode");
+      StoredProcedureQuery spq2 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpASCFromRS", Employee.class);
+
+      logTrace("Setting mode to FlushModeType.AUTO");
+      Query q = spq2.setFlushMode(FlushModeType.AUTO);
+      FlushModeType fmt = q.getFlushMode();
+      if (fmt.equals(FlushModeType.AUTO)) {
+        logTrace("Received expected value of:" + fmt.name());
+        pass2 = true;
+      } else {
+        logErr("Expected a value of:" + FlushModeType.AUTO.name()
+            + ", actual:" + fmt.name());
+      }
+
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+    }
+
+    if (!pass1 || !pass2)
+      throw new Exception("setgetFlushModeTest failed");
+  }
+
+  /*
+   * @testName: setLockModeIllegalStateExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1637;
+   * 
+   * @test_Strategy:
+   */
+
+  public void setLockModeIllegalStateExceptionTest() throws Exception {
+    boolean pass = false;
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("UpdateEmpSalaryColumn");
+      try {
+        spq.setLockMode(LockModeType.PESSIMISTIC_READ);
+        logErr("Did not throw IllegalStateException");
+      } catch (IllegalStateException ise) {
+        logTrace("Received expected IllegalStateException");
+        pass = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+    }
+
+    if (!pass)
+      throw new Exception("setLockModeIllegalStateExceptionTest failed");
+  }
+  /*
+   * @testName: getLockModeIllegalStateExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1589;
+   * 
+   * @test_Strategy:
+   */
+
+  public void getLockModeIllegalStateExceptionTest() throws Exception {
+    boolean pass = false;
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("UpdateEmpSalaryColumn");
+      try {
+        spq.getLockMode();
+        logErr("Did not throw IllegalStateException");
+      } catch (IllegalStateException ise) {
+        logTrace("Received expected IllegalStateException");
+        pass = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+    }
+
+    if (!pass)
+      throw new Exception("getLockModeIllegalStateExceptionTest failed");
+  }
+
+  /*
+   * @testName: setGetParameterIntTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1597; PERSISTENCE:JAVADOC:1574;
+   * 
+   * @test_Strategy:
+   */
+
+  public void setGetParameterIntTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    try {
+      getEntityTransaction().begin();
+
+      logMsg("Testing StoredProcedureQuery");
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq.setParameter(1, 1);
+      Parameter p = spq.getParameter(1);
+      int pos = p.getPosition();
+      if (pos == 1) {
+        logTrace("Received expected parameter:" + pos);
+        pass1 = true;
+      } else {
+        logErr("Expected position: 1, actual:" + pos);
+      }
+
+      logMsg("Testing Query object returned from getParameter");
+      StoredProcedureQuery spq2 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq2.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq2.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      Query q = spq2.setParameter(1, 1);
+      p = q.getParameter(1);
+      pos = p.getPosition();
+      if (pos == 1) {
+        logTrace("Received expected parameter:" + pos);
+        pass2 = true;
+      } else {
+        logErr("Expected position: 1, actual:" + pos);
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+    }
+
+    if (!pass1 || !pass2)
+      throw new Exception("setGetParameterIntTest failed");
+  }
+
+  // disabling this test since Store Procedures with named parameters
+  // isn't supported by all DB's at this time
+  /*
+   * testName: setGetParameterStringTest assertion_ids:
+   * PERSISTENCE:JAVADOC:1549; PERSISTENCE:JAVADOC:1558;
+   * PERSISTENCE:JAVADOC:1568; PERSISTENCE:JAVADOC:1591; test_Strategy:
+   */
+
+  /*
+   * public void setGetParameterStringTest() throws Exception { boolean pass1 =
+   * false; boolean pass2 = false; boolean pass3 = false; try {
+   * getEntityTransaction().begin();
+   * 
+   * logMsg("Testing StoredProcedureQuery"); StoredProcedureQuery spq =
+   * getEntityManager().createStoredProcedureQuery("GetEmpFirstNameFromOut");
+   * spq.registerStoredProcedureParameter("IN_PARAM", Integer.class,
+   * ParameterMode.IN); spq.registerStoredProcedureParameter("OUT_PARAM",
+   * String.class, ParameterMode.OUT); spq.setParameter("IN_PARAM", 1);
+   * 
+   * Parameter p = spq.getParameter("OUT_PARAM"); Integer pos = p.getPosition();
+   * if (pos == null){ logTrace("Received expected null"); pass1 =
+   * true; } else { logErr("Expected position: null, actual:" + pos); }
+   * 
+   * spq.execute(); Object oActual = spq.getOutputParameterValue("OUT_PARAM");
+   * if (oActual instanceof String) { String actual = (String) oActual; if
+   * (actual.equals(emp0.getFirstName())) {
+   * logTrace("Received expected result:" + actual); pass2 = true; }
+   * else { logErr("Expected result: " + emp0.getFirstName() +
+   * ", actual:" + actual); } } else {
+   * logErr("Did not get instance of String, instead:" +
+   * oActual.getClass()); } getEntityTransaction().commit();
+   * 
+   * } catch (Exception e) { logErr("Caught exception: ", e); }
+   * 
+   * if (!pass1 || !pass2 ) throw new Exception("setGetParameterStringTest failed");
+   * }
+   */
+
+  /*
+   * @testName: getParameterStringExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1609; PERSISTENCE:JAVADOC:1569;
+   * 
+   * @test_Strategy:
+   */
+
+  public void getParameterStringExceptionTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    try {
+      getEntityTransaction().begin();
+      logMsg("Testing StoredProcedureQuery ");
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq.registerStoredProcedureParameter("ID", Integer.class,
+          ParameterMode.IN);
+      spq.registerStoredProcedureParameter("FIRSTNAME", String.class,
+          ParameterMode.OUT);
+      spq.setParameter("ID", 1);
+      try {
+        spq.getParameter("DOESNOTEXIST");
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass1 = true;
+      } catch (IllegalStateException ise) {
+        logTrace("Received expected IllegalStateException");
+        pass1 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      logMsg("Testing Query object returned from getParameter");
+      StoredProcedureQuery spq2 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq2.registerStoredProcedureParameter("ID", Integer.class,
+          ParameterMode.IN);
+      spq2.registerStoredProcedureParameter("FIRSTNAME", String.class,
+          ParameterMode.OUT);
+      Query q = spq2.setParameter("ID", 1);
+      try {
+        q.getParameter("DOESNOTEXIST");
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass2 = true;
+      } catch (IllegalStateException ise) {
+        logTrace("Received expected IllegalStateException");
+        pass2 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+    }
+
+    if (!pass1 || !pass2)
+      throw new Exception("getParameterStringExceptionTest failed");
+  }
+
+  /*
+   * @testName: getParameterIntIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1598;
+   * 
+   * @test_Strategy:
+   */
+
+  public void getParameterIntIllegalArgumentExceptionTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    try {
+      getEntityTransaction().begin();
+      logMsg("Testing StoredProcedureQuery ");
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq.setParameter(1, 1);
+      try {
+        spq.getParameter(99);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass1 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      logMsg("Testing Query object returned from getParameter");
+      StoredProcedureQuery spq2 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq2.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq2.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      Query q = spq2.setParameter(1, 1);
+      try {
+        q.getParameter(99);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass2 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+    }
+
+    if (!pass1 || !pass2)
+      throw new Exception("getParameterIntIllegalArgumentExceptionTest failed");
+  }
+
+  /*
+   * @testName: setParameterParameterObjectTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1562;
+   * 
+   * @test_Strategy:
+   */
+
+  public void setParameterParameterObjectTest() throws Exception {
+    boolean pass2 = false;
+    boolean pass4 = false;
+    try {
+      getEntityTransaction().begin();
+
+      logMsg("Testing StoredProcedureQuery ");
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq.setParameter(1, 99);
+      Parameter p = spq.getParameter(1);
+      spq.setParameter(p, 1);
+
+      if (!spq.execute()) {
+        Object oActual = spq.getOutputParameterValue(2);
+        if (oActual instanceof String) {
+          String actual = (String) oActual;
+          if (actual.equals(emp0.getFirstName())) {
+            logTrace("Received expected result:" + actual);
+            pass2 = true;
+          } else {
+            logErr("Expected result: " + emp0.getFirstName()
+                + ", actual:" + actual);
+          }
+        } else {
+          logErr(
+              "Did not get instance of String, instead:" + oActual.getClass());
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    }
+    try {
+      getEntityTransaction().begin();
+
+      logMsg("Testing Query object returned from setParameter");
+      StoredProcedureQuery spq2 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq2.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq2.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      Query q = spq2;
+      q.setParameter(1, 99);
+      Parameter p = q.getParameter(1);
+      q.setParameter(p, 1);
+      StoredProcedureQuery spq3 = (StoredProcedureQuery) q;
+      if (!spq3.execute()) {
+        Object oActual = spq3.getOutputParameterValue(2);
+        if (oActual instanceof String) {
+          String actual = (String) oActual;
+          if (actual.equals(emp0.getFirstName())) {
+            logTrace("Received expected result:" + actual);
+            pass4 = true;
+          } else {
+            logErr("Expected result: " + emp0.getFirstName()
+                + ", actual:" + actual);
+          }
+        } else {
+          logErr("Did not get instance of String, instead:" + oActual);
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    }
+
+    if (!pass2 || !pass4)
+      throw new Exception("setParameterParameterObjectTest failed");
+
+  }
+
+  /*
+   * @testName: setParameterParameterObjectIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1563;
+   * 
+   * @test_Strategy: call setParameter(Parameter, Object) using parameter from
+   * different query.
+   */
+
+  public void setParameterParameterObjectIllegalArgumentExceptionTest()
+      throws Exception {
+    boolean pass1 = false;
+    try {
+      getEntityTransaction().begin();
+
+      logTrace("Get parameter from other stored procedure");
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpLastNameFromInOut");
+      spq.registerStoredProcedureParameter(1, String.class,
+          ParameterMode.INOUT);
+      spq.setParameter(1, "INOUT");
+      // Parameter to be used in next StoredProcedure
+      Parameter p = spq.getParameter(1);
+
+      StoredProcedureQuery spq2 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq2.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq2.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+
+      try {
+        spq2.setParameter(p, 1);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass1 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+    }
+
+    if (!pass1)
+      throw new Exception(
+          "setParameterParameterObjectIllegalArgumentExceptionTest failed");
+  }
+
+  /*
+   * @testName: setParameterIntObjectIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1575;
+   * 
+   * @test_Strategy:
+   */
+  public void setParameterIntObjectIllegalArgumentExceptionTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    boolean pass3 = false;
+    boolean pass4 = false;
+    try {
+      getEntityTransaction().begin();
+      logMsg(
+          "Testing StoredProcedureQuery with incorrect position specified");
+
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq1.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq1.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      try {
+        spq1.setParameter(99, 1);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass1 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+          logMsg("Testing StoredProcedureQuery with incorrect type specified");
+
+      StoredProcedureQuery spq2 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq2.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq2.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      try {
+        spq2.setParameter(1, new java.util.Date());
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass2 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      logMsg("Testing Query object with incorrect position specified");
+      StoredProcedureQuery spq3 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq3.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq3.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      Query q1 = spq3.setParameter(1, 1);
+      try {
+        spq3.setParameter(99, 1);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass3 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      logMsg("Testing Query object with incorrect type specified");
+      StoredProcedureQuery spq4 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq4.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq4.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      Query q2 = spq4.setParameter(1, 1);
+      try {
+        q2.setParameter(1, new java.util.Date());
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass4 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+    }
+
+    if (!pass1 || !pass2 || !pass3 || !pass4)
+      throw new Exception(
+          "setParameterIntObjectIllegalArgumentExceptionTest failed");
+  }
+
+  /*
+   * @testName: getParametersTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1597; PERSISTENCE:JAVADOC:1603;
+   * 
+   * @test_Strategy:
+   */
+
+  public void getParametersTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass3 = false;
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      Set<Parameter<?>> p1 = spq.getParameters();
+      if (p1.size() == 0) {
+            logTrace("Received expected number of parameters when non exist:"
+                + p1.size());
+        pass1 = true;
+      } else {
+        logErr(
+            "Expected number of parameters when non exist: 0, actual:" + p1);
+      }
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq.setParameter(1, 1);
+
+      if (!spq.execute()) {
+        Set<Parameter<?>> p2 = spq.getParameters();
+        if (p2.size() == 2) {
+              logTrace("Received expected number of parameters:" + p2.size());
+          pass3 = true;
+        } else {
+              logErr("Expected number of parameters: 2, actual:" + p2.size());
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+    }
+
+    if (!pass1 || !pass3)
+      throw new Exception("getParametersTest failed");
+
+  }
+
+  /*
+   * @testName: setParameterIntCalendarTemporalTypeTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1576;
+   * 
+   * @test_Strategy:
+   */
+  @SetupMethod(name = "setupEmployee2Data")
+  public void setParameterIntCalendarTemporalTypeTest() throws Exception {
+    boolean pass2 = false;
+    boolean pass4 = false;
+    try {
+      getEntityTransaction().begin();
+      try {
+        logMsg("Testing StoredProcedureQuery object");
+
+        StoredProcedureQuery spq = getEntityManager()
+            .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+        spq.registerStoredProcedureParameter(1, Calendar.class,
+            ParameterMode.IN);
+        spq.registerStoredProcedureParameter(2, Integer.class,
+            ParameterMode.OUT);
+        spq.setParameter(1, calDate, TemporalType.DATE);
+
+        if (!spq.execute()) {
+          Object o = spq.getOutputParameterValue(2);
+          if (o instanceof Integer) {
+            int actual = (Integer) o;
+            if (actual == emp2.getId()) {
+              logTrace("Received expected id:" + actual);
+              pass2 = true;
+            } else {
+              logErr(
+                  "Expected id: " + emp2.getId() + ", actual:" + actual);
+            }
+
+          } else {
+            logErr("Did not get instance of Integer back:" + o);
+          }
+        } else {
+          logErr("Expected execute() to return false, actual: true");
+        }
+      } catch (Exception e) {
+        logErr("Caught exception: ", e);
+      }
+      try {
+        logMsg("Testing Query object");
+        StoredProcedureQuery spq1 = getEntityManager()
+            .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+        spq1.registerStoredProcedureParameter(1, Calendar.class,
+            ParameterMode.IN);
+        spq1.registerStoredProcedureParameter(2, Integer.class,
+            ParameterMode.OUT);
+        Query q = spq1;
+        q.setParameter(1, getCalDate(), TemporalType.DATE);
+        StoredProcedureQuery spq2 = (StoredProcedureQuery) q;
+        if (!spq2.execute()) {
+          Object o = spq2.getOutputParameterValue(2);
+          if (o instanceof Integer) {
+            int actual = (Integer) o;
+            if (actual == 5) {
+              logTrace("Received expected id:" + actual);
+              pass4 = true;
+            } else {
+              logErr("Expected id: 5, actual:" + actual);
+            }
+
+          } else {
+            logErr("Did not get instance of Integer back:" + o);
+          }
+        } else {
+          logErr("Expected execute() to return false, actual: true");
+        }
+      } catch (Exception e) {
+        logErr("Caught exception: ", e);
+      }
+
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+    }
+
+    if (!pass2 || !pass4)
+      throw new Exception("setParameterIntCalendarTemporalTypeTest failed");
+
+  }
+
+  /*
+   * @testName: setParameterIntCalendarTemporalTypeIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1577;
+   * 
+   * @test_Strategy:
+   */
+  @SetupMethod(name = "setupEmployee2Data")
+  public void setParameterIntCalendarTemporalTypeIllegalArgumentExceptionTest()
+      throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    try {
+      getEntityTransaction().begin();
+      logMsg(
+          "Testing StoredProcedureQuery with incorrect position specified");
+
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq1.registerStoredProcedureParameter(1, Calendar.class,
+          ParameterMode.IN);
+      try {
+        spq1.setParameter(99, getCalDate(), TemporalType.DATE);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass1 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      logMsg("Testing Query object with incorrect position specified");
+      StoredProcedureQuery spq3 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq3.registerStoredProcedureParameter(1, Calendar.class,
+          ParameterMode.IN);
+      Query q1 = spq3.setParameter(1, getCalDate(), TemporalType.DATE);
+      try {
+        q1.setParameter(99, getCalDate());
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass2 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+    }
+    if (!pass1 || !pass2)
+      throw new Exception(
+          "setParameterIntCalendarTemporalTypeIllegalArgumentExceptionTest failed");
+
+  }
+
+  /*
+   * @testName: setParameterIntDateTemporalTypeTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1578;
+   * 
+   * @test_Strategy:
+   */
+
+  public void setParameterIntDateTemporalTypeTest() throws Exception {
+    boolean pass2 = false;
+    boolean pass4 = false;
+    try {
+      getEntityTransaction().begin();
+      try {
+        logMsg("Testing StoredProcedureQuery");
+
+        StoredProcedureQuery spq = getEntityManager()
+            .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+        spq.registerStoredProcedureParameter(1, Date.class, ParameterMode.IN);
+        spq.registerStoredProcedureParameter(2, Integer.class,
+            ParameterMode.OUT);
+        spq.setParameter(1, utilDate, TemporalType.DATE);
+
+        if (!spq.execute()) {
+
+          Object o = spq.getOutputParameterValue(2);
+          if (o instanceof Integer) {
+            Integer actual = (Integer) o;
+            if (actual == 1) {
+              logTrace("Received expected id:" + actual);
+              pass2 = true;
+            } else {
+              logErr("Expected id: 1, actual:" + actual);
+            }
+
+          } else {
+            logErr("Did not get instance of Integer back:" + o);
+          }
+        } else {
+          logErr("Expected execute() to return false, actual: true");
+        }
+      } catch (Exception e) {
+        logErr("Caught exception: ", e);
+      }
+      try {
+        logMsg("Testing Query object");
+        StoredProcedureQuery spq1 = getEntityManager()
+            .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+        spq1.registerStoredProcedureParameter(1, Date.class, ParameterMode.IN);
+        spq1.registerStoredProcedureParameter(2, Integer.class,
+            ParameterMode.OUT);
+        Query q = spq1;
+        q.setParameter(1, utilDate, TemporalType.DATE);
+        StoredProcedureQuery spq2 = (StoredProcedureQuery) q;
+
+        if (!spq2.execute()) {
+
+          Object o = spq2.getOutputParameterValue(2);
+          if (o instanceof Integer) {
+            int actual = (Integer) o;
+            if (actual == 1) {
+              logTrace("Received expected id:" + actual);
+              pass4 = true;
+            } else {
+              logErr("Expected id: 1, actual:" + actual);
+            }
+
+          } else {
+            logErr("Did not get instance of Integer back:" + o);
+          }
+        } else {
+          logErr("Expected execute() to return false, actual: true");
+        }
+      } catch (Exception e) {
+        logErr("Caught exception: ", e);
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+    }
+
+    if (!pass2 || !pass4)
+      throw new Exception("setParameterIntDateTemporalTypeTest failed");
+
+  }
+
+  /*
+   * @testName: setParameterIntDateTemporalTypeIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1579;
+   * 
+   * @test_Strategy:
+   */
+
+  public void setParameterIntDateTemporalTypeIllegalArgumentExceptionTest()
+      throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    try {
+      getEntityTransaction().begin();
+      logMsg(
+          "Testing StoredProcedureQuery with incorrect position specified");
+
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq1.registerStoredProcedureParameter(1, Date.class, ParameterMode.IN);
+      try {
+        spq1.setParameter(99, utilDate, TemporalType.DATE);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass1 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      logMsg("Testing Query object with incorrect position specified");
+      StoredProcedureQuery spq3 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq3.registerStoredProcedureParameter(1, Date.class, ParameterMode.IN);
+      Query q1 = spq3.setParameter(1, getUtilDate());
+      try {
+        q1.setParameter(99, utilDate, TemporalType.DATE);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass2 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+    }
+
+    if (!pass1 || !pass2)
+      throw new Exception(
+          "setParameterIntDateTemporalTypeIllegalArgumentExceptionTest failed");
+  }
+
+  /*
+   * @testName: setParameterParameterCalendarTemporalTypeTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1564; PERSISTENCE:SPEC:1576;
+   * 
+   * @test_Strategy:
+   */
+  @SetupMethod(name = "setupEmployee2Data")
+  public void setParameterParameterCalendarTemporalTypeTest() throws Exception {
+    boolean pass2 = false;
+    boolean pass3 = false;
+    boolean pass5 = false;
+    try {
+      logMsg("Testing StoredProcedure");
+      getEntityTransaction().begin();
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq.registerStoredProcedureParameter(1, Calendar.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, Integer.class, ParameterMode.OUT);
+
+      spq.setParameter(1, getCalDate(), TemporalType.DATE);
+      Parameter p = spq.getParameter(1);
+      spq.setParameter(p, calDate, TemporalType.DATE);
+
+      if (!spq.execute()) {
+        Object o = spq.getOutputParameterValue(2);
+        if (o instanceof Integer) {
+          int actual = (Integer) o;
+          if (actual == emp2.getId()) {
+            logTrace("Received expected id:" + actual);
+            pass2 = true;
+          } else {
+                logErr("Expected id: " + emp2.getId() + ", actual:" + actual);
+          }
+
+        } else {
+          logErr("Did not get instance of Integer back:" + o);
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    }
+    try {
+      getEntityTransaction().begin();
+      logMsg("Testing Query object");
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq1.registerStoredProcedureParameter(1, Calendar.class,
+          ParameterMode.IN);
+      spq1.registerStoredProcedureParameter(2, Integer.class,
+          ParameterMode.OUT);
+      spq1.setParameter(1, getCalDate(), TemporalType.DATE);
+      Query q = spq1;
+
+      Parameter p = q.getParameter(1);
+      q.setParameter(p, calDate, TemporalType.DATE);
+      Parameter p2 = q.getParameter(1);
+      if (p.getPosition().equals(p2.getPosition())
+          && p.getParameterType().equals(p2.getParameterType())) {
+        logTrace("Received expected parameter");
+        pass3 = true;
+      } else {
+        logErr("Expected parameter:" + p + ", actual:" + p2);
+      }
+
+      StoredProcedureQuery spq2 = (StoredProcedureQuery) q;
+
+      if (!spq2.execute()) {
+        Object o = spq2.getOutputParameterValue(2);
+        if (o instanceof Integer) {
+          int actual = (Integer) o;
+          if (actual == emp2.getId()) {
+            logTrace("Received expected id:" + actual);
+            pass5 = true;
+          } else {
+                logErr("Expected id: " + emp2.getId() + ", actual:" + actual);
+          }
+
+        } else {
+          logErr("Did not get instance of Integer back:" + o);
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    }
+
+    if (!pass2 || !pass3 || !pass5)
+      throw new Exception("setParameterParameterCalendarTemporalTypeTest failed");
+  }
+
+  /*
+   * @testName:
+   * setParameterParameterCalendarTemporalTypeIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1565;
+   * 
+   * @test_Strategy:
+   */
+  @SetupMethod(name = "setupEmployee2Data")
+  public void setParameterParameterCalendarTemporalTypeIllegalArgumentExceptionTest()
+      throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    try {
+      getEntityTransaction().begin();
+      logTrace("Get parameter from other stored procedure");
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpLastNameFromInOut");
+      spq.registerStoredProcedureParameter(1, String.class,
+          ParameterMode.INOUT);
+      spq.setParameter(1, "INOUT");
+      // Parameter to be used in next StoredProcedure
+      Parameter p = spq.getParameter(1);
+
+      logMsg(
+          "Testing StoredProcedureQuery with parameter specified from another query");
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq1.registerStoredProcedureParameter(1, Calendar.class,
+          ParameterMode.IN);
+      spq1.setParameter(1, getCalDate(), TemporalType.DATE);
+      try {
+        spq1.setParameter(p, getCalDate(), TemporalType.DATE);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass1 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      logMsg(
+          "Testing Query object with parameter specified from another query");
+      StoredProcedureQuery spq3 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq3.registerStoredProcedureParameter(1, Calendar.class,
+          ParameterMode.IN);
+      Query q1 = spq3.setParameter(1, getCalDate());
+      try {
+        q1.setParameter(p, getCalDate(), TemporalType.DATE);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass2 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+    }
+
+    if (!pass1 || !pass2)
+      throw new Exception(
+          "setParameterParameterCalendarTemporalTypeIllegalArgumentExceptionTest failed");
+  }
+
+  /*
+   * @testName: setParameterParameterDateTemporalTypeTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1566;
+   * 
+   * @test_Strategy:
+   */
+  public void setParameterParameterDateTemporalTypeTest() throws Exception {
+    boolean pass2 = false;
+    boolean pass3 = false;
+    boolean pass5 = false;
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq.registerStoredProcedureParameter(1, Date.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, Integer.class, ParameterMode.OUT);
+      spq.setParameter(1, getUtilDate(), TemporalType.DATE);
+
+      Parameter p = spq.getParameter(1);
+      spq.setParameter(p, utilDate, TemporalType.DATE);
+
+      if (!spq.execute()) {
+        Object o = spq.getOutputParameterValue(2);
+        if (o instanceof Integer) {
+          int actual = (Integer) o;
+          if (actual == 1) {
+            logTrace("Received expected id:" + actual);
+            pass2 = true;
+          } else {
+            logErr("Expected id: 1, actual:" + actual);
+          }
+
+        } else {
+          logErr("Did not get instance of Integer back:" + o);
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    }
+    try {
+      getEntityTransaction().begin();
+
+      logMsg("Testing Query object");
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq1.registerStoredProcedureParameter(1, Date.class, ParameterMode.IN);
+      spq1.registerStoredProcedureParameter(2, Integer.class,
+          ParameterMode.OUT);
+      spq1.setParameter(1, getCalDate().getTime(), TemporalType.DATE);
+
+      Query q = spq1;
+
+      // override the previously set parameter
+      Parameter p = q.getParameter(1);
+      q.setParameter(p, utilDate, TemporalType.DATE);
+
+      Parameter p2 = q.getParameter(1);
+      if (p.getPosition().equals(p2.getPosition())
+          && p.getParameterType().equals(p2.getParameterType())) {
+        logTrace("Received expected parameter");
+        pass3 = true;
+      } else {
+        logErr("Expected parameter:" + p + ", actual:" + p2);
+      }
+      StoredProcedureQuery spq2 = (StoredProcedureQuery) q;
+      if (!spq2.execute()) {
+
+        Object o = spq2.getOutputParameterValue(2);
+        if (o instanceof Integer) {
+          int actual = (Integer) o;
+          if (actual == emp0.getId()) {
+            logTrace("Received expected id:" + actual);
+            pass5 = true;
+          } else {
+            logErr("Expected id: 1, actual:" + actual);
+          }
+
+        } else {
+          logErr("Did not get instance of Integer back:" + o);
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Caught exception: ", e);
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    }
+
+    if (!pass2 || !pass3 || !pass5)
+      throw new Exception("setParameterParameterDateTemporalTypeTest failed");
+  }
+
+  /*
+   * @testName:
+   * setParameterParameterDateTemporalTypeIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1567;
+   * 
+   * @test_Strategy:
+   */
+
+  public void setParameterParameterDateTemporalTypeIllegalArgumentExceptionTest()
+      throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    try {
+      getEntityTransaction().begin();
+      logTrace("Get parameter from other stored procedure");
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpLastNameFromInOut");
+      spq.registerStoredProcedureParameter(1, String.class,
+          ParameterMode.INOUT);
+      spq.setParameter(1, "INOUT");
+      // Parameter to be used in next StoredProcedure
+      Parameter p = spq.getParameter(1);
+      logMsg(
+          "Testing StoredProcedureQuery with parameter specified from another query");
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq1.registerStoredProcedureParameter(1, Date.class, ParameterMode.IN);
+      spq1.setParameter(1, getUtilDate(), TemporalType.DATE);
+      try {
+        spq1.setParameter(p, getUtilDate(), TemporalType.DATE);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass1 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      logMsg(
+          "Testing Query object with parameter specified from another query");
+      StoredProcedureQuery spq3 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpIdUsingHireDateFromOut");
+      spq3.registerStoredProcedureParameter(1, Calendar.class,
+          ParameterMode.IN);
+      Query q1 = spq3.setParameter(1, getCalDate());
+      try {
+        q1.setParameter(p, getCalDate(), TemporalType.DATE);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass2 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+
+    } catch (Exception e) {
+      logErr("Caught exception", e);
+    }
+
+    if (!pass1 || !pass2)
+      throw new Exception(
+          "setParameterParameterDateTemporalTypeIllegalArgumentExceptionTest failed");
+  }
+
+  /*
+   * @testName: executeUpdateOfAnUpdateTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1580; PERSISTENCE:JAVADOC:1551;
+   * PERSISTENCE:SPEC:1516; PERSISTENCE:SPEC:1580;
+   * 
+   * @test_Strategy:
+   */
+  public void executeUpdateOfAnUpdateTest() throws Exception {
+    boolean pass = false;
+    try {
+      getEntityTransaction().begin();
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("UpdateEmpSalaryColumn");
+
+      spq.executeUpdate();
+      int updateCount = spq.getUpdateCount();
+      if (updateCount == -1) {
+        logTrace("Received expected update count:" + updateCount);
+        pass = true;
+      } else {
+        logErr("Expected update count: -1, actual:" + updateCount);
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass)
+      throw new Exception("executeUpdateOfAnUpdateTest failed");
+  }
+
+  /*
+   * @testName: executeUpdateOfADeleteTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1580; PERSISTENCE:JAVADOC:1551;
+   * PERSISTENCE:SPEC:1516;
+   * 
+   * @test_Strategy:
+   */
+  public void executeUpdateOfADeleteTest() throws Exception {
+    boolean pass = false;
+    try {
+      getEntityTransaction().begin();
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("DeleteAllEmp");
+      spq.executeUpdate();
+      int updateCount = spq.getUpdateCount();
+      if (updateCount == -1) {
+        logTrace("Received expected update count:" + updateCount);
+        pass = true;
+      } else {
+        logErr("Expected update count: -1, actual:" + updateCount);
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass)
+      throw new Exception("executeUpdateOfADeleteTest failed");
+  }
+
+  /*
+   * @testName: executeUpdateTransactionRequiredExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1582;
+   * 
+   * @test_Strategy:
+   */
+  public void executeUpdateTransactionRequiredExceptionTest() throws Exception {
+    boolean pass = false;
+    try {
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("DeleteAllEmp");
+      try {
+
+            logMsg("IsActive returns:" + getEntityTransaction().isActive());
+        spq.executeUpdate();
+        logErr("Did not throw TransactionRequiredException");
+      } catch (TransactionRequiredException tre) {
+        logTrace("Received expected TransactionRequiredException");
+        pass = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass)
+      throw new Exception("executeUpdateTransactionRequiredExceptionTest failed");
+  }
+
+  /*
+   * @testName: getParameterValueParameterTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1605; PERSISTENCE:JAVADOC:1630;
+   * 
+   * @test_Strategy:
+   */
+  public void getParameterValueParameterTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass3 = false;
+    try {
+      getEntityTransaction().begin();
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq.setParameter(1, 1);
+      Parameter p = spq.getParameter(1);
+      boolean b = spq.isBound(p);
+      if (b == true) {
+        logTrace("Received expected from isBound():" + b);
+        pass1 = true;
+      } else {
+        logErr("Expected result from isBound():true, actual:" + b);
+      }
+      if (!spq.execute()) {
+        p = spq.getParameter(1);
+        Object o = spq.getParameterValue(p);
+        if (o instanceof Integer) {
+          logTrace("Received expected parameter type: Integer");
+          Integer i = (Integer) o;
+          if (i.equals(emp0.getId())) {
+            logTrace("Received expected parameter value:" + i);
+            pass3 = true;
+          } else {
+            logErr("Expected getParameterValue() result: "
+                + emp0.getId() + ", actual:" + i);
+          }
+
+        } else {
+          logErr(
+              "Did not get instance of Integer from getParameterValue():" + o);
+        }
+
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass1 || !pass3)
+      throw new Exception("getParameterValueParameterTest failed");
+
+  }
+
+  /*
+   * @testName: getParameterValueParameterIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1606;
+   * 
+   * @test_Strategy: execute getParameterValue using parameter from different
+   * query
+   */
+  public void getParameterValueParameterIllegalArgumentExceptionTest()
+      throws Exception {
+    boolean pass = false;
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpLastNameFromInOut");
+      spq.registerStoredProcedureParameter(1, String.class,
+          ParameterMode.INOUT);
+      spq.setParameter(1, "1");
+      Parameter p = spq.getParameter(1);
+
+      StoredProcedureQuery spq1 = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq1.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq1.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq1.setParameter(1, 1);
+      try {
+        spq1.getParameterValue(p);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass)
+      throw new Exception(
+          "getParameterValueParameterIllegalArgumentExceptionTest failed");
+
+  }
+
+  /*
+   * @testName: getParameterValueParameterIllegalStateExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1607; PERSISTENCE:JAVADOC:1630;
+   * 
+   * @test_Strategy:
+   */
+  public void getParameterValueParameterIllegalStateExceptionTest()
+      throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    try {
+      getEntityTransaction().begin();
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq.setParameter(1, 1);
+      Parameter p = spq.getParameter(1);
+      boolean b = spq.isBound(p);
+      if (b == true) {
+        logTrace("Received expected from isBound():" + b);
+        pass1 = true;
+      } else {
+        logErr("Expected result from isBound():true, actual:" + b);
+      }
+      Parameter p2 = spq.getParameter(2);
+
+      try {
+        spq.getParameterValue(p2);
+        logErr("Did not throw IllegalStateException");
+      } catch (IllegalStateException iae) {
+        logTrace("Received expected IllegalStateException");
+        pass2 = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass1 || !pass2)
+      throw new Exception(
+          "getParameterValueParameterIllegalStateExceptionTest failed");
+
+  }
+
+  /*
+   * @testName: getParameterValueIntTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1611; PERSISTENCE:SPEC:1572;
+   * 
+   * @test_Strategy:
+   */
+  public void getParameterValueIntTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+    boolean pass3 = false;
+    boolean pass4 = false;
+    try {
+      getEntityTransaction().begin();
+
+      logMsg("Testing createStoredProcedureQuery");
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpLastNameFromInOut");
+      spq.registerStoredProcedureParameter(1, String.class,
+          ParameterMode.INOUT);
+      spq.setParameter(1, "1");
+      Object o = spq.getParameterValue(1);
+      if (o instanceof String) {
+        logTrace("Received expected parameter type: String");
+        String s = (String) o;
+        if (s.equals("1")) {
+          logTrace("Received expected parameter value:" + s);
+          pass1 = true;
+        } else {
+              logErr("Expected getParameterValue() result: 1, actual:" + s);
+        }
+
+      } else {
+        logErr(
+            "Did not get instance of String from getParameterValue():" + o);
+      }
+
+      if (!spq.execute()) {
+        o = spq.getParameterValue(1);
+        if (o instanceof String) {
+          logTrace("Received expected parameter type: String");
+          String s = (String) o;
+          if (s.equals("1")) {
+            logTrace("Received expected parameter value:" + s);
+            pass2 = true;
+          } else {
+                logErr("Expected getParameterValue() result: 1, actual:" + s);
+          }
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    }
+    try {
+      getEntityTransaction().begin();
+
+      logMsg("Testing createNamedStoredProcedureQuery");
+      StoredProcedureQuery spq = getEntityManager()
+          .createNamedStoredProcedureQuery("getemplastnamefrominout");
+      spq.setParameter(1, "1");
+      Object o = spq.getParameterValue(1);
+      if (o instanceof String) {
+        logTrace("Received expected parameter type: String");
+        String s = (String) o;
+        if (s.equals("1")) {
+          logTrace("Received expected parameter value:" + s);
+          pass3 = true;
+        } else {
+		  logErr("Expected getParameterValue() result: 1, actual:" + s);
+        }
+
+      } else {
+        logErr(
+            "Did not get instance of String from getParameterValue():" + o);
+      }
+
+      if (!spq.execute()) {
+        o = spq.getParameterValue(1);
+        if (o instanceof String) {
+          logTrace("Received expected parameter type: String");
+          String s = (String) o;
+          if (s.equals("1")) {
+            logTrace("Received expected parameter value:" + s);
+            pass4 = true;
+          } else {
+			logErr("Expected getParameterValue() result: 1, actual:" + s);
+          }
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+      getEntityTransaction().commit();
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    }
+
+    if (!pass1 || !pass2 || !pass3 || !pass4)
+      throw new Exception("getParameterValueIntTest failed");
+
+  }
+
+  /*
+   * @testName: getParameterValueIntIllegalArgumentExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1613;
+   * 
+   * @test_Strategy:
+   */
+
+  public void getParameterValueIntIllegalArgumentExceptionTest() throws Exception {
+    boolean pass = false;
+    try {
+      getEntityTransaction().begin();
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq.setParameter(1, 1);
+      try {
+        spq.getParameterValue(99);
+        logErr("Did not throw IllegalArgumentException");
+      } catch (IllegalArgumentException iae) {
+        logTrace("Received expected IllegalArgumentException");
+        pass = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass)
+      throw new Exception(
+          "getParameterValueIntIllegalArgumentExceptionTest failed");
+
+  }
+
+  /*
+   * @testName: getParameterValueIntIllegalStateExceptionTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1612;
+   * 
+   * @test_Strategy:
+   */
+  public void getParameterValueIntIllegalStateExceptionTest() throws Exception {
+    boolean pass = false;
+    try {
+      getEntityTransaction().begin();
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq.setParameter(1, 1);
+      try {
+        spq.getParameterValue(2);
+        logErr("Did not throw IllegalStateException");
+      } catch (IllegalStateException iae) {
+        logTrace("Received expected IllegalStateException");
+        pass = true;
+      } catch (Exception e) {
+        logErr("Caught unexpected exception", e);
+      }
+      if (getEntityTransaction().isActive()) {
+        getEntityTransaction().rollback();
+      }
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass)
+      throw new Exception("getParameterValueIntIllegalStateExceptionTest failed");
+
+  }
+
+  /*
+   * @testName: setHintStringObjectTest
+   * 
+   * @assertion_ids: PERSISTENCE:JAVADOC:1560;
+   * 
+   * @test_Strategy: Vendor-specific hints that are not recognized by a provider
+   * must be silently ignored.
+   */
+  public void setHintStringObjectTest() throws Exception {
+    boolean pass = false;
+    try {
+      getEntityTransaction().begin();
+      StoredProcedureQuery spq = getEntityManager()
+          .createStoredProcedureQuery("GetEmpFirstNameFromOut");
+      spq.registerStoredProcedureParameter(1, Integer.class, ParameterMode.IN);
+      spq.registerStoredProcedureParameter(2, String.class, ParameterMode.OUT);
+      spq.setParameter(1, 1);
+      spq.getParameterValue(1);
+      spq.setHint("property.that.is.not.recognized",
+          "property.that.is.not.recognized");
+      spq.execute();
+      getEntityTransaction().commit();
+      pass = true;
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass)
+      throw new Exception("setHintStringObjectTest failed");
+
+  }
+
+  /*
+   * @testName: xmlOverridesNamedStoredProcedureQueryTest
+   * 
+   * @assertion_ids: PERSISTENCE:SPEC:2239; PERSISTENCE:SPEC:2241;
+   * PERSISTENCE:SPEC:2242;
+   * 
+   * @test_Strategy: verify xml overrides NamedStoredProcedureQuery annotation
+   */
+  public void xmlOverridesNamedStoredProcedureQueryTest() throws Exception {
+    boolean pass1 = false;
+    boolean pass2 = false;
+
+    try {
+
+      StoredProcedureQuery spq = getEntityManager()
+          .createNamedStoredProcedureQuery("tobeoverridden1");
+      spq.setParameter(1, 1);
+      Object o = spq.getParameterValue(1);
+      if (o instanceof Integer) {
+        logTrace("Received expected parameter type: Integer");
+        Integer i = (Integer) o;
+        if (i.equals(1)) {
+          logTrace("Received expected parameter value:" + i);
+          pass1 = true;
+        } else {
+              logErr("Expected getParameterValue() result: 1, actual:" + i);
+        }
+
+      } else {
+        logErr(
+            "Did not get instance of Integer from getParameterValue():" + o);
+      }
+
+      if (!spq.execute()) {
+        o = spq.getOutputParameterValue(2);
+        if (o instanceof String) {
+          logTrace("Received expected parameter type: String");
+          String s = (String) o;
+          if (s.equals(emp0.getFirstName())) {
+            logTrace("Received expected parameter value:" + s);
+            pass2 = true;
+          } else {
+            logErr("Expected getParameterValue() result: "
+                + emp0.getFirstName() + ", actual:" + s);
+          }
+        }
+      } else {
+        logErr("Expected execute() to return false, actual: true");
+      }
+    } catch (Exception e) {
+      logErr("Unexpected exception occurred", e);
+    }
+
+    if (!pass1 || !pass2)
+      throw new Exception("xmlOverridesNamedStoredProcedureQueryTest failed");
+
+  }
+
+  /*
+   * @testName: xmlOverridesSqlResultSetMappingAnnotationTest
+   * 
+   * @assertion_ids: PERSISTENCE:SPEC:2243; PERSISTENCE:SPEC:2245;
+   * PERSISTENCE:SPEC:2246;
+   * 
+   * @test_Strategy: verify xml overrides SqlResultSetMapping annotation
+   *
+   */
+  public void xmlOverridesSqlResultSetMappingAnnotationTest() throws Exception {
+    boolean pass = false;
+    try {
+      getEntityTransaction().begin();
+      try {
+        logMsg("Testing using name,result mapping");
+        clearCache();
+        StoredProcedureQuery spq = getEntityManager()
+            .createStoredProcedureQuery("GetEmpIdFNameLNameFromRS",
+                "tobeoverridden2");
+        spq.registerStoredProcedureParameter(1, Integer.class,
+            ParameterMode.IN);
+        if (dataBaseName.equalsIgnoreCase(ORACLE)
+            || dataBaseName.equalsIgnoreCase(POSTGRESQL)) {
+          logTrace("register refcursor parameter");
+          spq.registerStoredProcedureParameter(2, void.class,
+              ParameterMode.REF_CURSOR);
+        }
+        spq.setParameter(1, 1);
+        if (spq.execute()) {
+
+          List<List> listOfList = getResultSetsFromStoredProcedure(spq);
+          if (listOfList.size() == 1) {
+            List<Employee> expected = new ArrayList<Employee>();
+            expected.add(new Employee(emp0.getId(), emp0.getFirstName(),
+                emp0.getLastName()));
+            pass = verifyListOfListEmployees(expected, listOfList);
+          } else {
+            logErr(
+                "Did not get the correct number of result sets returned, expected: 1, actual:"
+                    + listOfList.size());
+          }
+        } else {
+          logErr("Expected execute() to return true, actual: false");
+        }
+      } catch (Exception ex) {
+        logErr("Received unexpected exception:", ex);
+      }
+
+      getEntityTransaction().commit();
+
+    } catch (Exception ex) {
+      logErr("Received unexpected exception:", ex);
+    }
+
+    if (!pass) {
+      throw new Exception("xmlOverridesSqlResultSetMappingAnnotationTest failed");
+    }
+
+  }
 
 	private void createEmployeeTestData() {
 

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client2.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client2.java
@@ -476,44 +476,4 @@ public class Client2 extends Client {
 			throw new Exception("setParameterParameterCalendarTemporalTypeIllegalArgumentExceptionTest failed");
 	}
 
-	private void createEmployee2TestData() {
-
-		try {
-			getEntityTransaction().begin();
-
-			logMsg( "Creating Employee2");
-
-			final Calendar d2 = getCalDate(2001, 06, 27);
-			final Calendar d3 = getCalDate(2002, 07, 07);
-			final Calendar d4 = getCalDate(2003, 03, 03);
-			final Calendar d5 = getCalDate();
-
-			emp2 = new Employee2(1, "Alan", "Frechette", calDate, (float) 35000.0);
-			empRef2.add(emp2);
-			empRef2.add(new Employee2(2, "Arthur", "Frechette", d2, (float) 35000.0));
-			empRef2.add(new Employee2(3, "Shelly", "McGowan", d3, (float) 50000.0));
-			empRef2.add(new Employee2(4, "Robert", "Bissett", d4, (float) 55000.0));
-			empRef2.add(new Employee2(5, "Stephen", "DMilla", d5, (float) 25000.0));
-			for (Employee2 e : empRef2) {
-				if (e != null) {
-					getEntityManager().persist(e);
-					logTrace( "persisted Employee2:" + e);
-				}
-			}
-
-			getEntityManager().flush();
-			getEntityTransaction().commit();
-		} catch (Exception e) {
-			logErr( "Unexpected exception occurred", e);
-		} finally {
-			try {
-				if (getEntityTransaction().isActive()) {
-					getEntityTransaction().rollback();
-				}
-			} catch (Exception fe) {
-				logErr( "Unexpected exception rolling back TX:", fe);
-			}
-		}
-	}
-
 }

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client2.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/basic/Client2.java
@@ -36,7 +36,7 @@ public class Client2 extends Client {
 	}
 
 	
-	public void setupData(String[] args, Properties p) throws Exception {
+	public void setup(String[] args, Properties p) throws Exception {
 		logTrace( "setupData");
 		try {
 			super.setup(args,p);

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
@@ -33,7 +33,7 @@ public class Client2 extends Client {
 		s.exit();
 	}
 
-	public void setupShortData(String[] args, Properties p) throws Exception {
+	public void setup(String[] args, Properties p) throws Exception {
 		logTrace( "setupShortData");
 		try {
 			super.setup(args,p);

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3.java
@@ -33,7 +33,7 @@ public class Client3 extends Client {
 		s.exit();
 	}
 
-	public void setupLongData(String[] args, Properties p) throws Exception {
+	public void setup(String[] args, Properties p) throws Exception {
 		logTrace( "setupLongData");
 		try {
 			super.setup(args,p);

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4.java
@@ -35,8 +35,7 @@ public class Client4 extends Client {
 		s.exit();
 	}
 
-
-	public void setupTimestampData(String[] args, Properties p) throws Exception {
+	public void setup(String[] args, Properties p) throws Exception {
 		logTrace( "setupTimestampData");
 		try {
 			super.setup(args,p);

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client1.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client1.java
@@ -23,6 +23,7 @@ package ee.jakarta.tck.persistence.core.query.flushmode;
 
 import java.util.List;
 
+import com.sun.ts.lib.harness.SetupMethod;
 import com.sun.ts.lib.harness.Status;
 import ee.jakarta.tck.persistence.common.schema30.Util;
 
@@ -60,7 +61,8 @@ public class Client1 extends Util {
 	 * updated name.*
 	 *
 	 */
-		public void flushModeTest1() throws Exception {
+	@SetupMethod(name = "setupCustomerData")
+	public void flushModeTest1() throws Exception {
 		boolean pass1 = false;
 		boolean pass2 = false;
 		boolean pass3 = false;

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client2.java
@@ -24,6 +24,7 @@ package ee.jakarta.tck.persistence.core.query.flushmode;
 import java.util.List;
 import java.util.Vector;
 
+import com.sun.ts.lib.harness.SetupMethod;
 import com.sun.ts.lib.harness.Status;
 import ee.jakarta.tck.persistence.common.schema30.Util;
 
@@ -56,6 +57,7 @@ public class Client2 extends Util {
 	 * customer used in the setCustomer call.
 	 * 
 	 */
+		@SetupMethod(name = "setupOrderData")
 		public void flushModeTest2() throws Exception {
 		boolean pass = false;
 		String expectedPKs[];
@@ -99,7 +101,8 @@ public class Client2 extends Util {
 	 * updates the name of a customer. It then executes an EJBQL query selecting
 	 * orders where the related customer has the updated name.
 	 */
-		public void flushModeTest3() throws Exception {
+	@SetupMethod(name = "setupOrderData")
+	public void flushModeTest3() throws Exception {
 		boolean pass = false;
 		String expectedPKs[];
 		List o;
@@ -143,7 +146,8 @@ public class Client2 extends Util {
 	 * name of the new spouse.
 	 *
 	 */
-		public void flushModeTest4() throws Exception {
+	@SetupMethod(name = "setupOrderData")
+	public void flushModeTest4() throws Exception {
 		boolean pass = false;
 		String expectedPKs[];
 
@@ -190,7 +194,8 @@ public class Client2 extends Util {
 	 * selecting orders where the related spouse of the related customer has the
 	 * updated name.
 	 */
-		public void flushModeTest5() throws Exception {
+	@SetupMethod(name = "setupOrderData")
+	public void flushModeTest5() throws Exception {
 		boolean pass = false;
 		String expectedPKs[];
 
@@ -232,7 +237,8 @@ public class Client2 extends Util {
 	 * executes an EJBQL query selecting customers having an order with the removed
 	 * number.
 	 */
-		public void flushModeTest6() throws Exception {
+	@SetupMethod(name = "setupOrderData")
+	public void flushModeTest6() throws Exception {
 		boolean pass = false;
 		String expectedPKs[];
 
@@ -282,7 +288,8 @@ public class Client2 extends Util {
 	 * executes an EJBQL query selecting a spouse whose customer has an order with
 	 * an credit card having the new number.
 	 */
-		public void flushModeTest7() throws Exception {
+	@SetupMethod(name = "setupOrderData")
+	public void flushModeTest7() throws Exception {
 		boolean pass = false;
 		String[] expected = new String[1];
 		expected[0] = "2";

--- a/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client3.java
+++ b/jpa/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/flushmode/Client3.java
@@ -23,6 +23,7 @@ package ee.jakarta.tck.persistence.core.query.flushmode;
 
 import java.util.List;
 
+import com.sun.ts.lib.harness.SetupMethod;
 import com.sun.ts.lib.harness.Status;
 import ee.jakarta.tck.persistence.common.schema30.Util;
 
@@ -47,6 +48,7 @@ public class Client3 extends Util {
 	 * 
 	 * @test_Strategy:
 	 */
+	@SetupMethod(name = "setupProductData")
 		public void secondaryTablesValueTest() throws Exception {
 		boolean pass = false;
 


### PR DESCRIPTION
This fixes another 36 tests that were not calling the setup method.
Down to 124 test failures.
