### PR TITLE
Update the jakarta.jakartaee-bom.version to 11.0.0-RC1 to fix transitive dependcies

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -38,7 +38,7 @@
     <arquillian.container.se.api.version>1.0.2.Final</arquillian.container.se.api.version>
     <arquillian.version>1.9.3.Final</arquillian.version>
     <!-- The version of the jakarta platform api bom -->
-    <jakarta.jakartaee-bom.version>11.0.0-M5</jakarta.jakartaee-bom.version>
+    <jakarta.jakartaee-bom.version>11.0.0-RC1</jakarta.jakartaee-bom.version>
     <!-- Jakarta TCK Tools version from the independently released tools submodule -->
     <!-- The Arquillian protocol artifacts -->
     <jakarta.tck.arquillian.version>11.0.0-RC2</jakarta.tck.arquillian.version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,8 @@
 
     SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
 
---><project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
@@ -78,6 +79,7 @@
         <module>tcks/profiles/platform/docs/userguide</module>
         
         <module>tools/signaturetest</module>
+        <module>tools/smoke</module>
     </modules>
 
     <properties>
@@ -92,7 +94,7 @@
 
         <!-- These are duplicated from the BOM for use by the release/pom.xml -->
         <!-- The version of the jakarta platform api bom -->
-        <jakarta.jakartaee-bom.version>11.0.0-M5</jakarta.jakartaee-bom.version>
+        <jakarta.jakartaee-bom.version>11.0.0-RC1</jakarta.jakartaee-bom.version>
         <!-- Jakarta TCK Tools version from the independently released tools submodule -->
         <!-- The Arquillian protocol artifacts -->
         <jakarta.tck.arquillian.version>11.0.0-RC2</jakarta.tck.arquillian.version>
@@ -194,7 +196,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.13.0</version>
+                    <version>3.14.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/tools/smoke/pom.xml
+++ b/tools/smoke/pom.xml
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2021  Contributors to the Eclipse Foundation
+    All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>jakarta.tck</groupId>
+        <artifactId>project</artifactId>
+        <version>11.0.0-SNAPSHOT</version>
+        <relativePath>../../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>smoke-tests</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Smoke Tests</name>
+    <description>Basic Smoke Tests</description>
+    <url>https://github.com/jakartaee/platform-tck</url>
+
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>jakarta.platform</groupId>
+                <artifactId>jakarta.jakartaee-bom</artifactId>
+                <version>${jakarta.jakartaee-bom.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <!-- Restricts the Java version to 17 -->
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.13.0</version>
+                <configuration>
+                    <release>17</release>
+                    <compilerArgument>-Xlint:all</compilerArgument>
+                </configuration>
+            </plugin>
+            
+
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>exec-maven-plugin</artifactId>
+                <version>3.5.0</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>java</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <mainClass>ee.tck.versions.VersionRelease</mainClass>
+                    <commandlineArgs>${release}</commandlineArgs>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/tools/smoke/src/test/java/jpms/SimpleApiTest.java
+++ b/tools/smoke/src/test/java/jpms/SimpleApiTest.java
@@ -1,0 +1,31 @@
+package jpms;
+
+import org.junit.jupiter.api.Test;
+import jakarta.inject.Inject;
+import jakarta.annotation.Nonnull;
+import jakarta.enterprise.context.ApplicationScoped;
+
+/**
+ * A simple test class to validate that a module-info.java can import and use Jakarta EE APIs.
+ * https://github.com/jakartaee/jakartaee-api/issues/185
+ * https://github.com/jakartaee/platform-tck/issues/2005
+ *
+ * The module-info.java only require the jakarta.cdi module, but this class uses classes from jakarta.annotation,
+ * jakarta.inject, and jakarta.cdi to validate that the jakarta.platform:jakarta.jakartaee-bom dependency
+ * does not exclude these APIs.
+ */
+@ApplicationScoped
+public class SimpleApiTest {
+    @Inject
+    Object nothing;
+
+    @Test
+    public void doNothing() {
+        System.out.println("Just validating that the test runs, no jpms compile errors");
+        doNothingPrivate("non-null arg");
+    }
+
+    private void doNothingPrivate(@Nonnull String arg) {
+        System.out.printf("doNothingPrivate(%s)%n", arg);
+    }
+}

--- a/tools/smoke/src/test/java/module-info.java
+++ b/tools/smoke/src/test/java/module-info.java
@@ -1,0 +1,6 @@
+module jakarta.smoke.test {
+    requires jakarta.cdi;
+    requires org.junit.jupiter.api;
+
+    exports jpms to  org.junit.platform.commons;
+}


### PR DESCRIPTION
Add smoke test for using the jakarta.platform:jakarta.jakartaee-bom with a JPMS project
Update the jakarta.jakartaee-bom.version to 11.0.0-RC1

**Fixes Issue**
Fixes #2005

**Related Issue(s)**
https://github.com/jakartaee/jakartaee-api/issues/185

