### PR TITLE
Change the test order in failing persistence tests

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientPmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientPmservletTest.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -26,7 +27,7 @@ import java.net.URL;
 @Tag("web")
 @Tag("tck-javatest")
 
-@TestMethodOrder(MethodOrderer.MethodName.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXmany.Client {
     static final String VEHICLE_ARCHIVE = "jpa_core_et_cascadeall_manyXmany_pmservlet_vehicle";
 
@@ -115,6 +116,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Order(3)
         public void cascadeAllMXMTest1() throws java.lang.Exception {
             super.cascadeAllMXMTest1();
         }
@@ -122,6 +124,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Order(2)
         public void cascadeAllMXMTest2() throws java.lang.Exception {
             super.cascadeAllMXMTest2();
         }
@@ -129,6 +132,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Order(4)
         public void cascadeAllMXMTest3() throws java.lang.Exception {
             super.cascadeAllMXMTest3();
         }
@@ -136,6 +140,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Order(1)
         public void cascadeAllMXMTest4() throws java.lang.Exception {
             super.cascadeAllMXMTest4();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientPuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientPuservletTest.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -26,7 +27,7 @@ import java.net.URL;
 @Tag("web")
 @Tag("tck-javatest")
 
-@TestMethodOrder(MethodOrderer.MethodName.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXmany.Client {
     static final String VEHICLE_ARCHIVE = "jpa_core_et_cascadeall_manyXmany_puservlet_vehicle";
 
@@ -147,6 +148,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("puservlet")
+        @Order(3)
         public void cascadeAllMXMTest1() throws java.lang.Exception {
             super.cascadeAllMXMTest1();
         }
@@ -154,6 +156,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("puservlet")
+        @Order(2)
         public void cascadeAllMXMTest2() throws java.lang.Exception {
             super.cascadeAllMXMTest2();
         }
@@ -161,6 +164,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("puservlet")
+        @Order(4)
         public void cascadeAllMXMTest3() throws java.lang.Exception {
             super.cascadeAllMXMTest3();
         }
@@ -168,6 +172,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("puservlet")
+        @Order(1)
         public void cascadeAllMXMTest4() throws java.lang.Exception {
             super.cascadeAllMXMTest4();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientPmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientPmservletTest.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -26,7 +27,7 @@ import java.net.URL;
 @Tag("web")
 @Tag("tck-javatest")
 
-@TestMethodOrder(MethodOrderer.MethodName.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXone.Client {
     static final String VEHICLE_ARCHIVE = "jpa_core_et_cascadeall_manyXone_pmservlet_vehicle";
 
@@ -147,6 +148,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Order(2)
         public void cascadeAllMX1Test1() throws java.lang.Exception {
             super.cascadeAllMX1Test1();
         }
@@ -154,6 +156,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Order(1)
         public void cascadeAllMX1Test2() throws java.lang.Exception {
             super.cascadeAllMX1Test2();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientPuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientPuservletTest.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -26,7 +27,7 @@ import java.net.URL;
 @Tag("web")
 @Tag("tck-javatest")
 
-@TestMethodOrder(MethodOrderer.MethodName.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXone.Client {
     static final String VEHICLE_ARCHIVE = "jpa_core_et_cascadeall_manyXone_puservlet_vehicle";
 
@@ -147,6 +148,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("puservlet")
+        @Order(2)
         public void cascadeAllMX1Test1() throws java.lang.Exception {
             super.cascadeAllMX1Test1();
         }
@@ -154,6 +156,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("puservlet")
+        @Order(1)
         public void cascadeAllMX1Test2() throws java.lang.Exception {
             super.cascadeAllMX1Test2();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientPmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientPmservletTest.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -26,7 +27,7 @@ import java.net.URL;
 @Tag("web")
 @Tag("tck-javatest")
 
-@TestMethodOrder(MethodOrderer.MethodName.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.Client {
     static final String VEHICLE_ARCHIVE = "jpa_core_et_persist_manyXone_pmservlet_vehicle";
 
@@ -147,6 +148,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Order(2)
         public void persistMX1Test1() throws java.lang.Exception {
             super.persistMX1Test1();
         }
@@ -154,6 +156,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Order(1)
         public void persistMX1Test2() throws java.lang.Exception {
             super.persistMX1Test2();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientPuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientPuservletTest.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -26,7 +27,7 @@ import java.net.URL;
 @Tag("web")
 @Tag("tck-javatest")
 
-@TestMethodOrder(MethodOrderer.MethodName.class)
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.Client {
     static final String VEHICLE_ARCHIVE = "jpa_core_et_persist_manyXone_puservlet_vehicle";
 
@@ -147,6 +148,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("puservlet")
+        @Order(2)
         public void persistMX1Test1() throws java.lang.Exception {
             super.persistMX1Test1();
         }
@@ -154,6 +156,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entityt
         @Test
         @Override
         @TargetVehicle("puservlet")
+        @Order(1)
         public void persistMX1Test2() throws java.lang.Exception {
             super.persistMX1Test2();
         }


### PR DESCRIPTION
**Describe the change**
- Changing the order of the tests passes all the remaining 6 failing tests in persistence web profile.
- This can be considered as a temporary fix to understand underlying issue. Possibly we should fix without relying on the order of the tests IMO. I am trying to find the cleanup/setup required to pass them otherwise. Please suggest if we can consider this as the permanent solution.

CC @arjantijms @gurunrao 
@starksm64 @scottmarlow
