### PR TITLE
Fix entityManagerFactoryCloseExceptions.ClientPmservletTest

### DIFF
--- a/glassfish-runner/persistence-platform-tck/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/pom.xml
@@ -467,7 +467,7 @@
                         </goals>
                         <configuration>
                             <includes>
-                                <include>ee/jakarta/tck/persistence/core/StoredProcedureQuery/Client1PmservletTest.java</include>
+                                <include>ee/jakarta/tck/persistence/**/*Test.java</include>
                             </includes>
                             <groups>tck-javatest</groups>
 

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/ClientPmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/ClientPmservletTest.java
@@ -1,16 +1,28 @@
 package ee.jakarta.tck.persistence.core.entityManagerFactoryCloseExceptions;
 
-import ee.jakarta.tck.persistence.core.entityManagerFactoryCloseExceptions.Client;
+import com.sun.ts.lib.harness.EETest;
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.tests.common.vehicle.VehicleClient;
+import com.sun.ts.tests.common.vehicle.VehicleRunnable;
+import com.sun.ts.tests.common.vehicle.VehicleRunnerFactory;
+import com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareBaseBean;
+import com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareIF;
+import com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper;
+import com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper;
+import com.sun.ts.tests.common.vehicle.ejb3share.UseEntityManager;
+import com.sun.ts.tests.common.vehicle.ejb3share.UseEntityManagerFactory;
+import com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper;
+import com.sun.ts.tests.common.vehicle.pmservlet.PMServletVehicle;
+import com.sun.ts.tests.common.vehicle.servlet.ServletVehicle;
+
 import java.net.URL;
+
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.OverProtocol;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -19,131 +31,129 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
-
 
 @ExtendWith(ArquillianExtension.class)
 @Tag("persistence")
 @Tag("platform")
 @Tag("web")
 @Tag("tck-javatest")
-
 @TestMethodOrder(MethodOrderer.MethodName.class)
-public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityManagerFactoryCloseExceptions.Client {
+public class ClientPmservletTest extends Client {
+
+    private static final long serialVersionUID = 1L;
     static final String VEHICLE_ARCHIVE = "jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle";
 
-        /**
-        EE10 Deployment Descriptors:
-        jpa_core_entityManagerFactoryCloseException: META-INF/persistence.xml
-        jpa_core_entityManagerFactoryCloseException_appmanaged_vehicle_client: META-INF/application-client.xml
-        jpa_core_entityManagerFactoryCloseException_appmanaged_vehicle_ejb: jar.sun-ejb-jar.xml
-        jpa_core_entityManagerFactoryCloseException_appmanagedNoTx_vehicle_client: META-INF/application-client.xml
-        jpa_core_entityManagerFactoryCloseException_appmanagedNoTx_vehicle_ejb: jar.sun-ejb-jar.xml
-        jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web: WEB-INF/web.xml
-        jpa_core_entityManagerFactoryCloseException_puservlet_vehicle_web: WEB-INF/web.xml
-        jpa_core_entityManagerFactoryCloseException_stateful3_vehicle_client: META-INF/application-client.xml
-        jpa_core_entityManagerFactoryCloseException_stateful3_vehicle_ejb: jar.sun-ejb-jar.xml
-        jpa_core_entityManagerFactoryCloseException_stateless3_vehicle_client: META-INF/application-client.xml
-        jpa_core_entityManagerFactoryCloseException_stateless3_vehicle_ejb: jar.sun-ejb-jar.xml
-        jpa_core_entityManagerFactoryCloseException_vehicles: 
-
-        Found Descriptors:
-        War:
-
-        /com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml
-        Ear:
-
-        */
-        @TargetsContainer("tck-javatest")
-        @OverProtocol("javatest")
-        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
-        public static EnterpriseArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+    /**
+     * EE10 Deployment Descriptors: jpa_core_entityManagerFactoryCloseException: META-INF/persistence.xml
+     * jpa_core_entityManagerFactoryCloseException_appmanaged_vehicle_client: META-INF/application-client.xml
+     * jpa_core_entityManagerFactoryCloseException_appmanaged_vehicle_ejb: jar.sun-ejb-jar.xml
+     * jpa_core_entityManagerFactoryCloseException_appmanagedNoTx_vehicle_client: META-INF/application-client.xml
+     * jpa_core_entityManagerFactoryCloseException_appmanagedNoTx_vehicle_ejb: jar.sun-ejb-jar.xml
+     * jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web: WEB-INF/web.xml
+     * jpa_core_entityManagerFactoryCloseException_puservlet_vehicle_web: WEB-INF/web.xml
+     * jpa_core_entityManagerFactoryCloseException_stateful3_vehicle_client: META-INF/application-client.xml
+     * jpa_core_entityManagerFactoryCloseException_stateful3_vehicle_ejb: jar.sun-ejb-jar.xml
+     * jpa_core_entityManagerFactoryCloseException_stateless3_vehicle_client: META-INF/application-client.xml
+     * jpa_core_entityManagerFactoryCloseException_stateless3_vehicle_ejb: jar.sun-ejb-jar.xml
+     * jpa_core_entityManagerFactoryCloseException_vehicles:
+     *
+     * Found Descriptors: War:
+     *
+     * /com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml Ear:
+     *
+     */
+    @TargetsContainer("tck-javatest")
+    @OverProtocol("javatest")
+    @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+    public static EnterpriseArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
         // War
-            // the war with the correct archive name
-            WebArchive jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.war");
-            // The class files
-            jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addClasses(
-            com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareBaseBean.class,
-            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.UseEntityManager.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareIF.class,
-            com.sun.ts.lib.harness.EETest.Fault.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.UseEntityManagerFactory.class,
-            ee.jakarta.tck.persistence.common.PMClientBase.class,
-            com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class,
-            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper.class,
-            com.sun.ts.lib.harness.EETest.class,
-            com.sun.ts.lib.harness.ServiceEETest.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
-            com.sun.ts.tests.common.vehicle.pmservlet.PMServletVehicle.class,
-            ee.jakarta.tck.persistence.core.entityManagerFactoryCloseExceptions.Client.class,
-            com.sun.ts.lib.harness.EETest.SetupException.class,
-            com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            );
-            // The web.xml descriptor
-            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
-            if(warResURL != null) {
-              jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
-            }
-            // The sun-web.xml descriptor
-            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.war.sun-web.xml");
-            if(warResURL != null) {
-              jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
-            }
+        // the war with the correct archive name
+        WebArchive jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web =
+            ShrinkWrap.create(WebArchive.class, "jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.war");
 
-            // Any libraries added to the war
-                URL libURL;
-                JavaArchive jpa_core_entityManagerFactoryCloseException_lib = ShrinkWrap.create(JavaArchive.class, "jpa_core_entityManagerFactoryCloseException.jar");
+        // The class files
+        jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addClasses(
+                EJB3ShareBaseBean.class,
+                VehicleRunnerFactory.class,
+                UseEntityManager.class,
+                EJB3ShareIF.class,
+                Fault.class,
+                UseEntityManagerFactory.class,
+                PMClientBase.class,
+                ServletVehicle.class,
+                VehicleRunnable.class,
+                UserTransactionWrapper.class,
+                EETest.class,
+                ServiceEETest.class,
+                EntityTransactionWrapper.class,
+                PMServletVehicle.class,
+                Client.class,
+                SetupException.class, VehicleClient.class,
+                NoopTransactionWrapper.class);
 
-                // The resources
-                        libURL = Client.class.getResource("persistence.xml");
-                        jpa_core_entityManagerFactoryCloseException_lib.addAsResource(libURL, "persistence.xml");
+        // The web.xml descriptor
+        URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
+        if (warResURL != null) {
+            jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+        }
 
-                jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addAsLibrary(jpa_core_entityManagerFactoryCloseException_lib);
+        // The sun-web.xml descriptor
+        warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.war.sun-web.xml");
+        if (warResURL != null) {
+            jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+        }
 
+        // Any libraries added to the war
+        JavaArchive jpa_core_entityManagerFactoryCloseException_lib =
+            ShrinkWrap.create(JavaArchive.class, "jpa_core_entityManagerFactoryCloseException.jar");
 
-            // Web content
-            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
-            if(warResURL != null) {
-              jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/pmservlet_vehicle_web.xml");
-            }
+        // The resources
+        URL libURL = Client.class.getResource("persistence.xml");
+        jpa_core_entityManagerFactoryCloseException_lib.addAsManifestResource(libURL, "persistence.xml");
 
-           // Call the archive processor
-           archiveProcessor.processWebArchive(jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web, Client.class, warResURL);
+        jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addAsLibrary(jpa_core_entityManagerFactoryCloseException_lib);
 
+        // Web content
+        warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
+        if (warResURL != null) {
+            jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web.addAsWebResource(warResURL,
+                    "/WEB-INF/pmservlet_vehicle_web.xml");
+        }
+
+        // Call the archive processor
+        archiveProcessor.processWebArchive(jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web, Client.class, warResURL);
 
         // Ear
-            EnterpriseArchive jpa_core_entityManagerFactoryCloseException_vehicles_ear = ShrinkWrap.create(EnterpriseArchive.class, "jpa_core_entityManagerFactoryCloseException_vehicles.ear");
+        EnterpriseArchive jpa_core_entityManagerFactoryCloseException_vehicles_ear =
+            ShrinkWrap.create(EnterpriseArchive.class, "jpa_core_entityManagerFactoryCloseException_vehicles.ear");
 
-            // Any libraries added to the ear
+        // Any libraries added to the ear
 
-            // The component jars built by the package target
-            jpa_core_entityManagerFactoryCloseException_vehicles_ear.addAsModule(jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web);
+        // The component jars built by the package target
+        jpa_core_entityManagerFactoryCloseException_vehicles_ear
+                .addAsModule(jpa_core_entityManagerFactoryCloseException_pmservlet_vehicle_web);
 
+        // The sun-application.xml descriptor
+        URL earResURL = Client.class.getResource("/.ear.sun-application.xml");
+        if (earResURL != null) {
+            jpa_core_entityManagerFactoryCloseException_vehicles_ear.addAsManifestResource(earResURL, "sun-application.xml");
+        }
 
+        // Call the archive processor
+        archiveProcessor.processEarArchive(jpa_core_entityManagerFactoryCloseException_vehicles_ear, Client.class, earResURL);
 
-            // The application.xml descriptor
-            URL earResURL = null;
-            // The sun-application.xml descriptor
-            earResURL = Client.class.getResource("/.ear.sun-application.xml");
-            if(earResURL != null) {
-              jpa_core_entityManagerFactoryCloseException_vehicles_ear.addAsManifestResource(earResURL, "sun-application.xml");
-            }
-            // Call the archive processor
-            archiveProcessor.processEarArchive(jpa_core_entityManagerFactoryCloseException_vehicles_ear, Client.class, earResURL);
         return jpa_core_entityManagerFactoryCloseException_vehicles_ear;
-        }
+    }
 
-        @Test
-        @Override
-        @TargetVehicle("pmservlet")
-        public void exceptionsTest() throws java.lang.Exception {
-            super.exceptionsTest();
-        }
-
+    @Test
+    @Override
+    @TargetVehicle("pmservlet")
+    public void exceptionsTest() throws java.lang.Exception {
+        super.exceptionsTest();
+    }
 
 }

--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/persistence.xml
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/persistence.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<persistence xmlns="https://jakarta.ee/xml/ns/persistence"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+    https://jakarta.ee/xml/ns/persistence/persistence_3_0.xsd"
+    version="3.0">
+
+    <persistence-unit name="CTS-EM" transaction-type="JTA">
+        <description>Persistence Unit for CTS Vehicle Tests</description>
+        <jta-data-source>jdbc/DB1</jta-data-source>
+    </persistence-unit>
+    
+    <persistence-unit name="CTS-EM2" transaction-type="JTA">
+        <description>Persistence Unit for CTS Vehicle Tests</description>
+        <jta-data-source>jdbc/DB1</jta-data-source>
+    </persistence-unit>
+    
+    <persistence-unit name="CTS-EM-NOTX" transaction-type="RESOURCE_LOCAL">
+        <description>
+            The persistence.xml file may be used to designate more than one persistence 
+            unit within the same scope.
+            
+            Persistence Unit for Application Managed Resource Local</description>
+        <non-jta-data-source>jdbc/DB_no_tx</non-jta-data-source>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
persistence.xml was missing AND added to the wrong folder

**Related Issue(s)**
#1433

Before:

```
[ERROR] Errors: 
[ERROR]   ClientPmservletTest » Runtime Could not invoke deployment method: public static org.jboss.shrinkwrap.api.spec.EnterpriseArchive ee.jakarta.tck.persistence.core.entityManagerFactoryCloseExceptions.ClientPmservletTest.createDeploymentVehicle(tck.arquillian.porting.lib.spi.TestArchiveProcessor)
[ERROR]   ClientPuservletTest » Runtime Could not invoke deployment method: public static org.jboss.shrinkwrap.api.spec.EnterpriseArchive ee.jakarta.tck.persistence.core.entityManagerFactoryCloseExceptions.ClientPuservletTest.createDeploymentVehicle(tck.arquillian.porting.lib.spi.TestArchiveProcessor)
[ERROR]   ClientPmservletTest.cascadeAllMXMTest4 »  Test case throws exception: cascadeAllMXMTest4 failed
[ERROR]   ClientPuservletTest.cascadeAllMXMTest4 »  Test case throws exception: cascadeAllMXMTest4 failed
[ERROR]   ClientPmservletTest.cascadeAllMX1Test2 »  Test case throws exception: cascadeAllMX1Test2 failed
[ERROR]   ClientPuservletTest.cascadeAllMX1Test2 »  Test case throws exception: cascadeAllMX1Test2 failed
[ERROR]   ClientPmservletTest.persistMX1Test2 »  Test case throws exception: persistMX1Test2 failed
[ERROR]   ClientPuservletTest.persistMX1Test2 »  Test case throws exception: persistMX1Test2 failed
[ERROR]   ClientPmservletTest.testCreateUUIDType »  Test case throws exception: Caught exception:
[ERROR]   ClientPuservletTest.testCreateUUIDType »  Test case throws exception: Caught exception:
[ERROR]   ClientPmservletTest.createEntityManagerFactoryStringTest »  Test case throws exception: java.lang.NoClassDefFoundError: ee/jakarta/tck/persistence/core/entityManagerFactory/Order
[ERROR]   ClientTest.test1 »  Test case throws exception: [BaseUrlClient] test1 failed! Check output for cause of failure.
[ERROR]   ClientPmservletTest » Runtime Could not invoke deployment method: public static org.jboss.shrinkwrap.api.spec.EnterpriseArchive ee.jakarta.tck.persistence.jpa.ee.packaging.jar.ClientPmservletTest.createDeploymentVehicle(tck.arquillian.porting.lib.spi.TestArchiveProcessor)
[INFO] 
[ERROR] Tests run: 3818, Failures: 0, Errors: 13, Skipped: 0
```

After:

```
[ERROR] Errors: 
[ERROR]   ClientPuservletTest.exceptionsTest »  Test running in PersistenceUnit servlet vehicle failed
[ERROR]   ClientPmservletTest.cascadeAllMXMTest4 »  Test case throws exception: cascadeAllMXMTest4 failed
[ERROR]   ClientPuservletTest.cascadeAllMXMTest4 »  Test case throws exception: cascadeAllMXMTest4 failed
[ERROR]   ClientPmservletTest.cascadeAllMX1Test2 »  Test case throws exception: cascadeAllMX1Test2 failed
[ERROR]   ClientPuservletTest.cascadeAllMX1Test2 »  Test case throws exception: cascadeAllMX1Test2 failed
[ERROR]   ClientPmservletTest.persistMX1Test2 »  Test case throws exception: persistMX1Test2 failed
[ERROR]   ClientPuservletTest.persistMX1Test2 »  Test case throws exception: persistMX1Test2 failed
[ERROR]   ClientPmservletTest.testCreateUUIDType »  Test case throws exception: Caught exception:
[ERROR]   ClientPuservletTest.testCreateUUIDType »  Test case throws exception: Caught exception:
[ERROR]   ClientPmservletTest.createEntityManagerFactoryStringTest »  Test case throws exception: java.lang.NoClassDefFoundError: ee/jakarta/tck/persistence/core/entityManagerFactory/Order
[ERROR]   ClientTest.test1 »  Test case throws exception: [BaseUrlClient] test1 failed! Check output for cause of failure.
[ERROR]   ClientPmservletTest » Runtime Could not invoke deployment method: public static org.jboss.shrinkwrap.api.spec.EnterpriseArchive ee.jakarta.tck.persistence.jpa.ee.packaging.jar.ClientPmservletTest.createDeploymentVehicle(tck.arquillian.porting.lib.spi.TestArchiveProcessor)
[INFO] 
[ERROR] Tests run: 3818, Failures: 0, Errors: 12, Skipped: 0
```

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
