### PR TITLE
JDBC runner changes for glassfish8

### DIFF
--- a/glassfish-runner/platform/jdbc-platform-tck/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/pom.xml
@@ -18,12 +18,14 @@
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <groupId>org.glassfish</groupId>
-        <artifactId>standalone-tck</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../pom.xml</relativePath>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.9</version>
+        <relativePath />
     </parent>
+
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jdbc-platform-tck</artifactId>
     <version>11.0.0-SNAPSHOT</version>
@@ -31,12 +33,17 @@
     <properties>
         <arquillian.core.version>1.9.1.Final</arquillian.core.version>
         <exec.asadmin>${glassfish.home}/glassfish/bin/asadmin</exec.asadmin>
-        <glassfish.home>${project.build.directory}/glassfish7</glassfish.home>
+        <glassfish.home>${project.build.directory}/glassfish8</glassfish.home>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
         <jdbc.db>derby</jdbc.db>
+        <ts.home>./jakartaeetck</ts.home>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <sql.directory>./sql</sql.directory>
         <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
+        <!-- Use JDK17 to run with GF-8.0.0-JDK17-M7 -->
+        <glassfish.version>8.0.0-JDK17-M9</glassfish.version>
+        <jakarta.tck.tools.version>11.0.0-RC4</jakarta.tck.tools.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -289,7 +296,7 @@ CALL SYSCS_UTIL.SYSCS_SET_DATABASE_PROPERTY('derby.database.classpath', 'CTS1.CS
                             <systemPropertyVariables>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
                                 <java.naming.factory.initial>com.sun.enterprise.naming.impl.SerialInitContextFactory</java.naming.factory.initial>
-                                <ts.home>${env.TS_HOME}</ts.home>
+                                <ts.home>${ts.home}</ts.home>
                                 <project.basedir>${project.basedir}</project.basedir>
                                 <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>
@@ -322,7 +329,7 @@ CALL SYSCS_UTIL.SYSCS_SET_DATABASE_PROPERTY('derby.database.classpath', 'CTS1.CS
                             <systemPropertyVariables>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
                                 <java.naming.factory.initial>com.sun.enterprise.naming.impl.SerialInitContextFactory</java.naming.factory.initial>
-                                <ts.home>${env.TS_HOME}</ts.home>
+                                <ts.home>${ts.home}</ts.home>
                                 <project.basedir>${project.basedir}</project.basedir>
                                 <arquillian.xml>arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>


### PR DESCRIPTION
**Describe the change**
- Use glassfish8 for jdbc runner
- Correct runner parent pom to run the Jenkins job https://ci.eclipse.org/jakartaee-tck/job/11/job/tck/job/jakarta-jdbc-tck-glassfish/  