### PR TITLE
Increase 1-second Calendar Timers

### DIFF
--- a/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/timer/schedule/expression/annotated/ScheduleBean.java
+++ b/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/timer/schedule/expression/annotated/ScheduleBean.java
@@ -255,7 +255,7 @@ public class ScheduleBean extends TimerBeanBaseWithoutTimeOutMethod {
     int nextDayOfMonth = TimerUtil.getForSchedule(Calendar.DAY_OF_MONTH, cal);
 
     Calendar cal2 = Calendar.getInstance();
-    cal2.add(Calendar.SECOND, 1); // times out after 1 second
+    cal2.add(Calendar.SECOND, 2); // times out after 2 seconds
 
     ScheduleExpression exp = new ScheduleExpression().year("*").month("*")
         .dayOfWeek(currentDayOfWeek).dayOfMonth(nextDayOfMonth)

--- a/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ScheduleBean.java
+++ b/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expression/annotated/ScheduleBean.java
@@ -259,7 +259,7 @@ public class ScheduleBean extends TimerBeanBaseWithoutTimeOutMethod {
     int nextDayOfMonth = TimerUtil.getForSchedule(Calendar.DAY_OF_MONTH, cal);
 
     Calendar cal2 = Calendar.getInstance();
-    cal2.add(Calendar.SECOND, 1); // times out after 1 second
+    cal2.add(Calendar.SECOND, 2); // times out after 2 seconds
 
     ScheduleExpression exp = new ScheduleExpression().year("*").month("*")
         .dayOfWeek(currentDayOfWeek).dayOfMonth(nextDayOfMonth)


### PR DESCRIPTION
Follow-on to https://github.com/jakartaee/platform-tck/pull/178

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/136

A couple tests were missed in the update to make sure that calendar-based timers won't expire before the test is ready for them to.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
