### PR TITLE
use derby.dml.sql as tsSqlStmtFile in Jdbc glassfish test runner

### DIFF
--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/src/test/resources/arquillian.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/src/test/resources/arquillian.xml
@@ -24,7 +24,7 @@
             <property name="clientDir">${project.basedir}</property>
             <property name="workDir">${ts.home}/tmp</property>
             <property name="tsJteFile">${ts.home}/bin/ts.jte</property>
-            <property name="tsSqlStmtFile">${ts.home}/bin/tssql.stmt</property>
+            <property name="tsSqlStmtFile">sql/derby/derby.dml.sql</property>
             <property name="trace">true</property>
             <property name="clientTimeout">20000</property>
         </protocol>


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/1924

**Describe the change**
- Use the correct derby.dml.sql as tsSqlStmtFile which has the fix applied in https://github.com/jakartaee/platform-tck/pull/1328 for the challenge issue https://github.com/jakartaee/platform-tck/issues/1260. 
- 

