### PR TITLE
Fix the build

### DIFF
--- a/arquillian/pom.xml
+++ b/arquillian/pom.xml
@@ -85,16 +85,4 @@
             <version>5.11.4</version>
         </dependency>
     </dependencies>
-
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-run/pom.xml
+++ b/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-run/pom.xml
@@ -12,11 +12,11 @@
   
   ejb30 lite env tests:
   
-  mvn spotless:apply && mvn clean install -Dglassfish.version=8.0.0-SNAPSHOT -Dmaven.build.cache.enabled=false -Pejb30,exclude-timeout,ejb30_lite_env
+  mvn clean install -Dglassfish.version=8.0.0-SNAPSHOT -Dmaven.build.cache.enabled=false -Pejb30,exclude-timeout,ejb30_lite_env
   
   ejb30 assembly, misc and tx tests:
   
-  mvn spotless:apply && mvn clean install -Dglassfish.version=8.0.0-SNAPSHOT -Dmaven.build.cache.enabled=false -Pejb30,exclude-timeout,ejb30_assembly_misc_tx
+  mvn clean install -Dglassfish.version=8.0.0-SNAPSHOT -Dmaven.build.cache.enabled=false -Pejb30,exclude-timeout,ejb30_assembly_misc_tx
   
   etc
   

--- a/pom.xml
+++ b/pom.xml
@@ -711,52 +711,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <version>2.36.0</version>
-                <configuration>
-                    <pom>
-                        <includes>
-                            <include>pom.xml</include>
-                        </includes>
-                        <sortPom>
-                            <nrOfIndentSpace>4</nrOfIndentSpace>
-                            <!-- default see https://github.com/Ekryd/sortpom/wiki/PredefinedSortOrderProfiles -->
-                            <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
-                            <!-- Sort properties -->
-                            <sortProperties>true</sortProperties>
-                            <!-- Sort plugin executions -->
-                            <sortExecutions>true</sortExecutions>
-                        </sortPom>
-                    </pom>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>check-spotless-poms</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>validate</phase>
-                        <configuration>
-                            <skip>${release}</skip>
-                            <pom combine.children="append">
-                                <sortPom combine.children="append">
-                                    <nrOfIndentSpace>4</nrOfIndentSpace>
-                                    <!-- default see https://github.com/Ekryd/sortpom/wiki/PredefinedSortOrderProfiles -->
-                                    <predefinedSortOrder>recommended_2008_06</predefinedSortOrder>
-                                    <!-- Sort properties -->
-                                    <sortProperties>true</sortProperties>
-                                    <!-- Sort modules -->
-                                    <sortModules>true</sortModules>
-                                    <!-- Sort plugin executions -->
-                                    <sortExecutions>true</sortExecutions>
-                                </sortPom>
-                            </pom>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 

--- a/user_guides/pom.xml
+++ b/user_guides/pom.xml
@@ -159,13 +159,6 @@
                     <skip>true</skip>
                 </configuration>
             </plugin>
-            <plugin>
-                <groupId>com.diffplug.spotless</groupId>
-                <artifactId>spotless-maven-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
The build now fails on every PR check. This was caused by a plugin called spotless.

Removing this plugin also simplifies the build in other placed, where can now build again with regular mvn clean install instead of mvn spotless:apply && mvn clean install.



CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
