### PR TITLE
Update selenium and htmlunit for CDI Extra tests

### DIFF
--- a/tcks/apis/cdi-ee-tck/tck/pom.xml
+++ b/tcks/apis/cdi-ee-tck/tck/pom.xml
@@ -136,61 +136,61 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.9.0</version>
+            <version>7.10.2</version>
         </dependency>
 
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chrome-driver</artifactId>
-            <version>4.7.2</version>
+            <version>4.28.1</version>
         </dependency>
         
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chromium-driver</artifactId>
-            <version>4.7.2</version>
+            <version>4.28.1</version>
         </dependency>
         
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-api</artifactId>
-            <version>4.7.2</version>
+            <version>4.28.1</version>
         </dependency>
 
         <dependency>
-            <groupId>net.sourceforge.htmlunit</groupId>
+            <groupId>org.htmlunit</groupId>
             <artifactId>htmlunit</artifactId>
-            <version>2.50.0</version>
+            <version>4.9.0</version>
         </dependency>
         
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-remote-driver</artifactId>
-            <version>4.7.2</version>
+            <version>4.28.1</version>
         </dependency>
         
          <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
-            <artifactId>selenium-devtools-v108</artifactId>
-            <version>4.7.2</version>
+            <artifactId>selenium-devtools-v130</artifactId>
+            <version>4.28.1</version>
         </dependency>
         
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-support</artifactId>
-            <version>4.7.2</version>
+            <version>4.28.1</version>
         </dependency>
         
         <dependency>
             <groupId>io.github.bonigarcia</groupId>
             <artifactId>webdrivermanager</artifactId>
-            <version>5.3.1</version>
+            <version>5.9.2</version>
         </dependency>
         
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>2.8.0</version>
+            <version>2.18.0</version>
         </dependency>
         
         <dependency>
@@ -224,21 +224,21 @@
         <dependency>
             <groupId>commons-lang</groupId>
             <artifactId>commons-lang</artifactId>
-            <version>2.2</version>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.xmlunit</groupId>
             <artifactId>xmlunit-core</artifactId>
-            <version>2.9.1</version>
+            <version>2.10.0</version>
             <scope>test</scope>
         </dependency>
         
         <dependency>
             <groupId>xml-apis</groupId>
             <artifactId>xml-apis</artifactId>
-            <version>1.4.01</version>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/InterceptorEnvironmentJNDITest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/InterceptorEnvironmentJNDITest.java
@@ -39,8 +39,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.WebClient;
 
 /**
  * @author Matus Abaffy

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/InterceptorEnvironmentJNDISessionBeanTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/interceptors/tests/contract/interceptorLifeCycle/environment/jndi/ejb/InterceptorEnvironmentJNDISessionBeanTest.java
@@ -37,8 +37,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.WebClient;
 
 /**
  * @author Matus Abaffy

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/selenium/ChromeDevtoolsDriver.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/selenium/ChromeDevtoolsDriver.java
@@ -20,16 +20,15 @@ import io.github.bonigarcia.wdm.WebDriverManager;
 import org.apache.commons.io.output.NullOutputStream;
 import org.openqa.selenium.*;
 import org.openqa.selenium.chrome.ChromeDriver;
-import org.openqa.selenium.chrome.ChromeDriverLogLevel;
 import org.openqa.selenium.chrome.ChromeDriverService;
 import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.chromium.ChromiumNetworkConditions;
 import org.openqa.selenium.devtools.DevTools;
-import org.openqa.selenium.devtools.v108.network.Network;
-import org.openqa.selenium.devtools.v108.network.model.Request;
-import org.openqa.selenium.devtools.v108.network.model.RequestId;
-import org.openqa.selenium.devtools.v108.network.model.ResponseReceived;
-import org.openqa.selenium.devtools.v108.network.model.TimeSinceEpoch;
+import org.openqa.selenium.devtools.v130.network.Network;
+import org.openqa.selenium.devtools.v130.network.model.Request;
+import org.openqa.selenium.devtools.v130.network.model.RequestId;
+import org.openqa.selenium.devtools.v130.network.model.ResponseReceived;
+import org.openqa.selenium.devtools.v130.network.model.TimeSinceEpoch;
 import org.openqa.selenium.html5.LocalStorage;
 import org.openqa.selenium.html5.Location;
 import org.openqa.selenium.html5.SessionStorage;
@@ -95,6 +94,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
     /**
      * initializes the extended functionality
      */
+    @Override
     public void postInit() {
         DevTools devTools = getDevTools();
         //we store always the last request for further reference
@@ -250,15 +250,18 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         return delegate.getCommandExecutor();
     }
 
+    @Override
     public void get(String url) {
         lastGet = url;
         delegate.get(url);
     }
 
+    @Override
     public String getTitle() {
         return delegate.getTitle();
     }
 
+    @Override
     public String getCurrentUrl() {
         return delegate.getCurrentUrl();
     }
@@ -271,10 +274,12 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         return delegate.print(printOptions);
     }
 
+    @Override
     public WebElement findElement(By locator) {
         return delegate.findElement(locator);
     }
 
+    @Override
     public List<WebElement> findElements(By locator) {
         return delegate.findElements(locator);
     }
@@ -283,16 +288,19 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         return delegate.findElements(context, findCommand, locator);
     }
 
+    @Override
     public String getPageSource() {
         return delegate.getPageSource();
     }
 
+    @Override
     public String getPageText() {
         String head = delegate.findElement(By.tagName("head")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
         String body = delegate.findElement(By.tagName("body")).getAttribute("innerText").replaceAll("[\\s\\n ]", " ");
         return head + " " + body;
     }
 
+    @Override
     public String getPageTextReduced() {
         String head = delegate.findElement(By.tagName("head")).getAttribute("innerText");
         String body = delegate.findElement(By.tagName("body")).getAttribute("innerText");
@@ -304,6 +312,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
      * resets the current tab and gives it a clean slate
      * that way we do not have to build up the entire tab again
      */
+    @Override
     public void reset() {
         DevTools devTools = delegate.getDevTools();
         devTools.clearListeners();
@@ -321,6 +330,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
      * hence reset now is the preferred way to recycle tabs instead
      * of using close
      */
+    @Override
     public void close() {
         reset();
         delegate.close();
@@ -329,14 +339,17 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
     /**
      * quits the driver entirely
      */
+    @Override
     public void quit() {
         delegate.quit();
     }
 
+    @Override
     public Set<String> getWindowHandles() {
         return delegate.getWindowHandles();
     }
 
+    @Override
     public String getWindowHandle() {
         return delegate.getWindowHandle();
     }
@@ -349,14 +362,17 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         return delegate.executeAsyncScript(script, args);
     }
 
+    @Override
     public TargetLocator switchTo() {
         return delegate.switchTo();
     }
 
+    @Override
     public Navigation navigate() {
         return delegate.navigate();
     }
 
+    @Override
     public Options manage() {
         return delegate.manage();
     }
@@ -432,6 +448,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         return delegate.getDevTools().send(Network.getResponseBody(data.requestId)).getBody();
     }
 
+    @Override
     public String getRequestData() {
         HttpCycleData data = getLastGetData();
         return data.request.getPostData().orElse("");
@@ -467,6 +484,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         });
     }
 
+    @Override
     public void printProcessedResponses() {
         sortResponses();
 
@@ -481,6 +499,7 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
                 });
     }
 
+    @Override
     public ChromeDriver getDelegate() {
         return delegate;
     }
@@ -523,8 +542,6 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
         prefs.put("intl.accept_languages", "en");
         options.setExperimentalOption("prefs", prefs);
         options.addArguments("--lang=en");
-
-        options.setLogLevel(ChromeDriverLogLevel.OFF);
 
         ExtendedWebDriver driver = new ChromeDevtoolsDriver(options);
         driver.manage().timeouts().implicitlyWait(WebPage.STD_TIMEOUT);

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/activation/ActivateRequestContextinEETest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/activation/ActivateRequestContextinEETest.java
@@ -20,8 +20,8 @@ import static org.testng.Assert.assertTrue;
 
 import java.net.URL;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.cdi.tck.AbstractTest;

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/application/ApplicationContextTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/application/ApplicationContextTest.java
@@ -34,8 +34,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * @author David Allen

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/application/async/ApplicationContextAsyncListenerTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/application/async/ApplicationContextAsyncListenerTest.java
@@ -23,8 +23,8 @@ import static org.testng.Assert.assertTrue;
 
 import java.net.URL;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.cdi.tck.AbstractTest;

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/ApplicationContextDestructionTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/application/destroy/ApplicationContextDestructionTest.java
@@ -37,8 +37,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * Test that the application context is destroyed when the application is shut down.

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/application/event/ApplicationScopeEventMultiWarTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/application/event/ApplicationScopeEventMultiWarTest.java
@@ -23,8 +23,8 @@ import java.net.URL;
 
 import jakarta.servlet.ServletContext;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.Testable;
 import org.jboss.arquillian.test.api.ArquillianResource;

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/AbstractConversationTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/AbstractConversationTest.java
@@ -22,10 +22,10 @@ import java.util.Set;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.cdi.tck.AbstractTest;
 
-import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlElement;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import org.htmlunit.Page;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlElement;
+import org.htmlunit.html.HtmlPage;
 
 public abstract class AbstractConversationTest extends AbstractTest {
 

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ClientConversationContextTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ClientConversationContextTest.java
@@ -32,12 +32,12 @@ import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlSpan;
-import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+import org.htmlunit.Page;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlSpan;
+import org.htmlunit.html.HtmlSubmitInput;
 
 /**
  * @author Nicklas Karlsson

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/InvalidatingSessionDestroysConversationTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/InvalidatingSessionDestroysConversationTest.java
@@ -29,7 +29,7 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 
 /**
  * @author Nicklas Karlsson

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ManualCidPropagationTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/ManualCidPropagationTest.java
@@ -25,9 +25,9 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlSubmitInput;
 
 /**
  * @author Nicklas Karlsson

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/ConversationDeterminationTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/determination/ConversationDeterminationTest.java
@@ -32,8 +32,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * @author Martin Kouba

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/LongRunningConversationLifecycleEventTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/LongRunningConversationLifecycleEventTest.java
@@ -30,8 +30,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * <p>

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/TransientConversationLifecycleEventTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/TransientConversationLifecycleEventTest.java
@@ -30,8 +30,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * <p>

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/DestroyConversationNotAssociatedWithCurrentRequestEventTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/event/notattached/DestroyConversationNotAssociatedWithCurrentRequestEventTest.java
@@ -31,8 +31,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * @author Martin Kouba

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/ConversationFilterTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/filter/ConversationFilterTest.java
@@ -41,10 +41,10 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.util.Cookie;
+import org.htmlunit.Page;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.util.Cookie;
 
 /**
  *

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/ServletConversationTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/conversation/servlet/ServletConversationTest.java
@@ -27,7 +27,7 @@ import java.net.URL;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.gargoylesoftware.htmlunit.FailingHttpStatusCodeException;
+import org.htmlunit.FailingHttpStatusCodeException;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.cdi.tck.AbstractTest;
@@ -39,13 +39,13 @@ import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.Page;
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.html.HtmlElement;
-import com.gargoylesoftware.htmlunit.html.HtmlPage;
-import com.gargoylesoftware.htmlunit.html.HtmlSubmitInput;
-import com.gargoylesoftware.htmlunit.html.HtmlTextInput;
+import org.htmlunit.Page;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
+import org.htmlunit.html.HtmlElement;
+import org.htmlunit.html.HtmlPage;
+import org.htmlunit.html.HtmlSubmitInput;
+import org.htmlunit.html.HtmlTextInput;
 
 /**
  * 

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/RequestContextTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/RequestContextTest.java
@@ -33,8 +33,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 @Test(groups = INTEGRATION)
 @SpecVersion(spec = "cdi", version = "2.0")

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/async/RequestContextAsyncListenerTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/async/RequestContextAsyncListenerTest.java
@@ -22,8 +22,8 @@ import static org.jboss.cdi.tck.cdi.Sections.REQUEST_CONTEXT_EE;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 import java.net.URL;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/event/RequestScopeEventTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/event/RequestScopeEventTest.java
@@ -31,8 +31,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * <p>

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/RequestScopeEventAsyncTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/event/async/RequestScopeEventAsyncTest.java
@@ -35,8 +35,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * An event with qualifier @Initialized(RequestScoped.class) is fired when the request context is initialized and an event with

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/RequestScopeEventTimeoutTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/event/timeout/RequestScopeEventTimeoutTest.java
@@ -34,8 +34,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * @author Martin Kouba

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/RequestContextTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/jaxrs/RequestContextTest.java
@@ -33,8 +33,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  *

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/EagerSingletonPostConstructCallbackTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/EagerSingletonPostConstructCallbackTest.java
@@ -31,8 +31,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * Test the request context is active during @PostConstruct callback of an eager singleton.

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/SimpleBeanPostConstructCallbackTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/request/postconstruct/SimpleBeanPostConstructCallbackTest.java
@@ -32,8 +32,8 @@ import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * Test the request context is active during @PostConstruct callback of a simple bean.

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/SessionContextTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/SessionContextTest.java
@@ -35,8 +35,8 @@ import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 @SpecVersion(spec = "cdi", version = "2.0")
 public class SessionContextTest extends AbstractTest {

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SessionContextAsyncListenerTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/async/SessionContextAsyncListenerTest.java
@@ -37,8 +37,8 @@ import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  *

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/event/SessionScopeEventTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/event/SessionScopeEventTest.java
@@ -31,8 +31,8 @@ import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * <p>

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SessionContextHttpSessionListenerTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SessionContextHttpSessionListenerTest.java
@@ -32,8 +32,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  *

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SessionContextServletRequestListenerTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/SessionContextServletRequestListenerTest.java
@@ -30,8 +30,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 @SpecVersion(spec = "cdi", version = "2.0")
 public class SessionContextServletRequestListenerTest extends AbstractTest {

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/SessionContextListenerShutdownTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/context/session/listener/shutdown/SessionContextListenerShutdownTest.java
@@ -39,8 +39,8 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * Test the session context is active during {@link HttpSessionListener#sessionDestroyed(jakarta.servlet.http.HttpSessionEvent)}

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/DecoratorInstanceIsDependentObjectTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/decorators/definition/lifecycle/DecoratorInstanceIsDependentObjectTest.java
@@ -19,8 +19,8 @@ import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.DECORATORS;
 import static org.testng.Assert.assertTrue;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.cdi.tck.AbstractTest;

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/ApplicationShutdownLifecycleTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/deployment/shutdown/ApplicationShutdownLifecycleTest.java
@@ -32,8 +32,8 @@ import jakarta.enterprise.context.RequestScoped;
 import jakarta.enterprise.context.SessionScoped;
 import jakarta.enterprise.inject.spi.BeforeShutdown;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 import org.jboss.arquillian.container.test.api.Deployer;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.OperateOnDeployment;

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ee/RequestContextLifecycleEventObserverOrderingTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/event/observer/priority/contextLifecycleEvent/ee/RequestContextLifecycleEventObserverOrderingTest.java
@@ -21,8 +21,8 @@ import static org.jboss.cdi.tck.cdi.Sections.OBSERVER_ORDERING;
 import java.io.IOException;
 import java.net.URL;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.cdi.tck.AbstractTest;

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/BuiltinMetadataEEBeanTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/metadata/ee/BuiltinMetadataEEBeanTest.java
@@ -21,7 +21,7 @@ import static org.jboss.cdi.tck.cdi.Sections.BEAN_METADATA_EE;
 import java.io.IOException;
 import java.net.URL;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.test.api.ArquillianResource;

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/servlet/ServletContainerBuiltinBeanTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/builtin/servlet/ServletContainerBuiltinBeanTest.java
@@ -36,8 +36,8 @@ import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * Test that servlet container built-in beans are available for injection.

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/JavaEEComponentsTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/ee/components/JavaEEComponentsTest.java
@@ -33,8 +33,8 @@ import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.TextPage;
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.TextPage;
+import org.htmlunit.WebClient;
 
 /**
  * Right now only Servlet Java EE component is tested.

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/ClientProxyTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/clientProxy/incontainer/ClientProxyTest.java
@@ -29,7 +29,7 @@ import org.jboss.test.audit.annotations.SpecAssertion;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 
 @Test(groups = INTEGRATION)
 @SpecVersion(spec = "cdi", version = "2.0")

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/el/integration/IntegrationWithUnifiedELTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/el/integration/IntegrationWithUnifiedELTest.java
@@ -33,7 +33,7 @@ import org.jboss.test.audit.annotations.SpecAssertions;
 import org.jboss.test.audit.annotations.SpecVersion;
 import org.testng.annotations.Test;
 
-import com.gargoylesoftware.htmlunit.WebClient;
+import org.htmlunit.WebClient;
 
 @Test(groups = INTEGRATION)
 @SpecVersion(spec = "cdi", version = "2.0")

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/InjectionIntoNonContextualComponentTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/InjectionIntoNonContextualComponentTest.java
@@ -25,8 +25,8 @@ import static org.jboss.cdi.tck.cdi.Sections.INJECTION_EE;
 
 import java.net.URL;
 
-import com.gargoylesoftware.htmlunit.WebClient;
-import com.gargoylesoftware.htmlunit.WebResponse;
+import org.htmlunit.WebClient;
+import org.htmlunit.WebResponse;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.cdi.tck.AbstractTest;


### PR DESCRIPTION
**Additional context**
The CDI extra tests contain a single test that parses the .js from Faces. This can currently only done with Selenium (using Chromium). The version of Selenium the project was already using couldn't get passed Chrome 114, so needed updating.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
