### PR TITLE
use derby.dml.sql in appclient tests - jdbc runner

### DIFF
--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/src/test/resources/appclient-arquillian.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/src/test/resources/appclient-arquillian.xml
@@ -56,7 +56,7 @@
             <property name="clientDir">${project.basedir}</property>
             <property name="workDir">${ts.home}/tmp</property>
             <property name="tsJteFile">${ts.home}/bin/ts.jte</property>
-            <property name="tsSqlStmtFile">${ts.home}/bin/tssql.stmt</property>
+            <property name="tsSqlStmtFile">sql/derby/derby.dml.sql</property>
             <property name="trace">true</property>
             <property name="clientTimeout">20000</property>
         </protocol>


### PR DESCRIPTION
**Describe the change**
- update tsSqlStmtFile for appclient tests

Related to https://github.com/jakartaee/platform-tck/pull/1934 and https://github.com/jakartaee/platform-tck/issues/1924

