### PR TITLE
Tags tck updates for runner and bundle

### DIFF
--- a/glassfish-runner/tags-tck/pom.xml
+++ b/glassfish-runner/tags-tck/pom.xml
@@ -27,7 +27,6 @@
     </parent>
 
     <artifactId>tags-tck</artifactId>
-    <version>4.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/tags-tck/tags-tck-install/pom.xml
+++ b/glassfish-runner/tags-tck/tags-tck-install/pom.xml
@@ -27,13 +27,14 @@
     </parent>
 
     <artifactId>tags-tck-install</artifactId>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta tags TCK</name>
 
     <properties>
-        <tck.test.tags.file>jakarta-tags-tck-${tck.test.tags.version}.zip</tck.test.tags.file>
+        <tck.test.tags.file>jakartaeetck-${tck.test.tags.version}-dist.zip</tck.test.tags.file>
         <tck.test.tags.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.tags.file}</tck.test.tags.url>
-        <tck.test.tags.version>11.0.0-M2</tck.test.tags.version>
+        <tck.test.tags.version>${project.version}</tck.test.tags.version>
     </properties>
 
     <build>
@@ -69,10 +70,10 @@
                         </goals>
                         <phase>process-resources</phase>
                         <configuration>
-                            <file>${project.build.directory}/jakarta-tags-tck-${tck.test.tags.version}.jar</file>
-                            <sources>${project.build.directory}/jakarta-tags-tck-${tck.test.tags.version}-sources.jar</sources>
+                            <file>${project.build.directory}/jakartaeetck/artifacts/tags-tck-${tck.test.tags.version}.jar</file>
+                            <sources>${project.build.directory}/jakartaeetck/artifacts/tags-tck-${tck.test.tags.version}-sources.jar</sources>
                             <groupId>jakarta.tck</groupId>
-                            <artifactId>jakarta-tags-tck</artifactId>
+                            <artifactId>tags-tck</artifactId>
                             <version>${tck.test.tags.version}</version>
                             <packaging>jar</packaging>
                         </configuration>

--- a/glassfish-runner/tags-tck/tags-tck-run/pom.xml
+++ b/glassfish-runner/tags-tck/tags-tck-run/pom.xml
@@ -24,10 +24,8 @@
         <relativePath />
     </parent>
     
-    <groupId>jakarta</groupId>
-    <artifactId>glassfish.jstl-tck</artifactId>
+    <artifactId>glassfish.tags-tck</artifactId>
     <version>11.0.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
 
     <properties>
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>
@@ -35,7 +33,7 @@
         <glassfish.version>8.0.0-JDK17-M9</glassfish.version>
         <glassfish.version.main>8</glassfish.version.main>
         <jakarta.platform.version>11.0.0-M4</jakarta.platform.version>
-        <tck.version>11.0.0-M2</tck.version>
+        <jakarta.tck.tags.version>${project.version}</jakarta.tck.tags.version>
     </properties>
 
     <dependencies>
@@ -50,8 +48,8 @@
         <!-- The actual TCK containing the tests -->
         <dependency>
             <groupId>jakarta.tck</groupId>
-            <artifactId>jakarta-tags-tck</artifactId>
-            <version>${tck.version}</version>
+            <artifactId>tags-tck</artifactId>
+            <version>${jakarta.tck.tags.version}</version>
         </dependency>
 
         <!-- Junit -->
@@ -129,7 +127,7 @@
                         </goals>
                         <configuration>
                             <groups>${testGroups}</groups>
-                            <dependenciesToScan>jakarta.tck:jakarta-tags-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:tags-tck</dependenciesToScan>
                             <systemPropertyVariables>
                                 <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
 

--- a/release/artifact-install.pom
+++ b/release/artifact-install.pom
@@ -329,6 +329,21 @@
                             <generatePom>false</generatePom>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>install-tags-tck</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <configuration>
+                            <groupId>jakarta.tck</groupId>
+                            <artifactId>tags-tck</artifactId>
+                            <version>${project.version}</version>
+                            <packaging>jar</packaging>
+                            <file>tags-tck-${project.version}.jar</file>
+                            <generatePom>false</generatePom>
+                        </configuration>
+                    </execution>
 
                     <execution>
                         <id>install-signaturetest</id>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -217,6 +217,17 @@
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
+            <artifactId>tags-tck</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>tags-tck</artifactId>
+            <version>${project.version}</version>
+            <classifier>sources</classifier>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
             <artifactId>signaturetest</artifactId>
             <version>${jakarta.tck.tools.version}</version>
         </dependency>

--- a/release/src/main/assembly/assembly.xml
+++ b/release/src/main/assembly/assembly.xml
@@ -132,6 +132,7 @@
                 <include>${project.groupId}:jsonp-platform-tck</include>
                 <include>${project.groupId}:pages-platform-tck</include>
                 <include>${project.groupId}:transactions-tck</include>
+                <include>${project.groupId}:tags-tck</include>
                 <include>${project.groupId}:signaturetest</include>
                 <include>${project.groupId}:websocket-tck-platform-tests</include>
                 <include>${project.groupId}:xa</include>

--- a/tcks/apis/tags/pom.xml
+++ b/tcks/apis/tags/pom.xml
@@ -26,36 +26,19 @@
         <relativePath />
     </parent>
 
-    <artifactId>jakarta-tags-tck</artifactId>
+    <groupId>jakarta.tck</groupId>
+    <artifactId>tags-tck</artifactId>
     <version>11.0.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
 
     <name>Jakarta Tags TCK</name>
     <description>This module contains all the tests for the Jakarta Tags TCK</description>
     <url>https://github.com/jakartaee/platform-tck</url>
     
-    <licenses>
-        <license>
-            <name>EPL 2.0</name>
-            <url>http://www.eclipse.org/legal/epl-2.0</url>
-            <distribution>repo</distribution>
-        </license>
-    </licenses>
     
-    <developers>
-        <developer>
-            <id>jakarta-platform-tck-develeopers</id>
-            <name>Platform TCK Developers</name>
-            <organization>Eclipse Foundation</organization>
-            <email>jakartaee-platform-dev@eclipse.org</email>
-        </developer>
-    </developers>
-
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        
-        <jakarta.tck.tools.version>11.0.0-SNAPSHOT</jakarta.tck.tools.version>
+        <jakarta.tck.tools.version>11.0.0-RC4</jakarta.tck.tools.version>
     </properties>
 
     <dependencies>
@@ -87,16 +70,6 @@
             <artifactId>common</artifactId>
             <version>${jakarta.tck.tools.version}</version>
         </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>runtime</artifactId>
-            <version>${jakarta.tck.tools.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>libutil</artifactId>
-            <version>${jakarta.tck.tools.version}</version>
-        </dependency>
         
         <dependency>
             <groupId>commons-httpclient</groupId>
@@ -116,16 +89,6 @@
     </dependencies>
 
     <build>
-        <finalName>${bundle-name}-${project.version}</finalName>
-        
-        <resources>
-            <resource>
-                <directory>src/main/resources</directory>
-                <includes>
-                    <include>com/</include>
-                </includes>
-            </resource>
-        </resources>
         <plugins>
             <!-- Sets minimal Maven version to 3.8.6 -->
             <plugin>
@@ -146,7 +109,7 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.13.0</version>
@@ -154,7 +117,7 @@
                     <release>17</release>
                 </configuration>
             </plugin>
-            
+
             <!-- Configure the jar with the sources. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -168,15 +131,23 @@
                     </execution>
                 </executions>
             </plugin>
-            
+
             <!-- Create Javadoc for API jar -->
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <configuration>
                     <doclint>none</doclint>
                 </configuration>
+                <executions>
+                    <execution>
+                        <id>attach-api-javadocs</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
-            
+
             <!-- Generate a "consumer pom" for the generated jar -->
             <plugin>
                 <groupId>org.codehaus.mojo</groupId>
@@ -206,25 +177,5 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>EFTL</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <bundle-name>jakarta-tags-tck</bundle-name>
-                <license>EFTL</license>
-            </properties>
-        </profile>
-        <profile>
-            <id>EPL</id>
-            <properties>
-                <bundle-name>tags-tck</bundle-name>
-                <license>EPL</license>
-            </properties>
-        </profile>
-    </profiles>
 
 </project>


### PR DESCRIPTION
**Describe the change**
- Add tags tck binary and sources to platform TCK bundle
- Correct the runner to use platform TCK and install the tags tck binary to run the tests

**Additional context**
- The Tags tck sources were brought back to platform TCK repository in PR https://github.com/jakartaee/platform-tck/pull/1892. 

