### PR TITLE
clean up after messaging createSharedDurableConsumerTest2 test

### DIFF
--- a/jms/src/main/java/com/sun/ts/tests/jms/core20/jmscontexttopictests/Client.java
+++ b/jms/src/main/java/com/sun/ts/tests/jms/core20/jmscontexttopictests/Client.java
@@ -1364,6 +1364,7 @@ public class Client extends ServiceEETest {
           consumer.close();
         if (consumer2 != null)
           consumer2.close();
+        cleanupSubscription(consumer2, context2, durableSubscriptionName);
       } catch (Exception e) {
         TestUtil.logErr("Caught unexpected exception: " + e);
       }


### PR DESCRIPTION
**Fixes Issue**
There was an issue with the createSharedDurableConsumerTest2 test. There was a [suspicion](https://github.com/jakartaee/platform-tck/issues/1495#issuecomment-2498030443), that it will be an issue with cleanup.
```
12-23-2024 12:27:43:  SVR: Create shared Durable Subscription and 1st JMSConsumer with message selector
12-23-2024 12:27:43:  SVR: Create 2nd JMSConsumer with message selector
12-23-2024 12:27:43:  SVR: Send 3 messages to Topic
12-23-2024 12:27:43:  SVR: Message 1 sent
12-23-2024 12:27:43:  SVR: Message 2 sent
12-23-2024 12:27:43:  SVR: Message 3 sent
12-23-2024 12:27:43:  SVR: Receive TextMessage from consumer1
12-23-2024 12:27:43:  SVR: Check the value in TextMessage
12-23-2024 12:27:43:  SVR-ERROR: TextMessage is incorrect expected Message 3, received For new topic
12-23-2024 12:27:43:  SVR-ERROR: Test case throws exception: createSharedDurableConsumerTest2 failed
12-23-2024 12:27:43:  SVR-ERROR: Exception at:
12-23-2024 12:27:43:  SVR-ERROR: java.lang.Exception: createSharedDurableConsumerTest2 failed
        at com.sun.ts.tests.jms.core20.jmscontexttopictests.Client.createSharedDurableConsumerTest2(Client.java:1373)
        at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:103)
        at java.base/java.lang.reflect.Method.invoke(Method.java:580)
```
After doing the cleanup (influencing another run with different vehicle), this test passes
```
[INFO] Tests run: 1578, Failures: 0, Errors: 0, Skipped: 0
```

**Describe the change**
I used the same cleanup as it is used in many other tests.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
