### PR TITLE
Remove duplicated dependencies

### DIFF
--- a/tcks/profiles/platform/assembly/pom.xml
+++ b/tcks/profiles/platform/assembly/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021  Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2025  Contributors to the Eclipse Foundation
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -78,11 +78,6 @@
             <groupId>jakarta.mail</groupId>
             <artifactId>jakarta.mail-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.activation</groupId>
-            <artifactId>jakarta.activation-api</artifactId>
-        </dependency>
-        
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>

--- a/tcks/profiles/platform/integration/pom.xml
+++ b/tcks/profiles/platform/integration/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021  Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2025  Contributors to the Eclipse Foundation
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -71,11 +71,6 @@
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
         </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-        </dependency>
-        
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>


### PR DESCRIPTION
Avoid:
```
[WARNING] Some problems were encountered while building the effective model for jakarta.tck:assembly-tck:jar:11.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: jakarta.activation:jakarta.activation-api:jar -> duplicate declaration of version (?) @ line 81, column 21
[WARNING]
[WARNING] Some problems were encountered while building the effective model for jakarta.tck:integration:jar:11.0.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: jakarta.annotation:jakarta.annotation-api:jar -> duplicate declaration of version (?) @ line 74, column 21
...
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
