### PR TITLE
Fix missing versions for various plugins

### DIFF
--- a/glassfish-runner/concurrency-tck/pom.xml
+++ b/glassfish-runner/concurrency-tck/pom.xml
@@ -131,6 +131,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
                 <configuration>
                     <release>17</release>
                 </configuration>
@@ -164,6 +165,7 @@
 
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
 
                 <configuration>
                     <argLine>-Xmx768m</argLine>

--- a/glassfish-runner/pages-tck/pages-tck-run/pom.xml
+++ b/glassfish-runner/pages-tck/pages-tck-run/pom.xml
@@ -139,6 +139,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
                 <configuration>
                     <release>17</release>
                 </configuration>
@@ -174,8 +175,8 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.2</version>
                 <configuration>
                     <dependenciesToScan>
                         <dependenciesToScan>jakarta.tck:jakarta-pages-tck</dependenciesToScan>

--- a/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-run/pom.xml
@@ -115,7 +115,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <version>3.8.1</version>
                 <executions>

--- a/glassfish-runner/servlet-tck/servlet-tck-run/pom.xml
+++ b/glassfish-runner/servlet-tck/servlet-tck-run/pom.xml
@@ -166,6 +166,7 @@
         <plugins>
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
                 <configuration>
                     <release>17</release>
                 </configuration>
@@ -236,8 +237,8 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.2</version>
                 <configuration>
                     <argLine>-Duser.language=en 
                           -Duser.country=US 


### PR DESCRIPTION
The plugin versions actually used were before dependend on the maven version used.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
