### PR TITLE
Update jakarta.tck:common to 11.0.0-RC1, the new merged common, libut…

### DIFF
--- a/arquillian/javatest/pom.xml
+++ b/arquillian/javatest/pom.xml
@@ -49,7 +49,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${ee.tck.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>

--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
-        <ee.tck.version>11.0.0-SNAPSHOT</ee.tck.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
     </properties>
 
     <dependencyManagement>
@@ -85,4 +85,16 @@
             <version>5.11.3</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.diffplug.spotless</groupId>
+                <artifactId>spotless-maven-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/arquillian/protocol-lib/pom.xml
+++ b/arquillian/protocol-lib/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${ee.tck.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
     </dependencies>
 
@@ -59,7 +59,7 @@
                                 <artifactItem>
                                     <groupId>jakarta.tck</groupId>
                                     <artifactId>common</artifactId>
-                                    <version>${ee.tck.version}</version>
+                                    <version>${jakarta.tck.tools.version}</version>
                                     <type>jar</type>
                                     <overWrite>false</overWrite>
                                     <outputDirectory>${project.build.directory}/classes</outputDirectory>

--- a/glassfish-runner/connector-platform-tck/pom.xml
+++ b/glassfish-runner/connector-platform-tck/pom.xml
@@ -93,7 +93,6 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>

--- a/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
@@ -42,7 +42,7 @@
         <glassfish.version>8.0.0-JDK17-M9</glassfish.version>
         
         <jakarta.tck.arquillian.version>11.0.0-M1</jakarta.tck.arquillian.version>
-        <jakarta.tck.tools.version>11.0.0-M2</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <tck.version>3.0.0-M1</tck.version>
         <ts.home>/jakartaeetck</ts.home>
     </properties>

--- a/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
@@ -42,7 +42,7 @@
         <glassfish.version>8.0.0-JDK17-M9</glassfish.version>
         
         <jakarta.tck.arquillian.version>11.0.0-M1</jakarta.tck.arquillian.version>
-        <jakarta.tck.tools.version>11.0.0-M2</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <tck.version>2.1.0-M1</tck.version>
         <ts.home>/jakartaeetck</ts.home>
     </properties>

--- a/glassfish-runner/mail-platform-tck/pom.xml
+++ b/glassfish-runner/mail-platform-tck/pom.xml
@@ -75,7 +75,6 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
         </dependency>
 
         <dependency>

--- a/glassfish-runner/messaging-platform-tck/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/pom.xml
@@ -262,7 +262,6 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>

--- a/glassfish-runner/messaging-tck/pom.xml
+++ b/glassfish-runner/messaging-tck/pom.xml
@@ -66,9 +66,8 @@
             <version>${junit.jupiter.version}</version>
         </dependency>
         <dependency>
-            <groupId>jakartatck</groupId>
+            <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>

--- a/glassfish-runner/persistence-platform-tck/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/pom.xml
@@ -49,7 +49,7 @@
         <ts.home>./jakartaeetck</ts.home>
         <version.jakarta.inject>2.0.1.MR</version.jakarta.inject>
         <version.jakarta.persistence>3.2.0</version.jakarta.persistence>
-        <version.jakarta.tck>11.0.0-M2</version.jakarta.tck>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <version.persistence.tck>11.0.0-SNAPSHOT</version.persistence.tck>
     </properties>
 
@@ -120,7 +120,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${version.jakarta.tck}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
 
         <dependency>

--- a/glassfish-runner/persistence-tck/persistence-tck-run-se/pom.xml
+++ b/glassfish-runner/persistence-tck/persistence-tck-run-se/pom.xml
@@ -131,7 +131,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${jakarta.ee.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
             <scope>test</scope>
         </dependency>
         

--- a/glassfish-runner/platform/appclient-platform-tck/pom.xml
+++ b/glassfish-runner/platform/appclient-platform-tck/pom.xml
@@ -84,7 +84,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>

--- a/glassfish-runner/platform/assembly-tck/pom.xml
+++ b/glassfish-runner/platform/assembly-tck/pom.xml
@@ -41,7 +41,6 @@
         <tck.artifactId>assembly-tck</tck.artifactId>
         <tck.version>11.0.0-SNAPSHOT</tck.version>
         <ts.home>./jakartaeetck</ts.home>
-        <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
         <version.jakarta.tck.arquillian>${project.version}</version.jakarta.tck.arquillian>
     </properties>
 
@@ -110,7 +109,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.glassfish.main.common</groupId>

--- a/glassfish-runner/platform/integration-platform-tck/pom.xml
+++ b/glassfish-runner/platform/integration-platform-tck/pom.xml
@@ -249,7 +249,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>

--- a/glassfish-runner/platform/jdbc-platform-tck/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>

--- a/glassfish-runner/platform/xa-platform-tck/pom.xml
+++ b/glassfish-runner/platform/xa-platform-tck/pom.xml
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>

--- a/glassfish-runner/transactions-tck/transactions-tck-run/pom.xml
+++ b/glassfish-runner/transactions-tck/transactions-tck-run/pom.xml
@@ -43,7 +43,7 @@
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <ts.home>${basedir}/jakartaeetck</ts.home>
         
-        <jakarta.tck.tools.version>11.0.0-M2</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <jakarta.tck.arquillian.version>11.0.0-M1</jakarta.tck.arquillian.version>
         <jakarta.tck.transactions.version>2.0.0-M1</jakarta.tck.transactions.version>
     </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>project</name>
-    <description>project</description>
+    <description>platform-tcks-parent</description>
 
     <modules>
         <module>arquillian</module>
@@ -71,14 +71,18 @@
     </modules>
 
     <properties>
+        <!-- Arquillian -->
         <ant.version>1.10.15</ant.version>
         <arquillian.container.se.api.version>1.0.2.Final</arquillian.container.se.api.version>
         <arquillian.jakarta.tck.version>${project.version}</arquillian.jakarta.tck.version>
         <arquillian.version>1.9.1.Final</arquillian.version>
+
         <!-- CDI -->
         <cdi-api.version>4.1.0</cdi-api.version>
+
         <!-- Jakarta Concurrency -->
         <concurrent-api.version>3.1.1</concurrent-api.version>
+
         <!-- Jakarta Persistence -->
         <jakarta-persistence-api.version>3.2.0</jakarta-persistence-api.version>
         <jakarta.activation-api.version>2.1.3</jakarta.activation-api.version>
@@ -101,6 +105,10 @@
         <!-- Jakarta EE Security + Authentication/Authorization -->
         <jakarta.security.enterprise-api.version>4.0.0</jakarta.security.enterprise-api.version>
         <jakarta.servlet-api.version>6.1.0</jakarta.servlet-api.version>
+
+        <!-- Jakarta TCK Tools version from the independently released tools submodule -->
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
+
         <!-- Jakarta Transactions -->
         <jakarta.transaction-api.version>2.0.1</jakarta.transaction-api.version>
         <jakarta.validation-api.version>3.1.0</jakarta.validation-api.version>
@@ -146,7 +154,7 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>common</artifactId>
-                <version>${project.version}</version>
+                <version>${jakarta.tck.tools.version}</version>
             </dependency>
 
             <dependency>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/tcks/apis/connector/pom.xml
+++ b/tcks/apis/connector/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jakarta.tck.tools.version>11.0.0-M2</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <jakarta.tck.arquillian.version>11.0.0-M1</jakarta.tck.arquillian.version>
     </properties>
 
@@ -62,11 +62,6 @@
     
     <dependencies>
         <!-- Jakarta EE dependencies -->
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>common</artifactId>
-            <version>11.0.0-M2</version>
-        </dependency>
         <dependency>
             <groupId>jakarta.resource</groupId>
             <artifactId>jakarta.resource-api</artifactId>
@@ -97,17 +92,7 @@
         <!-- Jakarta TCK tools dependencies -->
         <dependency>
             <groupId>jakarta.tck</groupId>
-            <artifactId>libutil</artifactId>
-            <version>${jakarta.tck.tools.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${jakarta.tck.tools.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>runtime</artifactId>
             <version>${jakarta.tck.tools.version}</version>
         </dependency>
         

--- a/tcks/apis/enterprise-beans/ejb30/pom.xml
+++ b/tcks/apis/enterprise-beans/ejb30/pom.xml
@@ -37,13 +37,14 @@
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
         <jaxwsStaleDirectory>${project.build.directory}/jaxws/stale</jaxwsStaleDirectory>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>11.0.0-M2</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/tcks/apis/javamail/pom.xml
+++ b/tcks/apis/javamail/pom.xml
@@ -52,7 +52,6 @@ EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
-            <version>11.0.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>jakarta.mail</groupId>

--- a/tcks/apis/jsonb/pom.xml
+++ b/tcks/apis/jsonb/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jakarta.tck.tools.version>11.0.0-M2</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <jakarta.tck.arquillian.version>11.0.0-M1</jakarta.tck.arquillian.version>
     </properties>
     

--- a/tcks/apis/jsonp/pom.xml
+++ b/tcks/apis/jsonp/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jakarta.tck.tools.version>11.0.0-M2</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <jakarta.tck.arquillian.version>11.0.0-M1</jakarta.tck.arquillian.version>
     </properties>
 

--- a/tcks/apis/pages/pom.xml
+++ b/tcks/apis/pages/pom.xml
@@ -39,7 +39,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         
-        <jakarta.tck.tools.version>11.0.0-M2</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
     
         <junit.jupiter.version>5.11.3</junit.jupiter.version>
     </properties>

--- a/tcks/apis/persistence/persistence-inside-container/common/pom.xml
+++ b/tcks/apis/persistence/persistence-inside-container/common/pom.xml
@@ -26,13 +26,7 @@
     </parent>
     <artifactId>persistence-platform-tck-common</artifactId>
     <packaging>jar</packaging>
-    <dependencies>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-    </dependencies>
+
     <build>
         <resources>
             <resource>

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/pom.xml
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/pom.xml
@@ -47,11 +47,6 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
-            <artifactId>common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
             <artifactId>persistence-platform-tck-common</artifactId>
             <version>${project.version}</version>
         </dependency>

--- a/tcks/apis/persistence/persistence-inside-container/pom.xml
+++ b/tcks/apis/persistence/persistence-inside-container/pom.xml
@@ -49,7 +49,6 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>

--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/pom.xml
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/pom.xml
@@ -32,11 +32,6 @@
             <artifactId>persistence-platform-tck-common</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>common</artifactId>
-            <version>${project.version}</version>
-        </dependency>
 
     </dependencies>
     <build>

--- a/tcks/apis/persistence/persistence-outside-container/bin/pom.xml
+++ b/tcks/apis/persistence/persistence-outside-container/bin/pom.xml
@@ -64,7 +64,7 @@
         <tck.common.artifactId>persistence-tck-common</tck.common.artifactId>
         <tck.artifactId>persistence-tck-spec-tests</tck.artifactId>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
-        <jakarta.ee.version>11.0.0-M1</jakarta.ee.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <persistence.tck.version>3.2.0</persistence.tck.version>
         <arquillian.junit5.version>1.9.1.Final</arquillian.junit5.version>
         <el.version>5.0.0-M1</el.version>

--- a/tcks/apis/persistence/persistence-outside-container/common/pom.xml
+++ b/tcks/apis/persistence/persistence-outside-container/common/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
-            <version>${jakarta.ee.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
     </dependencies>
     <build>

--- a/tcks/apis/persistence/persistence-outside-container/pom.xml
+++ b/tcks/apis/persistence/persistence-outside-container/pom.xml
@@ -41,19 +41,19 @@
         <arquillian.junit>1.7.0.Alpha14</arquillian.junit>
         <junit.jupiter.version>5.11.3</junit.jupiter.version>
         <tck.version>${project.version}</tck.version>
-        <jakarta.ee.version>11.0.0-M1</jakarta.ee.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <maven.compiler.release>17</maven.compiler.release>
     </properties>
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
-            <version>${jakarta.ee.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>signaturetest</artifactId>
-            <version>${jakarta.ee.version}</version>
+            <version>${jakarta.tck.tools.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.persistence</groupId>

--- a/tcks/apis/rest/pom.xml
+++ b/tcks/apis/rest/pom.xml
@@ -38,7 +38,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         
-        <jakarta.tck.tools.version>11.0.0-M2</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
     </properties>
 
 

--- a/tcks/apis/transactions/pom.xml
+++ b/tcks/apis/transactions/pom.xml
@@ -37,7 +37,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-        <jakarta.tck.tools.version>11.0.0-M2</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <jakarta.tck.arquillian.version>11.0.0-M1</jakarta.tck.arquillian.version>
     </properties>
 

--- a/tcks/apis/websocket/pom.xml
+++ b/tcks/apis/websocket/pom.xml
@@ -46,7 +46,7 @@
         <arquillian.junit>1.9.3.Final</arquillian.junit>
         <junit.jupiter.version>5.11.3</junit.jupiter.version>
         <tck.version>${project.version}</tck.version>
-        <jakarta.tck.tools.version>11.0.0-M1</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
         <maven.compiler.release>17</maven.compiler.release>
     </properties>
 

--- a/tcks/profiles/platform/appclient/pom.xml
+++ b/tcks/profiles/platform/appclient/pom.xml
@@ -72,7 +72,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
-            <version>${jakarta.ee.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>

--- a/tcks/profiles/platform/xa/pom.xml
+++ b/tcks/profiles/platform/xa/pom.xml
@@ -35,7 +35,6 @@
 
     <properties>
         <arquillian.junit>1.9.3.Final</arquillian.junit>
-        <jakarta.ee.version>11.0.0-SNAPSHOT</jakarta.ee.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <maven.compiler.release>17</maven.compiler.release>
     </properties>
@@ -44,7 +43,6 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>common</artifactId>
-            <version>${jakarta.ee.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.ejb</groupId>

--- a/tools/common/pom.xml
+++ b/tools/common/pom.xml
@@ -106,7 +106,8 @@
         </dependency>
     </dependencies>
 
-    <build><!-- Include the container descriptors in the output artifact -->
+    <build>
+        <!-- Include the container descriptors in the output artifact -->
         <resources>
             <resource>
                 <directory>src/main/java</directory>
@@ -120,6 +121,10 @@
                 <excludes>
                     <exclude>**/build.xml</exclude>
                 </excludes>
+            </resource>
+            <!-- Include the standard resources as well -->
+            <resource>
+                <directory>src/main/resources</directory>
             </resource>
         </resources>
         <plugins>

--- a/tools/signaturetest/pom.xml
+++ b/tools/signaturetest/pom.xml
@@ -40,7 +40,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         
-        <jakarta.tck.tools.version>11.0.0-SNAPSHOT</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC1</jakarta.tck.tools.version>
     </properties>
 
     <dependencies>

--- a/tsharness/pom.xml
+++ b/tsharness/pom.xml
@@ -35,7 +35,6 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>${project.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
…il, runtime artifacts.

Consistently use a jakarta.tck.tools.version for the common artifact version.

The staged jakarta.tck:common 11.0.0-RC1 artifact has been released to maven central, but it will take a while for this PR to pass validation checks as that was just done.

**Fixes Issue**
Fixes #1814


