### PR TITLE
fix 1 failing persistence test : update setContextRoot

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/propagation/cm/jta/Client.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/propagation/cm/jta/Client.java
@@ -60,6 +60,8 @@ public class Client extends AbstractUrlClient {
 	 */
 	@Test
 	public void test1() throws Exception {
+		setServletName(SERVLET_NAME);
+		setContextRoot(CONTEXT_ROOT);
 		TEST_PROPS.setProperty(APITEST, "test1");
 		invoke();
 	}


### PR DESCRIPTION

**Describe the change**
- setServletName, setContextRoot before test invocation for tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/propagation/cm/jta/Client.java#test1
- Will fix 1 failing test in persistence web profile

CC @arjantijms @gurunrao 
@starksm64 @scottmarlow
