### PR TITLE
Fix jpa.ee.packaging.jar.ClientPmservletTest

### DIFF
--- a/glassfish-runner/persistence-platform-tck/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/pom.xml
@@ -453,6 +453,8 @@
                                 <include>ee/jakarta/tck/persistence/ee/cdi/*Test.java</include>
                             </includes>
 
+                            <skipITs>${cdi.skip}</skipITs>
+
                             <systemPropertyVariables>
                                 <arquillian.xml>rest-arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa/ee/packaging/jar/Client.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa/ee/packaging/jar/Client.java
@@ -33,7 +33,8 @@ public class Client extends PMClientBase {
 	/*
 	 * @class.setup_props:
 	 */
-	@BeforeEach
+	@Override
+    @BeforeEach
 	public void setup() throws Exception {
 		logTrace( "setup");
 		try {
@@ -47,9 +48,9 @@ public class Client extends PMClientBase {
 
 	/*
 	 * @testName: JarFileElementsTest
-	 * 
+	 *
 	 * @assertion_ids: PERSISTENCE:SPEC:957
-	 * 
+	 *
 	 * @test_Strategy: With the above archive (jar-file elements), deploy, create
 	 * entities persist, then find.
 	 *
@@ -64,11 +65,13 @@ public class Client extends PMClientBase {
 			getEntityManager().persist(a);
 			logTrace( "persisted order " + a.toString());
 		}
+
 		for (int i = 1 + count; i <= count + count; i++) {
 			C c = new C(Integer.toString(i), "name_" + Integer.toString(i), i);
 			getEntityManager().persist(c);
 			logTrace( "persisted order " + c.toString());
 		}
+
 		for (int i = 1; i <= count; i++) {
 			B b = new B(Integer.toString(i), "name_" + Integer.toString(i), i);
 			getEntityManager().persist(b);
@@ -87,6 +90,7 @@ public class Client extends PMClientBase {
 				pass = false;
 			}
 		}
+
 		for (int i = 1 + count; i <= count + count; i++) {
 			C c = getEntityManager().find(C.class, Integer.toString(i));
 			if (c != null) {
@@ -96,6 +100,7 @@ public class Client extends PMClientBase {
 				pass = false;
 			}
 		}
+
 		for (int i = 1; i <= count; i++) {
 			B b = getEntityManager().find(B.class, Integer.toString(i));
 			if (b != null) {
@@ -110,7 +115,8 @@ public class Client extends PMClientBase {
 		}
 	}
 
-	@BeforeEach
+	@Override
+    @BeforeEach
 	public void cleanup() throws Exception {
 		logTrace( "cleanup");
 		removeTestData();

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa/ee/packaging/jar/ClientPmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/jpa/ee/packaging/jar/ClientPmservletTest.java
@@ -1,16 +1,28 @@
 package ee.jakarta.tck.persistence.jpa.ee.packaging.jar;
 
-import ee.jakarta.tck.persistence.jpa.ee.packaging.jar.Client;
+import com.sun.ts.lib.harness.EETest;
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.tests.common.vehicle.VehicleClient;
+import com.sun.ts.tests.common.vehicle.VehicleRunnable;
+import com.sun.ts.tests.common.vehicle.VehicleRunnerFactory;
+import com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareBaseBean;
+import com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareIF;
+import com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper;
+import com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper;
+import com.sun.ts.tests.common.vehicle.ejb3share.UseEntityManager;
+import com.sun.ts.tests.common.vehicle.ejb3share.UseEntityManagerFactory;
+import com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper;
+import com.sun.ts.tests.common.vehicle.pmservlet.PMServletVehicle;
+import com.sun.ts.tests.common.vehicle.servlet.ServletVehicle;
+
 import java.net.URL;
+
 import org.jboss.arquillian.container.test.api.Deployment;
-import org.jboss.arquillian.container.test.api.OperateOnDeployment;
 import org.jboss.arquillian.container.test.api.OverProtocol;
 import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
-import org.jboss.shrinkwrap.api.asset.StringAsset;
-import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -19,167 +31,149 @@ import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.ExtendWith;
+
+import ee.jakarta.tck.persistence.common.PMClientBase;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
-
-
 
 @ExtendWith(ArquillianExtension.class)
 @Tag("persistence")
 @Tag("platform")
 @Tag("web")
 @Tag("tck-javatest")
-
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class ClientPmservletTest extends ee.jakarta.tck.persistence.jpa.ee.packaging.jar.Client {
+
+    private static final long serialVersionUID = 1L;
     static final String VEHICLE_ARCHIVE = "jpa_ee_packaging_jar_pmservlet_vehicle";
 
-        /**
-        EE10 Deployment Descriptors:
-        jpa_ee_packaging_jar: META-INF/persistence.xml,META-INF/orm.xml,myMappingFile.xml,myMappingFile2.xml
-        jpa_ee_packaging_jar_appmanaged_vehicle_client: META-INF/application-client.xml
-        jpa_ee_packaging_jar_appmanaged_vehicle_ejb: jar.sun-ejb-jar.xml
-        jpa_ee_packaging_jar_pmservlet_vehicle_web: WEB-INF/web.xml
-        jpa_ee_packaging_jar_stateful3_vehicle_client: META-INF/application-client.xml
-        jpa_ee_packaging_jar_stateful3_vehicle_ejb: jar.sun-ejb-jar.xml
-        jpa_ee_packaging_jar_stateless3_vehicle_client: META-INF/application-client.xml
-        jpa_ee_packaging_jar_stateless3_vehicle_ejb: jar.sun-ejb-jar.xml
-        jpa_ee_packaging_jar_vehicles: 
-        jpa_ee_packaging_jar1: 
-        jpa_ee_packaging_jar2: 
-
-        Found Descriptors:
-        War:
-
-        /com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml
-        Ear:
-
-        */
-        @TargetsContainer("tck-javatest")
-        @OverProtocol("javatest")
-        @Deployment(name = VEHICLE_ARCHIVE, order = 2)
-        public static EnterpriseArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+    /**
+     * EE10 Deployment Descriptors: jpa_ee_packaging_jar:
+     * META-INF/persistence.xml,META-INF/orm.xml,myMappingFile.xml,myMappingFile2.xml
+     * jpa_ee_packaging_jar_appmanaged_vehicle_client: META-INF/application-client.xml
+     * jpa_ee_packaging_jar_appmanaged_vehicle_ejb: jar.sun-ejb-jar.xml jpa_ee_packaging_jar_pmservlet_vehicle_web:
+     * WEB-INF/web.xml jpa_ee_packaging_jar_stateful3_vehicle_client: META-INF/application-client.xml
+     * jpa_ee_packaging_jar_stateful3_vehicle_ejb: jar.sun-ejb-jar.xml jpa_ee_packaging_jar_stateless3_vehicle_client:
+     * META-INF/application-client.xml jpa_ee_packaging_jar_stateless3_vehicle_ejb: jar.sun-ejb-jar.xml
+     * jpa_ee_packaging_jar_vehicles: jpa_ee_packaging_jar1: jpa_ee_packaging_jar2:
+     *
+     * Found Descriptors: War:
+     *
+     * /com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml Ear:
+     *
+     */
+    @TargetsContainer("tck-javatest")
+    @OverProtocol("javatest")
+    @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+    public static EnterpriseArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
         // War
-            // the war with the correct archive name
-            WebArchive jpa_ee_packaging_jar_pmservlet_vehicle_web = ShrinkWrap.create(WebArchive.class, "jpa_ee_packaging_jar_pmservlet_vehicle_web.war");
-            // The class files
-            jpa_ee_packaging_jar_pmservlet_vehicle_web.addClasses(
-            com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareBaseBean.class,
-            ee.jakarta.tck.persistence.jpa.ee.packaging.jar.Client.class,
-            com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.UseEntityManager.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareIF.class,
-            com.sun.ts.lib.harness.EETest.Fault.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.UseEntityManagerFactory.class,
-            ee.jakarta.tck.persistence.common.PMClientBase.class,
-            com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class,
-            com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper.class,
-            com.sun.ts.lib.harness.EETest.class,
-            com.sun.ts.lib.harness.ServiceEETest.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.EntityTransactionWrapper.class,
-            com.sun.ts.tests.common.vehicle.pmservlet.PMServletVehicle.class,
-            com.sun.ts.lib.harness.EETest.SetupException.class,
-            com.sun.ts.tests.common.vehicle.VehicleClient.class,
-            com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            );
-            // The web.xml descriptor
-            URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
-            if(warResURL != null) {
-              jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
-            }
-            // The sun-web.xml descriptor
-            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.war.sun-web.xml");
-            if(warResURL != null) {
-              jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
-            }
+        // the war with the correct archive name
+        WebArchive jpa_ee_packaging_jar_pmservlet_vehicle_web = ShrinkWrap.create(WebArchive.class,
+                "jpa_ee_packaging_jar_pmservlet_vehicle_web.war");
 
-            // Any libraries added to the war
-                URL libURL;
-                JavaArchive jpa_ee_packaging_jar2_lib = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_jar2.jar");
-                    // The class files
-                    jpa_ee_packaging_jar2_lib.addClasses(
-                        ee.jakarta.tck.persistence.jpa.ee.packaging.jar.C.class
-                    );
+        // The class files
+        jpa_ee_packaging_jar_pmservlet_vehicle_web.addClasses(
+                EJB3ShareBaseBean.class,
+                Client.class,
+                VehicleRunnerFactory.class,
+                UseEntityManager.class,
+                EJB3ShareIF.class, Fault.class,
+                UseEntityManagerFactory.class,
+                PMClientBase.class,
+                ServletVehicle.class,
+                VehicleRunnable.class,
+                UserTransactionWrapper.class,
+                EETest.class,
+                ServiceEETest.class,
+                EntityTransactionWrapper.class,
+                PMServletVehicle.class,
+                SetupException.class,
+                VehicleClient.class,
+                NoopTransactionWrapper.class);
 
+        // The web.xml descriptor
+        URL warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
+        if (warResURL != null) {
+            jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+        }
 
-                // The resources
-                        libURL = Client.class.getResource("/com/sun/ts/tests/jpa/ee/packaging/jar/C.java");
-                        jpa_ee_packaging_jar2_lib.addAsResource(libURL, "/com/sun/ts/tests/jpa/ee/packaging/jar/C.java");
+        // The sun-web.xml descriptor
+        warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.war.sun-web.xml");
+        if (warResURL != null) {
+            jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+        }
 
-                jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsLibrary(jpa_ee_packaging_jar2_lib);
-                JavaArchive jpa_ee_packaging_jar1_lib = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_jar1.jar");
-                    // The class files
-                    jpa_ee_packaging_jar1_lib.addClasses(
-                        ee.jakarta.tck.persistence.jpa.ee.packaging.jar.B.class
-                    );
+        // Any libraries added to the war
+        URL libURL;
+        JavaArchive jpa_ee_packaging_jar2_lib = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_jar2.jar");
 
+        // The class files
+        jpa_ee_packaging_jar2_lib.addClasses(C.class);
 
-                // The resources
-                        libURL = Client.class.getResource("/com/sun/ts/tests/jpa/ee/packaging/jar/B.java");
-                        jpa_ee_packaging_jar1_lib.addAsResource(libURL, "/com/sun/ts/tests/jpa/ee/packaging/jar/B.java");
+        jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsLibrary(jpa_ee_packaging_jar2_lib);
+        JavaArchive jpa_ee_packaging_jar1_lib = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_jar1.jar");
 
-                jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsLibrary(jpa_ee_packaging_jar1_lib);
-                JavaArchive jpa_ee_packaging_jar_lib = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_jar.jar");
-                    // The class files
-                    jpa_ee_packaging_jar_lib.addClasses(
-                        ee.jakarta.tck.persistence.jpa.ee.packaging.jar.A.class
-                    );
+        // The class files
+        jpa_ee_packaging_jar1_lib.addClasses(B.class);
 
+        jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsLibrary(jpa_ee_packaging_jar1_lib);
+        JavaArchive jpa_ee_packaging_jar_lib = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_jar.jar");
 
-                // The resources
-                        libURL = Client.class.getResource("persistence.xml");
-                        jpa_ee_packaging_jar_lib.addAsResource(libURL, "persistence.xml");
-                        libURL = Client.class.getResource("/orm.xml");
-                        jpa_ee_packaging_jar_lib.addAsResource(libURL, "/orm.xml");
-                        libURL = Client.class.getResource("/myMappingFile.xml");
-                        jpa_ee_packaging_jar_lib.addAsResource(libURL, "/myMappingFile.xml");
-                        libURL = Client.class.getResource("/myMappingFile2.xml");
-                        jpa_ee_packaging_jar_lib.addAsResource(libURL, "/myMappingFile2.xml");
-                        libURL = Client.class.getResource("/com/sun/ts/tests/jpa/ee/packaging/jar/A.java");
-                        jpa_ee_packaging_jar_lib.addAsResource(libURL, "/com/sun/ts/tests/jpa/ee/packaging/jar/A.java");
+        // The class files
+        jpa_ee_packaging_jar_lib.addClasses(A.class);
 
-                jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsLibrary(jpa_ee_packaging_jar_lib);
+        // The resources
+        libURL = Client.class.getResource("/ee/jakarta/tck/persistence/ee/packaging/jar/persistence.xml");
+        jpa_ee_packaging_jar_lib.addAsManifestResource(libURL, "persistence.xml");
 
+        libURL = Client.class.getResource("/ee/jakarta/tck/persistence/ee/packaging/jar/orm.xml");
+        jpa_ee_packaging_jar_lib.addAsManifestResource(libURL, "orm.xml");
 
-            // Web content
-            warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
-            if(warResURL != null) {
-              jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/pmservlet_vehicle_web.xml");
-            }
+        libURL = Client.class.getResource("/ee/jakarta/tck/persistence/ee/packaging/jar/myMappingFile.xml");
+        jpa_ee_packaging_jar_lib.addAsResource(libURL, "myMappingFile.xml");
 
-           // Call the archive processor
-           archiveProcessor.processWebArchive(jpa_ee_packaging_jar_pmservlet_vehicle_web, Client.class, warResURL);
+        libURL = Client.class.getResource("/ee/jakarta/tck/persistence/ee/packaging/jar/myMappingFile2.xml");
+        jpa_ee_packaging_jar_lib.addAsResource(libURL, "myMappingFile2.xml");
 
+        jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsLibrary(jpa_ee_packaging_jar_lib);
+
+        // Web content
+        warResURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/pmservlet/pmservlet_vehicle_web.xml");
+        if (warResURL != null) {
+            jpa_ee_packaging_jar_pmservlet_vehicle_web.addAsWebResource(warResURL, "/WEB-INF/pmservlet_vehicle_web.xml");
+        }
+
+        // Call the archive processor
+        archiveProcessor.processWebArchive(jpa_ee_packaging_jar_pmservlet_vehicle_web, Client.class, warResURL);
 
         // Ear
-            EnterpriseArchive jpa_ee_packaging_jar_vehicles_ear = ShrinkWrap.create(EnterpriseArchive.class, "jpa_ee_packaging_jar_vehicles.ear");
+        EnterpriseArchive jpa_ee_packaging_jar_vehicles_ear = ShrinkWrap.create(EnterpriseArchive.class,
+                "jpa_ee_packaging_jar_vehicles.ear");
 
-            // Any libraries added to the ear
+        // Any libraries added to the ear
 
-            // The component jars built by the package target
-            jpa_ee_packaging_jar_vehicles_ear.addAsModule(jpa_ee_packaging_jar_pmservlet_vehicle_web);
+        // The component jars built by the package target
+        jpa_ee_packaging_jar_vehicles_ear.addAsModule(jpa_ee_packaging_jar_pmservlet_vehicle_web);
 
+        // The application.xml descriptor
+        URL earResURL = null;
 
+        // The sun-application.xml descriptor
+        earResURL = Client.class.getResource("/.ear.sun-application.xml");
+        if (earResURL != null) {
+            jpa_ee_packaging_jar_vehicles_ear.addAsManifestResource(earResURL, "sun-application.xml");
+        }
+        // Call the archive processor
+        archiveProcessor.processEarArchive(jpa_ee_packaging_jar_vehicles_ear, Client.class, earResURL);
 
-            // The application.xml descriptor
-            URL earResURL = null;
-            // The sun-application.xml descriptor
-            earResURL = Client.class.getResource("/.ear.sun-application.xml");
-            if(earResURL != null) {
-              jpa_ee_packaging_jar_vehicles_ear.addAsManifestResource(earResURL, "sun-application.xml");
-            }
-            // Call the archive processor
-            archiveProcessor.processEarArchive(jpa_ee_packaging_jar_vehicles_ear, Client.class, earResURL);
         return jpa_ee_packaging_jar_vehicles_ear;
-        }
+    }
 
-        @Test
-        @Override
-        @TargetVehicle("pmservlet")
-        public void JarFileElementsTest() throws java.lang.Exception {
-            super.JarFileElementsTest();
-        }
-
+    @Test
+    @Override
+    @TargetVehicle("pmservlet")
+    public void JarFileElementsTest() throws java.lang.Exception {
+        super.JarFileElementsTest();
+    }
 
 }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/resources/ee/jakarta/tck/persistence/ee/packaging/jar/persistence.xml
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/resources/ee/jakarta/tck/persistence/ee/packaging/jar/persistence.xml
@@ -18,10 +18,11 @@
 -->
 
 <persistence xmlns="https://jakarta.ee/xml/ns/persistence"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://jakarta.ee/xml/ns/persistence
     https://jakarta.ee/xml/ns/persistence/persistence_3_2.xsd"
-  version="3.2">
+    version="3.2">
+    
     <persistence-unit name="CTS-EM" transaction-type="JTA">
         <description>Persistence Unit for CTS EE Package Tests</description>
         <jta-data-source>jdbc/DB1</jta-data-source>
@@ -30,6 +31,7 @@
         <jar-file>jpa_ee_packaging_jar1.jar/</jar-file>
         <jar-file>jpa_ee_packaging_jar2.jar/</jar-file>
     </persistence-unit>
+
     <persistence-unit name="CTS-EM2" transaction-type="JTA">
         <description>Persistence Unit for CTS EE Package Tests</description>
         <jta-data-source>jdbc/DB1</jta-data-source>


### PR DESCRIPTION
.java files were included for no reason but myMappingFile.xml etc were wrongly included


**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1433

Before:

```
[ERROR] Errors: 
[ERROR]   ClientPuservletTest.exceptionsTest »  Test running in PersistenceUnit servlet vehicle failed
[ERROR]   ClientPmservletTest.cascadeAllMXMTest4 »  Test case throws exception: cascadeAllMXMTest4 failed
[ERROR]   ClientPuservletTest.cascadeAllMXMTest4 »  Test case throws exception: cascadeAllMXMTest4 failed
[ERROR]   ClientPmservletTest.cascadeAllMX1Test2 »  Test case throws exception: cascadeAllMX1Test2 failed
[ERROR]   ClientPuservletTest.cascadeAllMX1Test2 »  Test case throws exception: cascadeAllMX1Test2 failed
[ERROR]   ClientPmservletTest.persistMX1Test2 »  Test case throws exception: persistMX1Test2 failed
[ERROR]   ClientPuservletTest.persistMX1Test2 »  Test case throws exception: persistMX1Test2 failed
[ERROR]   ClientPmservletTest.testCreateUUIDType »  Test case throws exception: Caught exception:
[ERROR]   ClientPuservletTest.testCreateUUIDType »  Test case throws exception: Caught exception:
[ERROR]   ClientPmservletTest.createEntityManagerFactoryStringTest »  Test case throws exception: java.lang.NoClassDefFoundError: ee/jakarta/tck/persistence/core/entityManagerFactory/Order
[ERROR]   ClientTest.test1 »  Test case throws exception: [BaseUrlClient] test1 failed! Check output for cause of failure.
[ERROR]   ClientPmservletTest » Runtime Could not invoke deployment method: public static org.jboss.shrinkwrap.api.spec.EnterpriseArchive ee.jakarta.tck.persistence.jpa.ee.packaging.jar.ClientPmservletTest.createDeploymentVehicle(tck.arquillian.porting.lib.spi.TestArchiveProcessor)
[INFO] 
[ERROR] Tests run: 3818, Failures: 0, Errors: 12, Skipped: 0
```

After:

```
[ERROR] Errors: 
[ERROR]   ClientPuservletTest.exceptionsTest »  Test running in PersistenceUnit servlet vehicle failed
[ERROR]   ClientPmservletTest.cascadeAllMXMTest4 »  Test case throws exception: cascadeAllMXMTest4 failed
[ERROR]   ClientPuservletTest.cascadeAllMXMTest4 »  Test case throws exception: cascadeAllMXMTest4 failed
[ERROR]   ClientPmservletTest.cascadeAllMX1Test2 »  Test case throws exception: cascadeAllMX1Test2 failed
[ERROR]   ClientPuservletTest.cascadeAllMX1Test2 »  Test case throws exception: cascadeAllMX1Test2 failed
[ERROR]   ClientPmservletTest.persistMX1Test2 »  Test case throws exception: persistMX1Test2 failed
[ERROR]   ClientPuservletTest.persistMX1Test2 »  Test case throws exception: persistMX1Test2 failed
[ERROR]   ClientPmservletTest.testCreateUUIDType »  Test case throws exception: Caught exception:
[ERROR]   ClientPuservletTest.testCreateUUIDType »  Test case throws exception: Caught exception:
[ERROR]   ClientPmservletTest.createEntityManagerFactoryStringTest »  Test case throws exception: java.lang.NoClassDefFoundError: ee/jakarta/tck/persistence/core/entityManagerFactory/Order
[ERROR]   ClientTest.test1 »  Test case throws exception: [BaseUrlClient] test1 failed! Check output for cause of failure.
[INFO] 
[ERROR] Tests run: 3818, Failures: 0, Errors: 11, Skipped: 0
```



CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
