### PR TITLE
Java 24 in core profile fails with java.lang.UnsupportedOperationException: No access to RETAIN_CLASS_REFERENCE #1735

### DIFF
--- a/tcks/profiles/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/common/Utils.java
+++ b/tcks/profiles/core-profile-tck/tck/src/main/java/ee/jakarta/tck/core/common/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) "2022" Red Hat and others
+ * Copyright (c) "2022", "2025" Red Hat and others
  *
  * This program and the accompanying materials are made available under the
  * Apache Software License 2.0 which is available at:
@@ -17,7 +17,7 @@ import java.util.Stack;
 public class Utils {
     private static final Stack<String> callStack = new Stack<>();
     public static void pushMethod() {
-        StackWalker walker = StackWalker.getInstance();
+        StackWalker walker = StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE);
         Optional<String> methodName = walker.walk(frames -> frames
                 .skip(1)
                 .findFirst()
@@ -25,7 +25,11 @@ public class Utils {
         callStack.push(methodName.get());
     }
     private static String getMethodInfo(StackWalker.StackFrame frame) {
-        return frame.getMethodName() + frame.getDescriptor();
+        try {
+            return frame.getMethodName() + frame.getDescriptor();
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Cannot access frame: " + frame, e);
+        }
     }
     public static String popStack() {
         return callStack.pop();


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/1735

**Describe the change**
It requires the option StackWalker.getInstance(StackWalker.Option.RETAIN_CLASS_REFERENCE)

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
