### PR TITLE
Add persistence configuration to fix StoredProc tests

### DIFF
--- a/glassfish-runner/persistence-platform-tck/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/pom.xml
@@ -35,8 +35,10 @@
         <!-- <glassfish.version>8.0.0-M5</glassfish.version> -->
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
-        <glassfish.version>8.0.0-SNAPSHOT</glassfish.version>
+        <glassfish.version>8.0.0-JDK17-M5</glassfish.version>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
+        <jdbc.classpath>${project.build.directory}/${glassfish.toplevel.dir}/javadb/lib/derbyclient.jar:${project.build.directory}/${glassfish.toplevel.dir}/javadb/lib/derbyshared.jar:${project.build.directory}/${glassfish.toplevel.dir}/javadb/lib/derbytools.jar</jdbc.classpath>
+        <jdbc.url>jdbc:derby://localhost:1527/derbyDB;create=true</jdbc.url>
 
         <junit.jupiter.version>5.11.3</junit.jupiter.version>
         <tck.artifactId>persistence-platform-tck-tests</tck.artifactId>
@@ -379,7 +381,7 @@
                         </goals>
                         <phase>pre-integration-test</phase>
                         <configuration>
-                            <executable>target/glassfish8/glassfish/bin/asadmin</executable>
+                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>start-database</argument>
                             </arguments>
@@ -393,7 +395,7 @@
                         </goals>
                         <phase>post-integration-test</phase>
                         <configuration>
-                            <executable>target/glassfish8/glassfish/bin/asadmin</executable>
+                            <executable>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/bin/asadmin</executable>
                             <arguments>
                                 <argument>stop-database</argument>
                             </arguments>
@@ -418,17 +420,18 @@
                         <phase>pre-integration-test</phase>
                         <configuration>
                             <target>
-                                <path id="jdbc.classpath">
+                                <!-- <path id="jdbc.classpath">
                                     <pathelement path="target/glassfish8/javadb/lib/derbyclient.jar"></pathelement>
                                     <path refid="maven.runtime.classpath"></path>
-                                </path>
-                                <sql autocommit="true" classpathref="jdbc.classpath" delimiter=";" driver="org.apache.derby.jdbc.ClientDriver" onerror="continue" password="cts1" url="jdbc:derby://localhost:1527/derbyDB" userid="cts1">
-                                    <transaction src="sql/derby/derby.ddl.persistence.sql"></transaction>
+                                </path> -->
+                                <sql autocommit="true" classpath="${jdbc.classpath}" delimiter=";" driver="org.apache.derby.jdbc.ClientDriver" onerror="continue" password="cts1" url="${jdbc.url}" userid="cts1">
                                     <transaction src="sql/derby/derby.ddl.persistence.sprocs.sql"></transaction>
+                                    <transaction src="sql/derby/derby.ddl.sql"></transaction>
                                 </sql>
                             </target>
                         </configuration>
                     </execution>
+
                 </executions>
             </plugin>
 
@@ -440,11 +443,11 @@
                     <dependenciesToScan>jakarta.tck:persistence-platform-tck-tests</dependenciesToScan>
 
                     <systemPropertyVariables>
-                        <glassfish.enableDerby>true</glassfish.enableDerby>
+                        <!-- <glassfish.enableDerby>true</glassfish.enableDerby>
                         <glassfish.derbyDatabaseName>${glassfish.home}/glassfish/domains/domain1/config/derbyDB;create=true</glassfish.derbyDatabaseName>
                         <glassfish.derbySQLFile>${basedir}/sql/derby/derby.ddl.sql</glassfish.derbySQLFile>
                         <glassfish.derbyUser>cts1</glassfish.derbyUser>
-                        <glassfish.derbyPasswordFile>${basedir}/sql/derby/password.txt</glassfish.derbyPasswordFile>
+                        <glassfish.derbyPasswordFile>${basedir}/sql/derby/password.txt</glassfish.derbyPasswordFile> -->
 
                         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
                         <glassfish.postBootCommands>set server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true

--- a/glassfish-runner/persistence-platform-tck/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/pom.xml
@@ -453,9 +453,9 @@
                         <glassfish.postBootCommands>set server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true
                             create-file-user --groups guest --passwordfile ${project.basedir}/javajoe.pass javajoe
                             create-file-user --groups staff:mgr --passwordfile ${project.basedir}/j2ee.pass j2ee
-                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=${glassfish.home}/glassfish/domains/domain1/config/derbyDB:serverName=localhost:portNumber=1527:user=cts1:password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool
-                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=${glassfish.home}/glassfish/domains/domain1/config/derbyDB:serverName=localhost:PortNumber=1527:User=cts1:Password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool_no_tx
+                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=derbyDB:serverName=localhost:PortNumber=1527:User=cts1:Password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool
                             create-jdbc-resource --connectionpoolid cts-derby-pool jdbc/DB1
+                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=derbyDB:serverName=localhost:PortNumber=1527:User=cts1:Password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool_no_tx
                             create-jdbc-resource --connectionpoolid cts-derby-pool_no_tx jdbc/DB_no_tx
                             list-jdbc-connection-pools
                             list-jdbc-resources

--- a/glassfish-runner/persistence-platform-tck/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/pom.xml
@@ -36,8 +36,15 @@
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
         <glassfish.version>8.0.0-JDK17-M5</glassfish.version>
+        <jakarta.persistence.jdbc.driver>org.apache.derby.jdbc.ClientDriver</jakarta.persistence.jdbc.driver>
+        <jakarta.persistence.jdbc.password>cts1</jakarta.persistence.jdbc.password>
+        <jakarta.persistence.jdbc.url>jdbc:derby://localhost:1527/derbyDB;create=true</jakarta.persistence.jdbc.url>
+        <jakarta.persistence.jdbc.user>cts1</jakarta.persistence.jdbc.user>
+        <jakarta.persistence.provider>org.eclipse.persistence.jpa.PersistenceProvider</jakarta.persistence.provider>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
+        <javadb.lib>${glassfish.home}/javadb/lib</javadb.lib>
         <jdbc.classpath>${project.build.directory}/${glassfish.toplevel.dir}/javadb/lib/derbyclient.jar:${project.build.directory}/${glassfish.toplevel.dir}/javadb/lib/derbyshared.jar:${project.build.directory}/${glassfish.toplevel.dir}/javadb/lib/derbytools.jar</jdbc.classpath>
+        <jdbc.driver.classes>${javadb.lib}/derbyclient.jar:${javadb.lib}/derbyshared.jar:${javadb.lib}/derbytools.jar</jdbc.driver.classes>
         <jdbc.url>jdbc:derby://localhost:1527/derbyDB;create=true</jdbc.url>
 
         <junit.jupiter.version>5.11.3</junit.jupiter.version>
@@ -364,6 +371,13 @@
                                     <outputDirectory>${project.build.directory}/lib</outputDirectory>
                                     <destFileName>arquillian-protocol-lib.jar</destFileName>
                                 </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>dbprocedures</artifactId>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <destFileName>dbprocedures.jar</destFileName>
+                                </artifactItem>
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -428,6 +442,25 @@
                                     <transaction src="sql/derby/derby.ddl.persistence.sprocs.sql"></transaction>
                                     <transaction src="sql/derby/derby.ddl.sql"></transaction>
                                 </sql>
+                            </target>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>install_java_procedures</id>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <phase>pre-integration-test</phase>
+                        <configuration>
+                            <target>
+                                <path id="jdbc.classpath">
+                                    <pathelement path="${jdbc.driver.classes}"></pathelement>
+                                    <path refid="maven.runtime.classpath"></path>
+                                </path>
+                                <sql autocommit="true" classpath="${jdbc.classpath}" driver="${jakarta.persistence.jdbc.driver}" onerror="continue" password="${jakarta.persistence.jdbc.password}" url="${jakarta.persistence.jdbc.url}" userid="${jakarta.persistence.jdbc.user}">CALL sqlj.remove_jar('APP.dbprocedures', 0);
+                                            CALL sqlj.install_jar('${project.build.directory}/dbprocedures.jar', 'APP.dbprocedures', 0);
+                                            CALL SYSCS_UTIL.SYSCS_SET_DATABASE_PROPERTY('derby.database.classpath', 'APP.dbprocedures');</sql>
                             </target>
                         </configuration>
                     </execution>


### PR DESCRIPTION
**Describe the change**
Possible fix for https://github.com/jakartaee/platform-tck/issues/1716 

Test run command used : `mvn clean test-compile pre-integration-test failsafe:integration-test@jta-tests-javatest | tee run.log` 

```
[INFO] Results:
[INFO] 
[ERROR] Errors: 
[ERROR]   Client1PmservletTest.getSingleResultOrNullWithNullTest »  Test case throws exception: getSingleResultOrNullWithNullTest failed
[INFO] 
[ERROR] Tests run: 36, Failures: 0, Errors: 1, Skipped: 0
[INFO] 
```


Please squash merge if looks ok.  