### PR TITLE
Signature test fixes

### DIFF
--- a/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/config.adoc
+++ b/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/config.adoc
@@ -340,6 +340,7 @@ These are the properties that need to have a value in the `ts.jte` file provided
 * imap.port
 * iofile
 * java.naming.factory.initial
+* javaee.level
 * javamail.mailbox
 * javamail.password
 * javamail.protocol
@@ -354,6 +355,7 @@ These are the properties that need to have a value in the `ts.jte` file provided
 * logical.hostname.servlet
 * longvarbinarySize
 * mailuser1
+* optional.tech.packages.to.ignore
 * org.omg.CORBA.ORBClass
 * password
 * password1
@@ -1436,6 +1438,20 @@ Edition CI, Eclipse GlassFish 6.1, set to `javaee.jar`
 by your JAR file; must include any classes that might be extended or
 implemented by the classes in your jar_to_test; include `rt.jar` when
 running against the Jakarta Platform, Enterprise Edition CI
+
+[[javaee-level-property]]
+==== javaee.level Property
+
+Set the `javaee.level` property in the `<TS_HOME/bin/ts.jte` file to set the
+profile to run. For example `platform` for the full platform or `web` for the
+web profile.
+
+[[optional-tech-packages-to-ignore-property]]
+==== optional.tech.packages.to.ignore Property
+
+Set the `optional.tech.packages.to.ignore` property in the `<TS_HOME/bin/ts.jte` file to set the
+a comma delimited list of packages to ignore that are optionally available in the distribution.
+For example, for the web profile, you may need to exclude the `jakarta.mail` packages.
 
 [[bindir-property]]
 ==== bin.dir Property

--- a/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/config.adoc
+++ b/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/config.adoc
@@ -347,7 +347,6 @@ These are the properties that need to have a value in the `ts.jte` file provided
 * javamail.server
 * javamail.username
 * jdbc.db
-* jimage.dir
 * jms_timeout
 * jstl.db.user
 * jstl.db.password
@@ -1438,13 +1437,6 @@ by your JAR file; must include any classes that might be extended or
 implemented by the classes in your jar_to_test; include `rt.jar` when
 running against the Jakarta Platform, Enterprise Edition CI
 
-[[jimagedir-property]]
-==== jimage.dir Property
-
-Set the `jimage.dir` property in the `<TS_HOME>/bin/ts.jte` file to set the
-path where signatures for the Java Runtime will be extracted. This property can
-later be used to setup the `sigTestClasspath` for things like the `java.base` module.
-
 [[bindir-property]]
 ==== bin.dir Property
 
@@ -1561,7 +1553,6 @@ webServerPort=8080
 ts_home=./target/jakartaee
 
 bin.dir=./target/jakartaee/com/sun/ts/tests/signaturetest/signature-repository
-jimage.dir=./target/jdk-bundle
 sigTestClasspath=./target/wildfly/modules/system/layers/base/jakarta/activation/api/main/jakarta.activation-api-2.1.3.jar:./target/wildfly/modules/system/layers/base/jakarta/annotation/api/main/jakarta.annotation-api-3.0.0.jar:./target/wildfly/modules/system/layers/base/jakarta/batch/api/main/jakarta.batch-api-2.1.1.jar:./target/wildfly/modules/system/layers/base/jakarta/data/api/main/jakarta.data-api-1.0.1.jar:./target/wildfly/modules/system/layers/base/jakarta/ejb/api/main/jakarta.ejb-api-4.0.1.jar:./target/wildfly/modules/system/layers/base/jakarta/el/api/main/jakarta.el-api-6.0.1.jar:./target/wildfly/modules/system/layers/base/jakarta/enterprise/api/main/jakarta.enterprise.cdi-api-4.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/enterprise/api/main/jakarta.enterprise.cdi-el-api-4.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/enterprise/api/main/jakarta.enterprise.lang-model-4.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/enterprise/concurrent/api/main/jakarta.enterprise.concurrent-api-3.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/faces/impl/main/jakarta.faces-4.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/inject/api/main/jakarta.inject-api-2.0.1.jar:./target/wildfly/modules/system/layers/base/jakarta/interceptor/api/main/jakarta.interceptor-api-2.2.0.jar:./target/wildfly/modules/system/layers/base/jakarta/jms/api/main/jakarta.jms-api-3.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/json/api/main/jakarta.json-api-2.1.3.jar:./target/wildfly/modules/system/layers/base/jakarta/json/bind/api/main/jakarta.json.bind-api-3.0.1.jar:./target/wildfly/modules/system/layers/base/jakarta/mail/api/main/jakarta.mail-api-2.1.3.jar:./target/wildfly/modules/system/layers/base/jakarta/persistence/api/main/jakarta.persistence-api-3.2.0.jar:./target/wildfly/modules/system/layers/base/jakarta/resource/api/main/jakarta.resource-api-2.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/security/auth/message/api/main/jakarta.authentication-api-3.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/security/enterprise/api/main/jakarta.security.enterprise-api-4.0.0.jar:./target/wildfly/modules/system/layers/base/jakarta/security/jacc/api/main/jakarta.authorization-api-3.0.0.jar:./target/wildfly/modules/system/layers/base/jakarta/servlet/api/main/jakarta.servlet-api-6.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/servlet/jsp/api/main/jakarta.servlet.jsp-api-3.1.1.jar:./target/wildfly/modules/system/layers/base/jakarta/servlet/jstl/api/main/jakarta.servlet.jsp.jstl-3.0.1-jbossorg-1.jar:./target/wildfly/modules/system/layers/base/jakarta/servlet/jstl/api/main/jakarta.servlet.jsp.jstl-api-3.0.2.jar:./target/wildfly/modules/system/layers/base/jakarta/transaction/api/main/jakarta.transaction-api-2.0.1.jar:./target/wildfly/modules/system/layers/base/jakarta/validation/api/main/jakarta.validation-api-3.1.0.jar:./target/wildfly/modules/system/layers/base/jakarta/websocket/api/main/jakarta.websocket-api-2.2.0.jar:./target/wildfly/modules/system/layers/base/jakarta/websocket/api/main/jakarta.websocket-client-api-2.2.0.jar:./target/wildfly/modules/system/layers/base/jakarta/ws/rs/api/main/jakarta.ws.rs-api-4.0.0.jar:./target/jdk-bundle/java.base:./target/jdk-bundle/java.rmi:./target/jdk-bundle/java.sql:./target/jdk-bundle/java.naming
 ----
 

--- a/tcks/profiles/platform/signaturevalidation/pom.xml
+++ b/tcks/profiles/platform/signaturevalidation/pom.xml
@@ -138,6 +138,11 @@
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.lang-model</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/JakartaEESigTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/JakartaEESigTest.java
@@ -62,7 +62,7 @@ import com.sun.ts.lib.util.TestUtil;
  */
 public class JakartaEESigTest extends SigTestEE {
 
-  public static final String JAVAEE_FULL = "full";
+  public static final String JAVAEE_FULL = "platform";
 
   public static final String JAVAEE_KEYWORD = "javaee";
 

--- a/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTest.java
+++ b/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTest.java
@@ -21,12 +21,10 @@
 
 package com.sun.ts.tests.signaturetest;
 
-import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 
 import java.util.ArrayList;
 import java.util.Properties;
@@ -199,37 +197,6 @@ public abstract class SigTest {
         // ensure there are no full or partial implementations of an
         // optional technology which were not declared.
         ArrayList<String> unlistedTechnologyPkgs = getUnlistedOptionalPackages();
-
-        // If testing with Java 9+, extract the JDK's modules so they can be used
-        // on the testcase's classpath.
-
-        String version = System.getProperty("java.version");
-
-        String jimageDir = testInfo.getJImageDir();
-        File f = new File(jimageDir);
-        f.mkdirs();
-
-        String javaHome = System.getProperty("java.home");
-        logger.log(Logger.Level.INFO, "Executing JImage");
-
-        try {
-            ProcessBuilder pb = new ProcessBuilder(javaHome + "/bin/jimage", "extract", "--dir=" + jimageDir, javaHome + "/lib/modules");
-            logger.log(Logger.Level.INFO, javaHome + "/bin/jimage extract --dir=" + jimageDir + " " + javaHome + "/lib/modules");
-            pb.redirectErrorStream(true);
-            Process proc = pb.start();
-            BufferedReader out = new BufferedReader(new InputStreamReader(proc.getInputStream()));
-            String line = null;
-            while ((line = out.readLine()) != null) {
-                TestUtil.logMsg(line);
-            }
-
-            int rc = proc.waitFor();
-            TestUtil.logMsg("JImage RC = " + rc);
-            out.close();
-        } catch (Exception e) {
-            TestUtil.logMsg("Exception while executing JImage!  Some tests may fail.");
-            e.printStackTrace();
-        }
 
         try {
             results = getSigTestDriver().executeSigTest(packageFile, mapFile, repositoryDir, packages, classes, testClasspath,

--- a/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestData.java
+++ b/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestData.java
@@ -74,6 +74,7 @@ public class SigTestData {
         return props.getProperty("jtaJarClasspath", "");
     }
 
+    @Deprecated(forRemoval = true, since = "11.0.0")
     public String getJImageDir() {
         return props.getProperty("jimage.dir", "");
     }

--- a/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestDriver.java
+++ b/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestDriver.java
@@ -61,14 +61,6 @@ public class SigTestDriver extends SignatureTestDriver {
 
     private static final String FORMATPLAIN_FLAG = "-FormatPlain";
 
-    private static final String EXCLUDE_JDK_CLASS_FLAG = "-IgnoreJDKClass";
-
-    private static String[] excludeJdkClasses = { "java.util.Map", "java.lang.Object", "java.io.ByteArrayInputStream",
-            "java.io.InputStream", "java.lang.Deprecated", "java.io.Writer", "java.io.OutputStream", "java.util.List",
-            "java.util.Collection", "java.lang.instrument.IllegalClassFormatException", "javax.transaction.xa.XAException",
-            "java.lang.annotation.Repeatable", "java.lang.InterruptedException", "java.lang.CloneNotSupportedException",
-            "java.lang.Throwable", "java.lang.Thread", "java.lang.Enum" };
-
     // ---------------------------------------- Methods from SignatureTestDriver
 
     @Override
@@ -129,10 +121,9 @@ public class SigTestDriver extends SignatureTestDriver {
             command.add(subPackages[i]);
         }
 
-        for (String jdkClassName : excludeJdkClasses) {
-            command.add(EXCLUDE_JDK_CLASS_FLAG);
-            command.add(jdkClassName);
-        }
+        command.add("-BootCp");
+        command.add(javaReleaseVersion());
+        command.add("-IgnoreJDKClasses");
 
         command.add(API_VERSION_FLAG);
         command.add(info.getVersion());
@@ -257,5 +248,15 @@ public class SigTestDriver extends SignatureTestDriver {
         logger.log(Logger.Level.INFO, rawMessages);
 
         return sigTestInstance.toString().substring(7).startsWith("Passed.");
+    }
+
+    /**
+     * Returns the Java version the signature tests should be using. The version should be the minimum version the
+     * Jakarta EE TCK requires.
+     *
+     * @return the Java version the TCK requires, defaults to 17
+     */
+    protected String javaReleaseVersion() {
+        return System.getProperty("jakarta.tck.java.release.version", "17");
     }
 }

--- a/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestEE.java
+++ b/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/SigTestEE.java
@@ -16,10 +16,6 @@
 
 package com.sun.ts.tests.signaturetest;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStreamReader;
-
 import java.util.ArrayList;
 import java.util.Properties;
 
@@ -211,39 +207,6 @@ public abstract class SigTestEE extends ServiceEETest {
         // We want to ensure there are no full or partial implementations of an
         // optional technology which were not declared
         ArrayList<String> unlistedTechnologyPkgs = getUnlistedOptionalPackages();
-
-        // If testing with Java 9+, extract the JDK's modules so they can be used
-        // on the testcase's classpath.
-        Properties sysProps = System.getProperties();
-        String version = (String) sysProps.get("java.version");
-        if (!version.startsWith("1.")) {
-            String jimageDir = testInfo.getJImageDir();
-            File f = new File(jimageDir);
-            f.mkdirs();
-
-            String javaHome = (String) sysProps.get("java.home");
-            TestUtil.logMsg("Executing JImage");
-
-            try {
-                ProcessBuilder pb = new ProcessBuilder(javaHome + "/bin/jimage", "extract", "--dir=" + jimageDir,
-                        javaHome + "/lib/modules");
-                TestUtil.logMsg(javaHome + "/bin/jimage extract --dir=" + jimageDir + " " + javaHome + "/lib/modules");
-                pb.redirectErrorStream(true);
-                Process proc = pb.start();
-                BufferedReader out = new BufferedReader(new InputStreamReader(proc.getInputStream()));
-                String line = null;
-                while ((line = out.readLine()) != null) {
-                    TestUtil.logMsg(line);
-                }
-
-                int rc = proc.waitFor();
-                TestUtil.logMsg("JImage RC = " + rc);
-                out.close();
-            } catch (Exception e) {
-                TestUtil.logMsg("Exception while executing JImage!  Some tests may fail.");
-                e.printStackTrace();
-            }
-        }
 
         try {
             results = getSigTestDriver().executeSigTest(packageFile, mapFile, repositoryDir, packages, classes, testClasspath,


### PR DESCRIPTION
**Fixes Issue**
* resolves #2024
* resolves #2025

**Describe the change**

This removes the `jimage` command from being executed. It also replaces the individual `-IgnoreJDKClass` arguments with the single `-IgnoreJDKClasses`. 

Add the `-BootCp` property to the command with the ability to override it, while defaulting to 17. This is the minimum version which the signature test files are generated to.

Update the `JAVA_FULL` value from `full` to `platform` to match the JUnit 5 tag. Update the configuration documentation to include some additional signature test properties.

Upgrade the sigtest-maven-plugin to 2.6 and include a missing dependency.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
