### PR TITLE
Update websocket platform tests version and runner

### DIFF
--- a/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
@@ -36,10 +36,11 @@
         <tck.test.websocket.file>jakarta-websocket-tck-${tck.test.websocket.version}.zip</tck.test.websocket.file>
         <tck.test.websocket.url>https://download.eclipse.org/jakartaee/websocket/2.2/${tck.test.websocket.file}</tck.test.websocket.url>
         
-        <tck.test.websocket.extra.file>jakarta-websocket-extra-tck-${tck.test.websocket.version}.zip</tck.test.websocket.extra.file>
+        <tck.test.websocket.extra.file>jakartaeetck-${tck.test.websocket.extra.version}-dist.zip</tck.test.websocket.extra.file>
         <tck.test.websocket.extra.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.websocket.extra.file}</tck.test.websocket.extra.url>
         
         <tck.test.websocket.version>2.2.0</tck.test.websocket.version>
+        <tck.test.websocket.extra.version>11.0.0-SNAPSHOT</tck.test.websocket.extra.version>
     </properties>
 
     <build>
@@ -164,11 +165,11 @@
                         </goals>
                         <phase>process-resources</phase>
                         <configuration>
-                            <file>${project.build.directory}/websocket-tck-platform-tests-${tck.test.websocket.version}.jar</file>
-                            <sources>${project.build.directory}/websocket-tck-platform-tests-${tck.test.websocket.version}-sources.jar</sources>
+                            <file>${project.build.directory}/jakartaeetck/artifacts/websocket-tck-platform-tests-${tck.test.websocket.extra.version}.jar</file>
+                            <sources>${project.build.directory}/jakartaeetck/artifacts/websocket-tck-platform-tests-${tck.test.websocket.extra.version}-sources.jar</sources>
                             <groupId>jakarta.tck</groupId>
                             <artifactId>websocket-tck-platform-tests</artifactId>
-                            <version>${tck.test.websocket.version}</version>
+                            <version>${tck.test.websocket.extra.version}</version>
                             <packaging>jar</packaging>
                         </configuration>
                     </execution>

--- a/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-run/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>websocket-platform-extra-tck-run</artifactId>
-    <version>2.2.0-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <name>TCK: Run Jakarta websocket Extra TCK</name>
 
     <properties>
@@ -41,6 +41,8 @@
         <glassfish.version>8.0.0-M9</glassfish.version>
 
         <jakarta.tck.websocket.version>2.2.0</jakarta.tck.websocket.version>
+        <tck.test.websocket.extra.version>11.0.0-SNAPSHOT</tck.test.websocket.extra.version>
+        
     </properties>
 
     <dependencyManagement>
@@ -82,7 +84,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>websocket-tck-platform-tests</artifactId>
-            <version>${jakarta.tck.websocket.version}</version>
+            <version>${tck.test.websocket.extra.version}</version>
         </dependency>
         
         <dependency>

--- a/release/artifact-install.pom
+++ b/release/artifact-install.pom
@@ -401,9 +401,9 @@
                         <configuration>
                             <groupId>jakarta.tck</groupId>
                             <artifactId>websocket-tck-platform-tests</artifactId>
-                            <version>2.2.0</version>
+                            <version>${project.version}</version>
                             <packaging>jar</packaging>
-                            <file>websocket-tck-platform-tests-2.2.0.jar</file>
+                            <file>websocket-tck-platform-tests-${project.version}.jar</file>
                             <generatePom>false</generatePom>
                         </configuration>
                     </execution>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -244,12 +244,12 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>websocket-tck-platform-tests</artifactId>
-            <version>2.2.0</version>
+            <version>${project.version}</version>
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>websocket-tck-platform-tests</artifactId>
-            <version>2.2.0</version>
+            <version>${project.version}</version>
             <classifier>sources</classifier>
         </dependency>
 

--- a/tcks/apis/websocket/platform-tests/pom.xml
+++ b/tcks/apis/websocket/platform-tests/pom.xml
@@ -27,12 +27,14 @@
     <artifactId>websocket-tck-platform-tests</artifactId>
     <packaging>jar</packaging>
     <name>Jakarta Websocket TCK Platform Tests</name>
+    <version>11.0.0-SNAPSHOT</version>
+    
 
     <dependencies>
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>websocket-tck-common</artifactId>
-            <version>${project.version}</version>
+            <version>${project.parent.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>


### PR DESCRIPTION
**Describe the change**
- Update the version of websocket platform tests to 11.0.0-SNAPSHOT 
- Update the runner to use the websocket platform jar from the staged platform TCK bundle 

I believe it will be apt to change the version of websocket platform test jar to same as 11.0.0 instead of the api version (2.2.0) since it will be part of platform TCK bundle. As of now the websocket component TCK (https://download.eclipse.org/jakartaee/websocket/2.2/jakarta-websocket-tck-2.2.0.zip) has websocket spec & common jars.

cc @gurunrao @arjantijms @starksm64 @scottmarlow 

