### PR TITLE
Userguide updates

### DIFF
--- a/tools/version/src/main/java/ee/tck/versions/VerifyHashes.java
+++ b/tools/version/src/main/java/ee/tck/versions/VerifyHashes.java
@@ -51,12 +51,14 @@ public class VerifyHashes {
         if(!Files.exists(stagedJars)) {
             Files.createDirectory(stagedJars);
         }
+        System.out.println("Downloading jars to " + stagedJars);
         // Download the jars from the maven repository
         for (Path jarFile : jarFiles) {
             String jarFileName = jarFile.getFileName().toString();
             Matcher matcher = VERSION_PATTERN.matcher(jarFileName);
+            Path repoJar = stagedJars.resolve(jarFile);
             // Skip if a sources or javadoc jar, or already downloaded
-            if (matcher.matches() && !Files.exists(jarFile)) {
+            if (matcher.matches() && !Files.exists(repoJar)) {
                 String artifactId = matcher.group(1);
                 String version = matcher.group(2);
 
@@ -64,10 +66,10 @@ public class VerifyHashes {
                 System.out.println("Downloading " + url);
                 URL stagingUrl = new URL(url);
                 try (InputStream is = stagingUrl.openStream()) {
-                    is.transferTo(Files.newOutputStream(stagedJars.resolve(jarFileName)));
+                    is.transferTo(Files.newOutputStream(repoJar));
                 }
             } else {
-                //System.out.println("Skipping " + jarFileName);
+                System.out.printf("Skipping non-test artifact: '%s'\n", jarFileName);
             }
         }
     }

--- a/user_guides/platform/src/main/asciidoc/TCKpreface.adoc
+++ b/user_guides/platform/src/main/asciidoc/TCKpreface.adoc
@@ -54,16 +54,12 @@ implementation of the Jakarta EE {tck_version} Specification.
 Before reading this guide, you should familiarize yourself with the Java
 programming language, the Jakarta Platform, Enterprise Edition {tck_version} Specification, and the JavaTest documentation.
 
-The Jakarta Platform, Enterprise Edition {tck_version} Specification can be
-downloaded from `https://projects.eclipse.org/projects/ee4j.jakartaee-platform`.
+The Jakarta Platform, Enterprise Edition {tck_version} Specification can be downloaded from https://jakarta.ee/specifications/{tck_version}.
 
-For documentation on the test harness used for running the Jakarta EE {tck_version} Platform TCK
-test suite, see:
+For documentation on the test harness used for running the Jakarta EE {tck_version} Platform TCK test suite, see:
 
 * https://github.com/arquillian/arquillian-core[Arquillian]
 * https://junit.org/junit5/[Junit5]
-
-`https://wiki.openjdk.java.net/display/CodeTools/Documentation`.
 
 [[typographic-conventions]]
 = Typographic Conventions

--- a/user_guides/platform/src/main/asciidoc/config.adoc
+++ b/user_guides/platform/src/main/asciidoc/config.adoc
@@ -139,7 +139,7 @@ The default setting is `localhost`.
 which the Web server is running and configured with the CI.
 The default setting is `8001`.
 ..  Set the database-related properties in the `<TS_HOME>/bin/ts.jte`
-file. <<c.3-database-properties-in-ts.jte>>lists the names and descriptions for the database properties you need to set.
+file. <<c.3-database-properties-in-ts.jte>> lists the names and descriptions for the database properties you need to set.
 .  Install the Jakarta EE {tck_version} CI and configure basic settings, as described
 in <<installation>>
 .  Start the Jakarta EE {tck_version} CI application server.
@@ -177,7 +177,7 @@ which the Web server is running and configured with the CI. +
 The default setting is `8001`.
 
 ..  Set the `porting.ts.url.class` property to your porting
-implementation class that is used for obtaining URLs.
+implementation class that is used for obtaining URLs. See <<porting-package-apis>> for more information.
 
 ..  Set the database-related properties in the `<TS_HOME>/bin/ts.jte`
 file. <<c.3-database-properties-in-ts.jte>> lists the names and descriptions for the database properties you need to set.
@@ -236,7 +236,7 @@ server.
 
 . Provide access to a Web server.
 
-. Provide access to a Jakarta Mail server that supports the SMTP protocol.
+. Provide access to a Jakarta Mail server that supports the SMTP protocol. (Full Platform only)
 
 . Install server certificates +
 +
@@ -260,18 +260,16 @@ certificate that suits your environment.
 
 ..  `clientcert.p12`: Contains TCK client certificate in `pkcs12` format
 
-.. Make the appropriate transaction interoperability setting on the Jakarta EE {tck_version} server and the server that is running the Jakarta EE {tck_version} CI.
+. Make the appropriate transaction interoperability setting on the Jakarta EE {tck_version} server and the server that is running the Jakarta EE {tck_version} CI.
 
+. If necessary, refer to the sections later in this chapter for
+additional configuration information you may require for your particular test goals. +
 
-.. If necessary, refer to the sections later in this chapter for
-additional configuration information you may require for your particular
-test goals. +
+. Restart your Jakarta EE {tck_version} server.
 
-.. Restart your Jakarta EE {tck_version} server.
+. Install the Jakarta EE {tck_version} CI.
 
-.. Install the Jakarta EE {tck_version} CI.
-
-.. Set the following properties in your `<TS_HOME>/bin/ts.jte` file. +
+. Set the following properties in your `<TS_HOME>/bin/ts.jte` file. +
 The current values should be saved since they will be needed later in this step.
 
 * Set the `javaee.home.ri` property to the location where the Jakarta EE {tck_version}
@@ -303,7 +301,6 @@ This section includes the following topics:
 
 * <<test-harness-setup>>
 * <<windows-specific-properties>>
-* <<jakarta-servlet-test-setup>>
 * <<jakarta-websocket-test-setup>>
 * <<jdbc-test-setup>>
 * <<jakarta-mail-test-setup>>
@@ -339,7 +336,7 @@ porting.ts.tsHttpsURLConnection.class.1=<vendor-HttpsURLConnection-class>
 [[full-list-tsjte-properties]]
 ==== Complete List of `ts.jte' Properties
 
-These are the properties that need to have a in the `ts.jte` file provided to the test runner:
+These are the properties that need to have a value in the `ts.jte` file provided to the test runner:
 
 * s1as
 * s1as.modules
@@ -449,53 +446,6 @@ When configuring the CI and TCK for the Windows environment, never
 specify drive letters in any path properties in `ts.jte`.
 
 ======================================================================
-
-
-[[jakarta-servlet-test-setup]]
-=== Jakarta Servlet Test Setup
-
-Make sure that the following servlet properties have been set in the
-`ts.jte` file:
-
-[source,properties]
-----
-ServletClientThreads=[2X size of default servlet instance pool] 
-servlet_waittime=[number_of_milliseconds]
-servlet_async_wait=[number_of_seconds]
-logical.hostname.servlet=server
-s1as.java.endorsed.dirs=${endorsed.dirs}${pathsep}${ts.home}/endorsedlib
-----
-
-The `servlet_waittime` property specifies the amount of time, in
-milliseconds, to wait between the time when the `HttpSession` is set to
-expire on the server and when the `HttpSession` actually expires on the
-client. This time is configurable to allow the servlet container enough
-time to completely invalidate the `HttpSession`. The default value is 10
-milliseconds.
-
-The test `serverpush` in Jakarta Servlet 6.0, uses `httpclient`, a new library
-in JDK9 that depends on `java.util.concurrent.flow` (also new class in JDK9).
-
-The `servlet_async_wait` property sets the duration of time in seconds
-to wait between sending asynchronous messages. This property is used in
-place to test non-interrupted IO, where two messages are sent in two
-different batches and the receiving end will be read in a different read
-cycle. This property sets the time to wait in seconds on the sending
-side. The default is 4 seconds.
-
-The `logical.hostname.servlet` property identifies the configuration
-name of the logical host on which the `ServletContext` is deployed. This
-used to identify the name of a logical host that processes Jakarta EE {tck_version}
-requests. Jakarta EE {tck_version} requests may be directed to a logical host using
-various physical or virtual host names or addresses, and a message
-processing runtime may be composed of multiple logical hosts. The
-`logical.hostname.servlet` property is required to properly identify the
-Jakarta EE {tck_version} profile's `AppContextId` hostname. This property is used by
-the Jakarta EE {tck_version} security tests as well as by the
-`ServletContext.getVirtualServerName()` method. If a
-`logical.hostname.servlet` does not exist, set this property to the
-default hostname (for example, `webServerHost`). The default is
-"server".
 
 [[jakarta-websocket-test-setup]]
 === Jakarta WebSocket Test Setup
@@ -1057,9 +1007,9 @@ to Chapter 7 of the Jakarta Persistence API Specification
 (`https://jakarta.ee/specifications/persistence/3.2`) for additional information regarding entity managers.
 
 [NOTE]
-===
+====
 There is a test of installing a custom Jakarta Persistence provider in the Jakarta Persistence API tests. The tests expect that the log.file.location from the ts.jte file has been propagated to a system property in the server environment. Normally this is automatically done by the TCK harness, but if  your Jakarta Persistence integration causes the custom `jakarta.persistence.spi.PersistenceProvider` or `jakarta.persistence.spi.ProviderUtil` to initialize before the TCK harness, you may need to set the system property manually.
-===
+====
 
 [[configure-jpa-pluggability-tests]]
 ==== To Configure the Test Environment to Run the Jakarta Persistence Pluggability Tests

--- a/user_guides/platform/src/main/asciidoc/install.adoc
+++ b/user_guides/platform/src/main/asciidoc/install.adoc
@@ -93,7 +93,7 @@ cd jakartaeetck/artifacts
 java VerifyHashes.java
 ----
 
-When run with no arguments this downloads the Jakarta EE staging repository artifacts and validates them against the hashes of the artifacts in the distribution. If you want o validate the artifacts in another repo, pass in the URL to the jakarta.tck groupId in the repository. For example:
+When run with no arguments this downloads the Jakarta EE staging repository artifacts and validates them against the hashes of the artifacts in the distribution. If you want to validate the artifacts in another repo, pass in the URL to the jakarta.tck groupId in the repository. For example:
 [source,bash]
 ----
 java VerifyHashes.java https://repo1.maven.org/maven2/jakarta/tck/

--- a/user_guides/platform/src/main/asciidoc/intro.adoc
+++ b/user_guides/platform/src/main/asciidoc/intro.adoc
@@ -309,7 +309,7 @@ based on a particular file system behavior, and so on) may be excluded.
 
 [NOTE]
 ======================================================================
-Implementers are not permitted to alter or modify Excluded Tests. Changes the Excluded Tests can only be made by using the procedure described in
+Implementers are not permitted to alter or modify which tests are Excluded Tests. Changes the Excluded Tests can only be made by using the procedure described in
 <<appeals-process-ee>> and <<appeals-process-wp>>
 ======================================================================
 
@@ -363,7 +363,7 @@ Linux software that meet the following software requirements:
 ** Any operating system that supports the Java SE 17 or 21 platform
 * Java SE 17 or 21
 * Jakarta EE {tck_version} CI or Jakarta EE {tck_version} Web Profile CI
-* Mail server that supports the IMAP and SMTP protocols
+* Mail server that supports the IMAP and SMTP protocols (Full Platform Only)
 * One of the following databases:
 ** MySQL
 ** Apache Derby
@@ -373,39 +373,42 @@ Linux software that meet the following software requirements:
 
 // edburns check these versions and links please
 In addition to the instructions and requirements described in this
-document, all Jakarta EE {tck_version} Platform implementations must
-also pass the standalone TCKs for the following technologies:
+document, all Jakarta EE {tck_version} Platform implementations must also pass the standalone TCKs for the following technologies:
 
 * Jakarta Activation -- see https://jakarta.ee/specifications/activation/ for additional details
-* Jakarta Authentication -- see https://jakarta.ee/specifications/authentication/3.0/ for additional details
+* Jakarta Authentication -- see https://jakarta.ee/specifications/authentication/3.1/ for additional details
 * Jakarta Batch -- see https://jakarta.ee/specifications/batch/2.1/ for additional details
-* Jakarta Bean Validation -- see https://jakarta.ee/specifications/bean-validation/3.0/ for additional details
-* Jakarta Concurrency -- see https://jakarta.ee/specifications/concurrency/3.0/ for additional details
-* Jakarta Contexts and Dependency Injection (including Language Model TCK) -- see https://jakarta.ee/specifications/cdi/4.0/ for additional details
+* Jakarta Bean Validation -- see https://jakarta.ee/specifications/bean-validation/3.1/ for additional details
+* Jakarta Concurrency -- see https://jakarta.ee/specifications/concurrency/3.1/ for additional details
+* Jakarta Contexts and Dependency Injection (including Language Model TCK) -- see https://jakarta.ee/specifications/cdi/4.1/ for additional details
+* Jakarta Data -- see https://jakarta.ee/specifications/data/1.0/
 * Jakarta Debugging Support for Other Languages -- see https://jakarta.ee/specifications/debugging/ for additional details
 * Jakarta Dependency Injection -- see https://jakarta.ee/specifications/dependency-injection/2.0/ , for additional details
 * Jakarta Faces -- see https://jakarta.ee/specifications/faces/4.0/ for additional details
 * Jakarta JSON Binding -- see https://jakarta.ee/specifications/jsonb/3.0/ for additional details
 * Jakarta JSON Processing -- see https://jakarta.ee/specifications/jsonp/2.1/ for additional details
 * Jakarta Mail -- see https://jakarta.ee/specifications/mail/2.1/ for additional details
-* Jakarta RESTFul Web Services -- see https://jakarta.ee/specifications/restful-ws/3.1/ for additional details
-* Jakarta Security -- see https://jakarta.ee/specifications/security/3.0/ for additional details
-* Jakarta XML Binding -- see https://jakarta.ee/specifications/xml-binding/3.0/ for additional details
+* Jakarta RESTFul Web Services -- see https://jakarta.ee/specifications/restful-ws/4.0/ for additional details
+* Jakarta Security -- see https://jakarta.ee/specifications/security/4.0/ for additional details
+* Jakarta Servlet -- see https://jakarta.ee/specifications/servlet/6.1/ for additional details
+* Jakarta XML Binding -- see https://jakarta.ee/specifications/xml-binding/4.0/ for additional details
 
 All Jakarta EE {tck_version} Web Profile implementations must also pass the standalone TCKs for the following technologies:
 
 // edburns check these versions and links please
-* Jakarta Authentication -- see https://jakarta.ee/specifications/authentication/3.0/ for additional details
-* Jakarta Bean Validation -- see https://jakarta.ee/specifications/bean-validation/3.0/ for additional details
-* Jakarta Concurrency -- see https://jakarta.ee/specifications/concurrency/3.0/ for additional details
-* Jakarta Contexts and Dependency Injection (including Language Model TCK) -- see https://jakarta.ee/specifications/cdi/4.0/ for additional details
+* Jakarta Authentication -- see https://jakarta.ee/specifications/authentication/3.1/ for additional details
+* Jakarta Bean Validation -- see https://jakarta.ee/specifications/bean-validation/3.1/ for additional details
+* Jakarta Concurrency -- see https://jakarta.ee/specifications/concurrency/3.1/ for additional details
+* Jakarta Contexts and Dependency Injection (including Language Model TCK) -- see https://jakarta.ee/specifications/cdi/4.1/ for additional details
+* Jakarta Data -- see https://jakarta.ee/specifications/data/1.0/
 * Jakarta Debugging Support for Other Languages -- see https://jakarta.ee/specifications/debugging/ for additional details
 * Jakarta Dependency Injection -- see https://jakarta.ee/specifications/dependency-injection/2.0/ for additional details
 * Jakarta Faces -- see https://jakarta.ee/specifications/faces/4.0/ for additional details
 * Jakarta JSON Binding -- see https://jakarta.ee/specifications/jsonb/3.0/ for additional details
 * Jakarta JSON Processing -- see https://jakarta.ee/specifications/jsonp/2.1/ for additional details
-* Jakarta RESTFul Web Services -- see https://jakarta.ee/specifications/restful-ws/3.1/ for additional details
-* Jakarta Security -- see https://jakarta.ee/specifications/security/3.0/ for additional details
+* Jakarta RESTFul Web Services -- see https://jakarta.ee/specifications/restful-ws/4.0/ for additional details
+* Jakarta Security -- see https://jakarta.ee/specifications/security/4.0/ for additional details
+* Jakarta Servlet -- see https://jakarta.ee/specifications/servlet/6.1/ for additional details
 
 
 [[getting-started-with-the-jakarta-ee-platform-tck-test-suite]]

--- a/user_guides/platform/src/main/asciidoc/portingpackage.adoc
+++ b/user_guides/platform/src/main/asciidoc/portingpackage.adoc
@@ -24,8 +24,7 @@ Edition server environment.
 == Overview
 
 The Jakarta Platform, Enterprise Edition CI uses a set of
-module-name-with-extension`.sun-`standard-deployment-desc-component-prefix`.xml`
-files that are associated with each deployable component. GlassFish supports several runtime XML files: `sun-application_1_4-0.xml`, `sun-application-client_1_4-0.xml`,
+component specific deployment descriptors to configure the runtime files that are associated with each deployable component. GlassFish supports several runtime XML files: `sun-application_1_4-0.xml`, `sun-application-client_1_4-0.xml`,
 `sun-ejb-jar_2_1-0.xml`, and `sun-web-app_2_4-0.xml`, for vendor specific information.
 
 To specify your implementation of the `tck.arquillian.porting.lib.spi.AbstractTestArchiveProcessor` class, you need to create an Arquillian `org.jboss.arquillian.core.spi.LoadableExtension` service implementation that registers your subclass of the `tck.arquillian.porting.lib.spi.AbstractTestArchiveProcessor` class. An example is shown in the following listing:
@@ -41,20 +40,22 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 public class JBossTckExtension implements LoadableExtension {
     @Override
     public void register(ExtensionBuilder builder) {
-        builder.service(ResourceProvider.class, JBossXmlProcessor.class);
-        builder.observer(JBossXmlProcessor.class);
+        builder.service(ResourceProvider.class, JBossXmlProcessor.class);<1>
+        builder.observer(JBossXmlProcessor.class);<2>
     }
 }
 ----
+<1> Call the `builder.service` method passing in your subclass of `tck.arquillian.porting.lib.spi.AbstractTestArchiveProcessor`.
+<2> Call the `builder.observer` method passing in your subclass of `tck.arquillian.porting.lib.spi.AbstractTestArchiveProcessor`.
 
-You need to call the `builder.service` and `builder.observer` methods passing in your subclass of `tck.arquillian.porting.lib.spi.AbstractTestArchiveProcessor`. In the above listing it is the `JBossXmlProcessor.class`.
+In the above listing, the `tck.arquillian.porting.lib.spi.AbstractTestArchiveProcessor` subclass is the `JBossXmlProcessor.class`.
 
 The following `com.sun.cts.porting` porting interfaces may need to be implemented if the defaults are not sufficient:
 
 * `TSLoginContextInterface`
 * `TSURLInterface`
 * `TSJMSAdminInterface` (Full Platform Only)
-* `TSHttpsURLConnectionInterface`
+* `TSHttpsURLConnectionInterface` (Full Platform Only)
 
 To use specific implementations of these classes, you simply modify the following `porting.ts.*.class.1` entries of the `ts.jte` environment file to identify the fully-qualified class names:
 
@@ -72,26 +73,15 @@ porting.ts.HttpsURLConnection.class
 <3> <<tsjmsadmininterface>>
 <4> <<tshttpsurlconnectioninterface>>
 
-The `https://github.com/jakartaee/platform-tck/tree/main/tools/common/src/main/java/com/sun/ts/lib/porting` directory contains the interfaces and `Factory` classes for the porting package.
+You can find these interfaces in the `jakarta.tck:common` artifact and the `src/tools/common/src/main/java/com/sun/ts/lib/porting` directory of the TCK distribution.
 
-
-Make sure your porting class implementations meet the following
-requirements:
-
-* Implement the following porting interfaces:
-
-** `TSLoginContextInterface`
-** `TSURLInterface`
-** `TSJMSAdminInterface`
-** `TSHttpsURLConnectionInterface`
-
-* Include the implementation of the previous interfaces in the
+Include the implementation of the previous interfaces in the
 classpaths of the test clients, and the test server
-components:
-
-** In the classpath of your Jakarta Platform, Enterprise Edition server
+components in the classpath of your Jakarta Platform, Enterprise Edition server
 
 Note that because the test harness VM calls certain classes in the TCK porting package directly, porting class implementations are not permitted to exit the VM (for example, by using the `System.exit` call).
+
+Additional implementation details for the porting package are provided in the following sections.
 
 [[porting-package-apis]]
 == Porting Package APIs

--- a/user_guides/platform/src/main/asciidoc/rules-wp.adoc
+++ b/user_guides/platform/src/main/asciidoc/rules-wp.adoc
@@ -53,8 +53,7 @@ intended only as a means for formally specifying the application
 programming interfaces defined by the Specifications.
 
 |Application |A collection of components contained in a single
-application package (such as an EAR file or JAR file) and deployed at
-the same time using a Deployment Tool.
+application package (such as an EAR file or WAR file) and deployed at the same time.
 
 |Computational Resource a|
 A piece of hardware or software that may vary in quantity, existence, or
@@ -84,8 +83,7 @@ Edition Runtime Product, as specified in the Specifications, or a later
 version of a Java Platform, Standard Edition Runtime Product that also
 meets these compatibility requirements.
 
-|Deployment Tool |A tool used to deploy applications or components in a
-Product, as described in the Specifications.
+|Deployment Tool |A tool used to deploy applications or components in a Product, as described in the Specifications.
 
 |Documented |Made technically accessible and made known to users,
 typically by means such as marketing materials, product documentation,
@@ -358,8 +356,10 @@ EE-WP21 Compliance testing for Jakarta EE {tck_version} Web Profile consists of 
 * Jakarta JSON Processing 
 * Jakarta RESTful Web Services
 * Jakarta Security
+* Jakarta Servlet
 * Jakarta XML Binding (If XML Binding is supported)
 
+See <<additional-jakarta-ee-platform-tck-requirements>> for additional information on the component specification TCKs.
 
 In addition to the compatibility rules outlined in this TCK User's
 Guide, Jakarta EE {tck_version} implementations must also adhere to all the compatibility rules defined in the User's Guides of the aforementioned

--- a/user_guides/platform/src/main/asciidoc/rules.adoc
+++ b/user_guides/platform/src/main/asciidoc/rules.adoc
@@ -56,8 +56,7 @@ intended only as a means for formally specifying the application
 programming interfaces defined by the Specifications.
 
 |Application |A collection of components contained in a single
-application package (such as an EAR file or JAR file) and deployed at
-the same time using a Deployment Tool.
+application package (such as an EAR file or WAR file) and deployed at the same time.
 
 |Computational Resource a|
 A piece of hardware or software that may vary in quantity, existence, or
@@ -90,9 +89,7 @@ meets these compatibility requirements.
 |Deployment Tool |A tool used to deploy applications or components in a
 Product, as described in the Specifications.
 
-|Development Kit |A software product that implements or incorporates a
-Compiler, a Schema Compiler, a Schema Generator, a Java-to-WSDL Tool, a
-WSDL-to-Java Tool, and an RMI Compiler.
+|Development Kit |A software product that implements or incorporates a Compiler, a Schema Compiler, a Schema Generator.
 
 |Documented |Made technically accessible and made known to users,
 typically by means such as marketing materials, product documentation,
@@ -205,13 +202,6 @@ the Maintenance Lead as applicable to a given Version of the Technology.
 |Version |A release of the Technology, as produced through the
 Jakarta EE Specification Process (JESP).
 
-|WSDL-to-Java Output |Output of a WSDL-to-Java tool that is required for
-Web service deployment and invocation.
-
-|WSDL-to-Java Tool |A software development tool that implements or
-incorporates a function that generates web service interfaces for
-clients and endpoints from a WSDL description as specified by the JAXWS
-Specification.
 |=======================================================================
 
 [[rules-for-jakarta-platform-enterprise-edition-version-products]]
@@ -399,19 +389,6 @@ EE21.1 If the Jakarta EE {tck_version} implementation uses a runtime which has
 already been validated by the Technology Compatibility Kit,
 the Jakarta EE {tck_version} implementation may use result of such validation
 to claim its compliance with the Technology Compatibility Kit.
-
-EE22 Source Code in WSDL-to-Java Output when compiled by a Reference
-Compiler must execute properly when run on a Reference Runtime.
-
-EE23 Source Code in WSDL-to-Java Output must be in source file format
-defined by the Java Language Specification (JLS).
-
-EE24 Java-to-WSDL Output must fully meet W3C requirements for the Web
-Services Description Language (WSDL) 1.1.
-
-EE25 A Java-to-WSDL Tool must not produce Java-to-WSDL Output from
-source code that does not conform to the Java Language Specification
-(JLS).
 
 [[appeals-process-ee]]
 == Jakarta Platform, Enterprise Edition Version 11 Test Appeals Process

--- a/user_guides/platform/src/main/asciidoc/title.adoc
+++ b/user_guides/platform/src/main/asciidoc/title.adoc
@@ -1,23 +1,21 @@
 
 = Eclipse Foundation™
 
-Jakarta Platform, Enterprise Edition 11 Test Compatibility Kit User's
-Guide
+Jakarta Platform, Enterprise Edition {tck_version} Test Compatibility Kit User's Guide
 
-Release 11 for Jakarta EE
+Release {tck_version} for Jakarta EE
 
 March 2025
 
 Provides detailed instructions for obtaining, installing, configuring,
-and using the Eclipse Jakarta, Enterprise Edition 11 Compatibility Test
+and using the Eclipse Jakarta, Enterprise Edition {tck_version} Compatibility Test
 Suite for the Full Profile and the Web Profile.
 
 '''''
 
-Jakarta Platform, Enterprise Edition 11 Test Compatibility Kit User's
-Guide, Release 11 for Jakarta EE
+Jakarta Platform, Enterprise Edition {tck_version} Test Compatibility Kit User's Guide, Release {tck_version} for Jakarta EE
 
-Copyright © 2017, 2021 Oracle and/or its affiliates. All rights reserved.
+Copyright © 2017, 2025 Oracle and/or its affiliates, and others. All rights reserved.
 
 
 Emeritus Author: Eric Jendrock

--- a/user_guides/platform/src/main/asciidoc/troubleshooting.adoc
+++ b/user_guides/platform/src/main/asciidoc/troubleshooting.adoc
@@ -10,9 +10,7 @@ Test Suite.
 [[common-tck-problems-and-resolutions]]
 == Common TCK Problems and Resolutions
 
-This section lists common problems that you may encounter as you run the
-Jakarta Platform, Enterprise Edition Test Compatibility Kit software on
-the Jakarta Platform, Enterprise Edition CI, Eclipse {glassfish_version}, and other implementations. It also proposes resolutions for the problems, where applicable.
+This section lists common problems that you may encounter as you run the Jakarta Platform, Enterprise Edition Test Compatibility Kit software on the Jakarta Platform, Enterprise Edition CI, Eclipse {glassfish_version}, and other implementations. It also proposes resolutions for the problems, where applicable.
 
 
 * Problem: +
@@ -42,9 +40,8 @@ You may have the `log.file.location` set in the ts.jte file, but if your Jakarta
 [[support]]
 == Support
 
-Jakarta EE is a community sponsored and community supported project. If you need additional
-assistance, you can reach out to the specific developer community. You will find the 
-list of all Eclipse EE4J projects at `https://projects.eclipse.org/projects/ee4j`. All the sub-projects
-are listed. Each project page has details regarding how to contact their developer community.
+Jakarta EE is a community sponsored and community supported project. If you need additional assistance, you can reach out to the specific developer community. You will find the list of all Eclipse EE4J projects at `https://projects.eclipse.org/projects/ee4j`. All the sub-projects are listed. Each project page has details regarding how to contact their developer community.
 
+For Jakarta EE TCK specific issues, you can reach out to the Jakarta EE TCK project team via the resources listed at `https://projects.eclipse.org/projects/ee4j.jakartaee-tck`.
 
+I

--- a/user_guides/platform/src/main/asciidoc/using.adoc
+++ b/user_guides/platform/src/main/asciidoc/using.adoc
@@ -9,7 +9,8 @@ This chapter includes the following topics:
 * <<jakarta-ee-platform-tck-operating-assumptions>>
 * <<running-the-tests>>
 * <<validating-your-test-configuration>>
-* <<running-a-subset-of-the-tests>>
+* <<using-keywords-to-test>>
+* <<rebuilding-test-for-different-databases>>
 * <<test-reports>>
 
 [NOTE]
@@ -428,7 +429,8 @@ To restrict the tests to the group of tests that are required by the Web Profile
 
 Only tests that are required by the Web Profile will be run.
 
-== Rebuilding Test Directories for Different Databases
+[[rebuilding-test-for-different-databases]]
+== Rebuilding Tests for Different Databases
 
 The following packages in the `jakarta.tck:ejb30` test artifact require rebuilding if you are using a database other than Derby:
 


### PR DESCRIPTION
**Fixes Issue**
#1966 

**Related Issue(s)**
#1753

**Describe the change**
The VerifyHashes.java program was incorrectly validating whether a staged jar had already been downloaded, so that has been corrected.

The userguide has various updates and improvements

