### PR TITLE
Give arquillian modules their own parent

### DIFF
--- a/arquillian/appclient/pom.xml
+++ b/arquillian/appclient/pom.xml
@@ -1,31 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
-    <!-- Model Version -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"><!-- Model Version -->
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Parent -->
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>tck.arquillian.parent</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Artifact Configuration -->
     <groupId>jakarta.tck.arquillian</groupId>
     <artifactId>arquillian-protocol-appclient</artifactId>
+
     <name>Arquillian Protocol AppClient</name>
     <description>Protocol handler for communicating using console output</description>
 
-    <!-- Properties -->
-    <properties>
-        <!-- Versioning -->
-    </properties>
-
-    <!-- Dependencies -->
     <dependencies>
-
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-common</artifactId>
@@ -62,5 +52,4 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
-
 </project>

--- a/arquillian/common/pom.xml
+++ b/arquillian/common/pom.xml
@@ -1,31 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
-    <!-- Model Version -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"><!-- Model Version -->
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Parent -->
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>tck.arquillian.parent</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Artifact Configuration -->
     <groupId>jakarta.tck.arquillian</groupId>
     <artifactId>arquillian-protocol-common</artifactId>
+
     <name>Arquillian Protocol Common</name>
     <description>Common classes used by the protocols</description>
 
-    <!-- Properties -->
-    <properties>
-        <!-- Versioning -->
-    </properties>
-
-    <!-- Dependencies -->
     <dependencies>
-
         <dependency>
             <groupId>org.jboss.arquillian.test</groupId>
             <artifactId>arquillian-test-spi</artifactId>

--- a/arquillian/javatest/pom.xml
+++ b/arquillian/javatest/pom.xml
@@ -1,34 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
-    <!-- Model Version -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Parent -->
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>tck.arquillian.parent</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Artifact Configuration -->
     <groupId>jakarta.tck.arquillian</groupId>
     <artifactId>arquillian-protocol-javatest</artifactId>
+
     <name>Arquillian Protocol JavaTest</name>
     <description>Protocol handler for communicating JavaTest CTS Vehicles</description>
 
-    <!-- Properties -->
-    <properties>
-        <!-- Versioning -->
-        <ee.tck.version>11.0.0-SNAPSHOT</ee.tck.version>
-        <!-- There are post SE 11 language features used -->
-        <maven.compiler.release>17</maven.compiler.release>
-    </properties>
-
-    <!-- Dependencies -->
     <dependencies>
-
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-common</artifactId>
@@ -56,7 +43,6 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-spi</artifactId>
-            <version>${shrinkwrap.descriptors.version}</version>
             <scope>compile</scope>
         </dependency>
 

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -1,20 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
-    <!-- Model Version -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"><!-- Model Version -->
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Parent -->
     <parent>
-        <groupId>jakarta.tck</groupId>
+        <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>1.0.9</version>
+        <relativePath />
     </parent>
 
     <!-- Artifact Configuration -->
     <groupId>jakarta.tck</groupId>
     <artifactId>tck.arquillian.parent</artifactId>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
+
     <name>Arquillian Jakarta TCK Parent</name>
     <description>Protocols and testenrichers for Jakarta TCKs</description>
 
@@ -27,18 +27,62 @@
     </modules>
 
     <scm>
-        <connection>scm:git:https://github.com/eclipse-ee4j/jakartaee-tck-tools</connection>
-        <developerConnection>scm:git:https://github.com/eclipse-ee4j/jakartaee-tck-tools</developerConnection>
+        <connection>scm:git:https://github.com/jakartaee/platform-tck</connection>
+        <developerConnection>scm:git:https://github.com/jakartaee/platform-tck</developerConnection>
         <tag>master</tag>
-        <url>https://github.com/eclipse-ee4j/jakartaee-tck-tools/tools/arquillian</url>
+        <url>http://github.com/jakartaee/platform-tck</url>
     </scm>
 
-    <!-- Properties -->
     <properties>
-
         <maven.compiler.release>17</maven.compiler.release>
-        <!-- Versioning -->
-        <version.arquillian_core>1.9.1.Final</version.arquillian_core>
+        <ee.tck.version>11.0.0-M2</ee.tck.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.9.1.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.jboss.shrinkwrap</groupId>
+                <artifactId>shrinkwrap-bom</artifactId>
+                <version>2.0.0-beta-2</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.descriptors</groupId>
+                <artifactId>shrinkwrap-descriptors-bom</artifactId>
+                <version>2.0.0</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            
+             <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-depchain</artifactId>
+                <version>3.1.1</version>
+                <type>pom</type>
+            </dependency>
+
+            <dependency>
+                <groupId>org.jboss.shrinkwrap.resolver</groupId>
+                <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+                <version>3.1.1</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+    <dependencies>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.11.3</version>
+        </dependency>
+    </dependencies>
 </project>

--- a/arquillian/porting-lib/pom.xml
+++ b/arquillian/porting-lib/pom.xml
@@ -1,31 +1,21 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
-    <!-- Model Version -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Parent -->
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>tck.arquillian.parent</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Artifact Configuration -->
     <groupId>jakarta.tck.arquillian</groupId>
     <artifactId>tck-porting-lib</artifactId>
+
     <name>Jakarta TCK Porting Lib Common</name>
     <description>Arquillian SPI classes used vendors to add implementation details</description>
 
-    <!-- Properties -->
-    <properties>
-        <!-- Versioning -->
-    </properties>
-
-    <!-- Dependencies -->
     <dependencies>
-
         <dependency>
             <groupId>org.jboss.arquillian.test</groupId>
             <artifactId>arquillian-test-spi</artifactId>
@@ -35,5 +25,4 @@
             <artifactId>arquillian-container-spi</artifactId>
         </dependency>
     </dependencies>
-
 </project>

--- a/arquillian/protocol-lib/pom.xml
+++ b/arquillian/protocol-lib/pom.xml
@@ -1,28 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
-    <!-- Model Version -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"><!-- Model Version -->
     <modelVersion>4.0.0</modelVersion>
 
-    <!-- Parent -->
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>tck.arquillian.parent</artifactId>
         <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <!-- Artifact Configuration -->
     <groupId>jakarta.tck.arquillian</groupId>
     <artifactId>arquillian-protocol-lib</artifactId>
+
     <name>Arquillian Protocol Lib</name>
 
-    <properties>
-        <!-- Versioning -->
-        <ee.tck.version>11.0.0-SNAPSHOT</ee.tck.version>
-    </properties>
-
-    <!-- Dependencies -->
     <dependencies>
         <dependency>
             <groupId>jakarta.tck</groupId>
@@ -38,13 +29,12 @@
 
     <build>
         <plugins>
-            <plugin>
-                <!-- TODO: either make a proper artifact or define this as a setup requirement
-        in the TCK user guide.
+            <plugin><!-- TODO: either make a proper artifact or define this as a setup requirement
+                     in the TCK user guide.
 
-        This combines the TCK vehicle related classes into a protocol.jar that is
-         included in the test deployments by the JavaTestDeploymentPackager class.
-         -->
+                     This combines the TCK vehicle related classes into a protocol.jar that is
+                     included in the test deployments by the JavaTestDeploymentPackager class.
+                -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.6.1</version>


### PR DESCRIPTION
That way we can more easily release these for consumption by TCKs outside the platform TCK project.

Additionally the advantage is that the huge amount of dependencies and settings in the parent will not be on the path of arquillian now.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
