### PR TITLE
Fix archive name according to default convention, another deployment have same name and can cause issue with multithread testing

### DIFF
--- a/tcks/apis/websocket/spec-tests/src/main/java/com/sun/ts/tests/websocket/negdep/onmessage/srv/binaryduplicate/WSCClientIT.java
+++ b/tcks/apis/websocket/spec-tests/src/main/java/com/sun/ts/tests/websocket/negdep/onmessage/srv/binaryduplicate/WSCClientIT.java
@@ -50,7 +50,7 @@ public class WSCClientIT extends NegativeDeploymentClient {
 	public static WebArchive createDeployment() throws IOException {
 
 		WebArchive archive = ShrinkWrap.create(WebArchive.class,
-				"wsc_negdep_onmessage_srv_binaryinputstreamboolean_web.war");
+				"wsc_negdep_onmessage_srv_binaryduplicate_web.war");
 		archive.addPackages(false, Filters.exclude(WSCClientIT.class),
 				"com.sun.ts.tests.websocket.negdep.onmessage.srv.binaryduplicate");
 		archive.addPackages(false, Filters.exclude(NegativeDeploymentClient.class),


### PR DESCRIPTION
Signed-off-by: Olivier Lamy <olamy@apache.org>

**Fixes Issue**
Specify the issue (link) that is solved with this pull request.

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
A clear and concise description of the change.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
