### PR TITLE
Update to el platform tck and runner

### DIFF
--- a/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>expression-language-extra-tck-install</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Expression Language Platform Substitute TCK</name>
 
@@ -73,7 +73,7 @@
                             <file>${project.build.directory}/jakartaeetck/artifacts/el-platform-tck-${tck.test.expression-language-extra.version}.jar</file>
                             <groupId>jakarta.tck</groupId>
                             <artifactId>el-platform-tck</artifactId>
-                            <version>6.0.0-M1</version>
+                            <version>${tck.test.expression-language-extra.version}</version>
                             <packaging>jar</packaging>
                         </configuration>
                     </execution>

--- a/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-run/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-run/pom.xml
@@ -35,7 +35,7 @@
         <glassfish.version>8.0.0-M9</glassfish.version>
         
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
-        <tck.version>6.0.0-M1</tck.version>
+        <tck.version>11.0.0-SNAPSHOT</tck.version>
         <ts.home>./jakartaeetck</ts.home>
     </properties>
 

--- a/tcks/apis/expression-language/expression-language-inside-container/pom.xml
+++ b/tcks/apis/expression-language/expression-language-inside-container/pom.xml
@@ -20,10 +20,10 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakarta.tck</groupId>
+        <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
-        <relativePath>../../../../pom.xml</relativePath>
+        <version>1.0.9</version>
+        <relativePath />
     </parent>
 
     <artifactId>el-platform-tck</artifactId>


### PR DESCRIPTION
**Describe the change**
- update to parent pom of el platform tck as jakarta.tck:project:pom:11.0.0-SNAPSHOT is not available. (M1 is available)
- update the tck version to 11.0.0-SNAPSHOT in runner
- Requires staging of platform tck 