### PR TITLE
[2007] & [2008] Revert some changes that broke signature tests

### DIFF
--- a/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTest.java
+++ b/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTest.java
@@ -168,6 +168,21 @@ public abstract class SigTest {
 
   protected SigTestData testInfo; // holds the bin.dir property
 
+    /**
+     * Called by the test framework to initialize this test. The method simply
+     * retrieves some state information that is necessary to run the test when
+     * the test framework invokes the run method (actually the test1 method).
+     */
+    public void setup() {
+        try {
+            logger.log(Logger.Level.TRACE, "$$$ SigTest.setup() called");
+            this.testInfo = new SigTestData();
+            TestUtil.logTrace("$$$ SigTest.setup() complete");
+        } catch (Exception e) {
+            logger.log(Logger.Level.ERROR, "Unexpected exception " + e.getMessage());
+        }
+    }
+
   /**
    * Called by the test framework to initialize this test. The method simply
    * retrieves some state information that is necessary to run the test when

--- a/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SignatureTestDriver.java
+++ b/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SignatureTestDriver.java
@@ -21,6 +21,8 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.Properties;
@@ -491,18 +493,18 @@ public abstract class SignatureTestDriver {
   protected String getSigFileName(String baseName, String repositoryDir,
       String version) throws FileNotFoundException {
 
-    String sigFile;
-    if (repositoryDir.endsWith(File.separator)) {
-      sigFile = repositoryDir + baseName + SIG_FILE_EXT;
-    } else {
-      sigFile = repositoryDir + File.separator + baseName + SIG_FILE_EXT;
+    final Path baseDir = Path.of(repositoryDir);
+
+    Path sigFile = baseDir.resolve(baseName + SIG_FILE_EXT);
+    if (Files.notExists(sigFile)) {
+      sigFile = baseDir.resolve(baseName + SIG_FILE_EXT + SIG_FILE_VER_SEP + version);
     }
 
-    File testFile = new File(sigFile);
-
-    if (!testFile.exists() && !testFile.isFile()) {
+    if (Files.notExists(sigFile) && !Files.isRegularFile(sigFile)) {
+      final Path unversioned = baseDir.resolve(baseName + SIG_FILE_EXT);
+      // Append the version
       throw new FileNotFoundException(
-          "Signature file \"" + sigFile + "\" does not exist.");
+          "Signature file \"" + unversioned + " or " + sigFile + "\" does not exist.");
     }
 
     // we are actually requiring this normalizeFileName call to get
@@ -514,7 +516,7 @@ public abstract class SignatureTestDriver {
     // "file://com/sun/ts/tests/signaturetest/foo.sig"
     // so now use file path and name only.
     // return normalizeFileName(testFile);
-    return testFile.toString();
+    return sigFile.toString();
 
   } // END getSigFileName
 


### PR DESCRIPTION
**Fixes Issue**
- resolves #2007
- resolves #2008

**Describe the change**
Adds back the `setup()` no-arg method to the `SigTest` for backwards compatibility.

Allow both the versioned, `jakarta.spec.sig_${version}`, and non-versioned, `jakarta.spec.sig`, signature test files to work.

**Additional context**
See #1948 and #1995 where each of the regressions were introduced.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
