### PR TITLE
Let runners use latest version of the Big Zip

### DIFF
--- a/glassfish-runner/annotations-tck/pom.xml
+++ b/glassfish-runner/annotations-tck/pom.xml
@@ -30,7 +30,7 @@
     
     <groupId>jakarta.tck</groupId>
     <artifactId>glassfish.annotations-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-install/pom.xml
@@ -35,7 +35,7 @@
         <tck.test.cdi-extra.file>jakartaeetck-${tck.test.cdi-extra.version}-dist.zip</tck.test.cdi-extra.file>
         <tck.test.cdi-extra.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.cdi-extra.file}</tck.test.cdi-extra.url>
 
-        <tck.test.cdi-extra.version>11.0.0-SNAPSHOT</tck.test.cdi-extra.version>
+        <tck.test.cdi-extra.version>11.0.0-M7</tck.test.cdi-extra.version>
     </properties>
 
     <build>

--- a/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-run/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <cdi.tck-4-1.version>4.1.0</cdi.tck-4-1.version>
         <!-- The CDI EE Platform Integration TCK Version -->
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
         
         <glassfish.root>${project.build.directory}</glassfish.root>
 

--- a/glassfish-runner/connector-platform-tck/pom.xml
+++ b/glassfish-runner/connector-platform-tck/pom.xml
@@ -33,7 +33,7 @@
 
    <groupId>jakarta.tck</groupId>
    <artifactId>glassfish.connector-platform-tck</artifactId>
-   <version>11.0.0-SNAPSHOT</version>
+   <version>11.0.0-M7</version>
    <packaging>jar</packaging>
 
    <properties>
@@ -68,7 +68,7 @@
         <rapassword1>rapassword1</rapassword1>
         <rauser1>rauser1</rauser1>
         <sql.directory>./sql</sql.directory>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
 
        <jakarta.tck.arquillian.version>11.0.0-RC1</jakarta.tck.arquillian.version>
 

--- a/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-install/pom.xml
+++ b/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-install/pom.xml
@@ -33,7 +33,7 @@
     <properties>
         <tck.test.enterprise-beans.file>jakartaeetck-${tck.test.enterprise-beans.version}-dist.zip</tck.test.enterprise-beans.file>
         <tck.test.enterprise-beans.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.enterprise-beans.file}</tck.test.enterprise-beans.url>
-        <tck.test.enterprise-beans.version>11.0.0-SNAPSHOT</tck.test.enterprise-beans.version>
+        <tck.test.enterprise-beans.version>11.0.0-M7</tck.test.enterprise-beans.version>
     </properties>
 
     <build>

--- a/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-run/src/test/resources/jakartaeetck/tmp/tstest.jte
+++ b/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-run/src/test/resources/jakartaeetck/tmp/tstest.jte
@@ -1,5 +1,5 @@
-#Properties for test: persistCoffeeCreateTimerRollbackStateless
-#Wed Nov 06 14:52:04 CET 2024
+#Properties for test: lookupTimerService
+#Sat Feb 22 13:23:02 CET 2025
 Driver=DriverOnlyUsedIfDriverManagerIsYes
 DriverManager=no
 authpassword=javajoe
@@ -37,6 +37,7 @@ longvarbinarySize=50
 mailuser1=cts1@jsepc04.us.oracle.com
 org.omg.CORBA.ORBClass=foo
 password=j2ee
+password1=cts1
 platform.mode=jakartaEE
 porting.ts.HttpsURLConnection.class.1=com.sun.ts.lib.implementation.sun.javaee.SunRIHttpsURLConnection
 porting.ts.HttpsURLConnection.class.2=com.sun.ts.lib.implementation.sun.javaee.SunRIHttpsURLConnection
@@ -53,18 +54,20 @@ rapassword1=cts1
 rapassword2=cts2
 rauser1=cts1
 rauser2=cts2
+s1as.modules=${javaee.home}/modules
 securedWebServicePort=1044
-service_eetest.vehicles=ejbliteservlet2
+service_eetest.vehicles=ejblitejsf
 sigTestClasspath=${s1as.modules}/glassfish-corba-omgapi.jar${pathsep}${s1as.modules}/glassfish-corba-orb.jar${pathsep}${s1as.modules}/jakarta.enterprise.cdi-api.jar${pathsep}${s1as.modules}/jakarta.json-api.jar${pathsep}${s1as.modules}/jakarta.json.bind-api.jar${pathsep}${s1as.modules}/jakarta.batch-api.jar${pathsep}${s1as.modules}/jakarta.interceptor-api.jar${pathsep}${s1as.modules}/stax2-api.jar${pathsep}${s1as.modules}/jakarta.enterprise.concurrent-api.jar${pathsep}${s1as.modules}/jakarta.websocket-api.jar${pathsep}${s1as.modules}/jakarta.websocket-client-api.jar${pathsep}${s1as.modules}/jakarta.jms-api.jar${pathsep}${s1as.modules}/jakarta.faces.jar${pathsep}${s1as.modules}/jakarta.validation-api.jar${pathsep}${s1as.modules}/jakarta.annotation-api.jar${pathsep}${s1as.modules}/jakarta.xml.bind-api.jar${pathsep}${s1as.modules}/webservices-api-osgi.jar${pathsep}${pathsep}${s1as.modules}/jakarta.ws.rs-api.jar${pathsep}${s1as.modules}/weld-osgi-bundle.jar${pathsep}${s1as.modules}/jakarta.ejb-api.jar${pathsep}${s1as.modules}/jakarta.mail-api.jar${pathsep}${s1as.modules}/jakarta.persistence-api.jar${pathsep}${s1as.modules}/jakarta.resource-api.jar${pathsep}${s1as.modules}/jakarta.authorization-api.jar${pathsep}${s1as.modules}/jakarta.authentication-api.jar${pathsep}${s1as.modules}/jakarta.servlet-api.jar${pathsep}${s1as.modules}/jakarta.inject-api.jar${pathsep}${s1as.modules}/jakarta.el-api.jar${pathsep}${s1as.modules}/jakarta.servlet.jsp-api.jar${pathsep}${s1as.modules}/jakarta.servlet.jsp.jstl-api.jar${pathsep}${jtaJarClasspath}${pathsep}${s1as.modules}/jakarta.security.enterprise-api.jar${pathsep}${s1as.modules}/jakarta.activation-api.jar${pathsep}${jimage.dir}/java.base${pathsep}${jimage.dir}/java.rmi${pathsep}${jimage.dir}/java.sql${pathsep}${jimage.dir}/java.naming
 smtp.port=25
-test_classname=com.sun.ts.tests.ejb32.lite.timer.basic.xa.Client
+test_classname=com.sun.ts.tests.ejb32.lite.timer.basic.concurrency.JsfClient
 transport_protocol=smtp
 ts_home=dummy
 user=j2ee
 user1=cts1
 varbinarySize=48
-vehicle=ejbliteservlet2
-vehicle_archive_name=ejb32_lite_timer_basic_xa_ejbliteservlet2_vehicle_web
+variable.mapper=org.glassfish.expressly.lang.VariableMapperImpl
+vehicle=ejblitejsf
+vehicle_archive_name=ejb32_lite_timer_basic_concurrency_ejblitejsf_vehicle_web
 webServerHost=localhost
 webServerPort=8080
 whitebox-anno_no_md=java\:comp/env/eis/whitebox-anno_no_md

--- a/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>expression-language-extra-tck-install</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Expression Language Platform Substitute TCK</name>
 

--- a/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-run/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-run/pom.xml
@@ -25,7 +25,7 @@
     
     <groupId>jakarta</groupId>
     <artifactId>glassfish.el-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -35,7 +35,7 @@
         <glassfish.version>8.0.0-M9</glassfish.version>
         
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
         <ts.home>./jakartaeetck</ts.home>
     </properties>
 

--- a/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-install/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonb-tck-install</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta JSON-B Extra TCK</name>
 

--- a/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
@@ -27,7 +27,7 @@
     
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsonb-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/glassfish-runner/jsonb-platform-extra-tck/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonp-platform-extra-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-install/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonp-tck-install</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta JSON-P Extra TCK</name>
 

--- a/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
@@ -27,7 +27,7 @@
     
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsonp-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/glassfish-runner/jsonp-platform-extra-tck/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonb-platform-extra-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/mail-platform-tck/pom.xml
+++ b/glassfish-runner/mail-platform-tck/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.mail-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
@@ -63,7 +63,7 @@
         <mail.user>user01</mail.user>
         <mailboxFolder1>${project.build.directory}/../mailboxes</mailboxFolder1>
         <smtp.port>1025</smtp.port>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
     </properties>
 
     <dependencyManagement>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>javamail</artifactId>
-            <version>11.0.0-SNAPSHOT</version>
+            <version>11.0.0-M7</version>
         </dependency>
         <dependency>
             <groupId>org.eclipse.angus</groupId>

--- a/glassfish-runner/messaging-platform-tck/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/pom.xml
@@ -25,7 +25,7 @@
     
     <groupId>jakarta.tck</groupId>
     <artifactId>messaging-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -106,11 +106,11 @@
         <s1as.lib>${javaee.home}/lib</s1as.lib>
         <sql.directory>./sql</sql.directory>
         <tck.artifactId>jms</tck.artifactId>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
         <ts.home>./jakartaeetck</ts.home>
         <user1>cts1</user1>
         <user2>cts1</user2>
-        <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
+        <version.jakarta.tck>11.0.0-M7</version.jakarta.tck>
     </properties>
     <dependencyManagement>
         <dependencies>

--- a/glassfish-runner/messaging-tck/pom.xml
+++ b/glassfish-runner/messaging-tck/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jms-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -85,7 +85,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>jms-tck</artifactId>
-            <version>11.0.0-SNAPSHOT</version>
+            <version>11.0.0-M7</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>

--- a/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-install/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>pages-extra-tck-install</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Pages Platform Extra TCK</name>
 

--- a/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-run/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsp-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -34,7 +34,7 @@
         <jakarta.platform.version>11.0.0-M4</jakarta.platform.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.artifactId>pages-platform-tck</tck.artifactId>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
     </properties>
 
     <!-- The Junit5 test frameworks -->

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-install/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-install/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <tck.test.persistence.file>jakartaeetck-${tck.test.persistence.version}-dist.zip</tck.test.persistence.file>
         <tck.test.persistence.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.persistence.file}</tck.test.persistence.url>
-        <tck.test.persistence.version>11.0.0-SNAPSHOT</tck.test.persistence.version>
+        <tck.test.persistence.version>11.0.0-M7</tck.test.persistence.version>
     </properties>
 
     <build>

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jpa-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
 
     <properties>
         <!-- Require at least Java 17 to compile -->
@@ -42,10 +42,10 @@
         <glassfish.version>8.0.0-JDK17-M9</glassfish.version>
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
 
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
         <jakarta.tck.arquillian.version>11.0.0-RC1</jakarta.tck.arquillian.version>
         <jakarta.tck.tools.version>11.0.0-RC5</jakarta.tck.tools.version>
-        <version.persistence.tck>11.0.0-SNAPSHOT</version.persistence.tck>
+        <version.persistence.tck>11.0.0-M7</version.persistence.tck>
         
         <ts.home>./jakartaeetck</ts.home>
     </properties>

--- a/glassfish-runner/persistence-platform-tck/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>persistence-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/platform/appclient-platform-tck/pom.xml
+++ b/glassfish-runner/platform/appclient-platform-tck/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0-M7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.appclient-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
     <properties>
         <admin.pass>admin</admin.pass>
@@ -62,7 +62,7 @@
         <ri.home>${project.build.directory}/${glassfish.toplevel.dir}/mq</ri.home>
 
         <tck.artifactId>jakarta.jms-tck</tck.artifactId>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
         <tck.version>3.1.0</tck.version>
     </properties>
     <dependencyManagement>
@@ -90,7 +90,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>appclient</artifactId>
-            <version>11.0.0-SNAPSHOT</version>
+            <version>11.0.0-M7</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>

--- a/glassfish-runner/platform/assembly-tck/pom.xml
+++ b/glassfish-runner/platform/assembly-tck/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0-M7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.assembly-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -40,7 +40,7 @@
         <jakarta.tck.arquillian.version>11.0.0-RC1</jakarta.tck.arquillian.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <tck.artifactId>assembly-tck</tck.artifactId>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
         <ts.home>./jakartaeetck</ts.home>
     </properties>
 

--- a/glassfish-runner/platform/integration-platform-tck/pom.xml
+++ b/glassfish-runner/platform/integration-platform-tck/pom.xml
@@ -19,12 +19,12 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0-M7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.integration-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -83,11 +83,11 @@
         <restype>javax.sql.DataSource</restype>
         <sql.directory>./sql</sql.directory>
         <tck.artifactId>integration</tck.artifactId>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
         <ts.home>./jakartaeetck/</ts.home>
         <user1>cts1</user1>
         <user2>cts1</user2>
-        <version.jakarta.tck>11.0.0-SNAPSHOT</version.jakarta.tck>
+        <version.jakarta.tck>11.0.0-M7</version.jakarta.tck>
     </properties>
 
     <dependencyManagement>

--- a/glassfish-runner/platform/javaee-module-tck/pom.xml
+++ b/glassfish-runner/platform/javaee-module-tck/pom.xml
@@ -19,11 +19,11 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0-M7</version>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.javaee-module-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -35,7 +35,7 @@
         <jakarta.platform.version>11.0.0-M2</jakarta.platform.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.artifactId>javaee-tck</tck.artifactId>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
     </properties>
 
     <dependencies>

--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-install/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <tck.test.jdbc.file>jakartaeetck-${tck.test.jdbc.version}-dist.zip</tck.test.jdbc.file>
         <tck.test.jdbc.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.jdbc.file}</tck.test.jdbc.url>
-        <tck.test.jdbc.version>11.0.0-SNAPSHOT</tck.test.jdbc.version>
+        <tck.test.jdbc.version>11.0.0-M7</tck.test.jdbc.version>
     </properties>
 
     <build>

--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jdbc-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
     <properties>
         <arquillian.core.version>1.9.1.Final</arquillian.core.version>
@@ -39,7 +39,7 @@
         <ts.home>./jakartaeetck</ts.home>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <sql.directory>./sql</sql.directory>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
         <jakarta.tck.arquillian.version>11.0.0-RC1</jakarta.tck.arquillian.version>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <!-- Use JDK17 to run with GF-8.0.0-JDK17-M7 -->

--- a/glassfish-runner/platform/jdbc-platform-tck/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>jdbc-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/platform/xa-platform-tck/pom.xml
+++ b/glassfish-runner/platform/xa-platform-tck/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>org.glassfish</groupId>
         <artifactId>standalone-tck</artifactId>
-        <version>11.0.0-SNAPSHOT</version>
+        <version>11.0.0-M7</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.xa-platform-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>jar</packaging>
     <properties>
         <arquillian.core.version>1.9.1.Final</arquillian.core.version>
@@ -62,7 +62,7 @@
         <rauser1>cts1</rauser1>
         <sql.directory>./sql</sql.directory>
         <tck.artifactId>jakarta.tck.jdbc</tck.artifactId>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
 
         <!-- XA properties -->
         <xa.datasource.class>org.apache.derby.jdbc.ClientXADataSource</xa.datasource.class>
@@ -97,7 +97,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>xa</artifactId>
-            <version>11.0.0-SNAPSHOT</version>
+            <version>11.0.0-M7</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>

--- a/glassfish-runner/pom.xml
+++ b/glassfish-runner/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>org.glassfish</groupId>
     <artifactId>glassfish-runner</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-install/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>rest-extra-tck-install</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta REST Platform Extra TCK</name>
 

--- a/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-run/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish-restful-tests</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
 
     <name>TCK: Run Jakarta REST Platform Extra TCK</name>
     <description>
@@ -43,7 +43,7 @@
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <!-- Use JDK17 to run with GF-8.0.0-JDK17-M7 -->
         <glassfish.version>8.0.0-JDK17-M9</glassfish.version>
-        <tck.version>11.0.0-SNAPSHOT</tck.version>
+        <tck.version>11.0.0-M7</tck.version>
     </properties>
 
     <!-- The Junit5 test frameworks -->

--- a/glassfish-runner/tags-tck/tags-tck-install/pom.xml
+++ b/glassfish-runner/tags-tck/tags-tck-install/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>tags-tck-install</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta tags TCK</name>
 

--- a/glassfish-runner/tags-tck/tags-tck-run/pom.xml
+++ b/glassfish-runner/tags-tck/tags-tck-run/pom.xml
@@ -25,7 +25,7 @@
     </parent>
     
     <artifactId>glassfish.tags-tck</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
 
     <properties>
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>

--- a/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
+++ b/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>transactions-tck-install</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Transactions TCK</name>
 

--- a/glassfish-runner/transactions-tck/transactions-tck-run/pom.xml
+++ b/glassfish-runner/transactions-tck/transactions-tck-run/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>transactions-tck-run</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
@@ -40,7 +40,7 @@
         <tck.test.websocket.extra.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.websocket.extra.file}</tck.test.websocket.extra.url>
         
         <tck.test.websocket.version>2.2.0</tck.test.websocket.version>
-        <tck.test.websocket.extra.version>11.0.0-SNAPSHOT</tck.test.websocket.extra.version>
+        <tck.test.websocket.extra.version>11.0.0-M7</tck.test.websocket.extra.version>
     </properties>
 
     <build>

--- a/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-run/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>websocket-platform-extra-tck-run</artifactId>
-    <version>11.0.0-SNAPSHOT</version>
+    <version>11.0.0-M7</version>
     <name>TCK: Run Jakarta websocket Extra TCK</name>
 
     <properties>
@@ -41,7 +41,7 @@
         <glassfish.version>8.0.0-M9</glassfish.version>
 
         <jakarta.tck.websocket.version>2.2.0</jakarta.tck.websocket.version>
-        <tck.test.websocket.extra.version>11.0.0-SNAPSHOT</tck.test.websocket.extra.version>
+        <tck.test.websocket.extra.version>11.0.0-M7</tck.test.websocket.extra.version>
         
     </properties>
 


### PR DESCRIPTION
Make sure runners download and use the latest version of the big zip, and definitely not a snapshot version. That way the Eclipse CI can test the latest version of this Big Zip.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
