### PR TITLE
Propagate ts.home from Maven to Arquillian Tests in Glassfish Messaging Runner

### DIFF
--- a/glassfish-runner/messaging-platform-tck/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/pom.xml
@@ -104,7 +104,7 @@
         <sql.directory>./sql</sql.directory>
         <tck.artifactId>jms</tck.artifactId>
         <tck.version>11.0.0-SNAPSHOT</tck.version>
-        <ts.home>./jakartaeetck/</ts.home>
+        <ts.home>./jakartaeetck</ts.home>
         <user1>cts1</user1>
         <user2>cts1</user2>
         <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
@@ -812,6 +812,7 @@
                                 <java.io.tmpdir>/tmp</java.io.tmpdir>
                                 <project.basedir>${project.basedir}</project.basedir>
                                 <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                                <ts.home>${ts.home}</ts.home>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -860,6 +861,7 @@
                                 <cts.harness.debug>true</cts.harness.debug>
                                 <java.io.tmpdir>/tmp</java.io.tmpdir>
                                 <arquillian.xml>arquillian.xml</arquillian.xml>
+                                <ts.home>${ts.home}</ts.home>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>


### PR DESCRIPTION
**Fixes Issue**
When running messaging TCK in the glassfish runner, some tests reported this error:
```
java.lang.IllegalStateException: java.io.FileNotFoundException: ${ts.home}/bin/certificates/clientcert.jks (No such file or directory)
```

**Describe the change**
The problem was in unresolved `ts.home`. This PR adds it to the test from Maven variable to the test system properties.

The total amount of errors decreased from 1932 to 1494. Old summary:
```
    <completed>3510</completed>
    <errors>1932</errors>
    <failures>0</failures>
    <skipped>0</skipped>
```
vs after this change (including the previous [clean up PR](https://github.com/jakartaee/platform-tck/pull/1718)):
```
    <completed>3510</completed>
    <errors>1494</errors>
    <failures>0</failures>
    <skipped>0</skipped>
```


**Additional context**
Just run `mvn clean install` in `platform-tck/glassfish-runner/messaging-platform-tck`. I used Java 21.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
