### PR TITLE
Remove Thread.dumpStack calls and revert SigTestData vehicle property change back to empty string

### DIFF
--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/JakartaEESigTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/JakartaEESigTest.java
@@ -513,7 +513,6 @@ public class JakartaEESigTest extends SigTestEE {
    * Initial entry point for JavaTest.
    */
   public static void main(String[] args) {
-    Thread.dumpStack(); // this is for debugging why signature tests aren't initialized correctly, remove this change
     JakartaEESigTest theTests = new JakartaEESigTest();
     Status s = theTests.run(args, System.out, System.err);
     s.exit();
@@ -527,7 +526,6 @@ public class JakartaEESigTest extends SigTestEE {
    * jtaJarClasspath, The Location of the JTA API jar file;
    */
 public void setup(String[] args, Properties p) throws Exception {
-  Thread.dumpStack(); // this is for debugging why signature tests aren't initialized correctly, remove this change
   super.setup(args, p);
 }
 
@@ -552,7 +550,6 @@ public void setup(String[] args, Properties p) throws Exception {
  *           When an error occurs executing the signature tests.
  */
 public void signatureTest() throws Exception {
-  Thread.dumpStack(); // this is for debugging why signature tests aren't initialized correctly, remove this change
   super.signatureTest();
 }
   /*

--- a/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestData.java
+++ b/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestData.java
@@ -39,7 +39,7 @@ public class SigTestData {
   }
 
   public String getVehicle() {
-    return props.getProperty("vehicle", "servlet"); // default to "servlet" which we should remove with calls to dumpStack
+    return props.getProperty("vehicle", "");
   }
 
   public String getBinDir() {

--- a/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestEE.java
+++ b/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestEE.java
@@ -205,7 +205,6 @@ public abstract class SigTestEE extends ServiceEETest {
    */
   public void setup(String[] args, Properties p) throws Exception {
     try {
-      Thread.dumpStack(); // this is for debugging why signature tests aren't initialized correctly, remove this change
       TestUtil.logMsg("$$$ SigTestEE.setup() called");
       this.testInfo = new SigTestData(p);
       TestUtil.logMsg("$$$ SigTestEE.setup() complete");
@@ -220,7 +219,6 @@ public abstract class SigTestEE extends ServiceEETest {
    * @throws Exception
    */
   public void setup() throws Exception {
-    Thread.dumpStack(); // this is for debugging why signature tests aren't initialized correctly, remove this change
     setup(null, System.getProperties());
   }
 
@@ -234,7 +232,6 @@ public abstract class SigTestEE extends ServiceEETest {
    *           When an error occurs executing the signature tests.
    */
   public void signatureTest() throws Exception {
-    Thread.dumpStack(); // this is for debugging why signature tests aren't initialized correctly, remove this change
     TestUtil.logMsg("$$$ SigTestEE.signatureTest() called");
     SigTestResult results = null;
     String mapFile = getMapFile();


### PR DESCRIPTION
We should soon merge this change after we get EE Signature validation working.