### PR TITLE
Fix resource inclusion in TCK jars

### DIFF
--- a/tcks/apis/cdi-ee-tck/tck/pom.xml
+++ b/tcks/apis/cdi-ee-tck/tck/pom.xml
@@ -388,6 +388,12 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*/**</include>
+                </includes>
+            </resource>
         </resources>
     </build>
 

--- a/tcks/apis/expression-language/expression-language-inside-container/pom.xml
+++ b/tcks/apis/expression-language/expression-language-inside-container/pom.xml
@@ -192,6 +192,12 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*/**</include>
+                </includes>
+            </resource>
         </resources>
     </build>
 </project>

--- a/tcks/apis/jsonb/pom.xml
+++ b/tcks/apis/jsonb/pom.xml
@@ -213,6 +213,12 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*/**</include>
+                </includes>
+            </resource>
         </resources>
     </build>
 </project>

--- a/tcks/apis/jsonp/pom.xml
+++ b/tcks/apis/jsonp/pom.xml
@@ -203,6 +203,12 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*/**</include>
+                </includes>
+            </resource>
         </resources>
     </build>
 </project>

--- a/tcks/apis/pages/pom.xml
+++ b/tcks/apis/pages/pom.xml
@@ -216,6 +216,12 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*/**</include>
+                </includes>
+            </resource>
         </resources>
     </build>
     

--- a/tcks/apis/rest/pom.xml
+++ b/tcks/apis/rest/pom.xml
@@ -228,6 +228,12 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*/**</include>
+                </includes>
+            </resource>
         </resources>
     </build>
     

--- a/tcks/apis/tags/pom.xml
+++ b/tcks/apis/tags/pom.xml
@@ -222,6 +222,12 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*/**</include>
+                </includes>
+            </resource>
         </resources>
     </build>
 

--- a/tcks/apis/transactions/pom.xml
+++ b/tcks/apis/transactions/pom.xml
@@ -236,6 +236,12 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*/**</include>
+                </includes>
+            </resource>
         </resources>
     </build>
 </project>

--- a/tcks/apis/websocket/platform-tests/pom.xml
+++ b/tcks/apis/websocket/platform-tests/pom.xml
@@ -71,6 +71,12 @@
                 </includes>
                 <targetPath>META-INF</targetPath>
             </resource>
+            <resource>
+                <directory>src/main/resources/</directory>
+                <includes>
+                    <include>*/**</include>
+                </includes>
+            </resource>
         </resources>
     </build>
 </project>


### PR DESCRIPTION
Because of including the license file, the default resource inclusion was broken. All jars files for TCKs that needed resource inclusion were broken.

This PR fixes that.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
