### PR TITLE
Update the signature test runner to pass on both platform and web. Re…

### DIFF
--- a/glassfish-runner/pages-tck/pages-tck-run/pom.xml
+++ b/glassfish-runner/pages-tck/pages-tck-run/pom.xml
@@ -199,8 +199,7 @@
                         <porting.ts.url.class.1>ee.jakarta.tck.pages.lib.implementation.sun.common.SunRIURL</porting.ts.url.class.1>
 
                         <!-- Set the properties for the API signature test -->
-                        <jimage.dir>${project.build.directory}/jdk-bundle</jimage.dir>
-                        <sigTestClasspath>${glassfish.root}/glassfish8/glassfish/modules/jakarta.servlet.jsp-api.jar:${glassfish.root}/glassfish8/glassfish/modules/jakarta.servlet-api.jar:${glassfish.root}/glassfish8/glassfish/modules/jakarta.el-api.jar:${project.build.directory}/jdk-bundle/java.base:${project.build.directory}/jdk-bundle/java.rmi:${project.build.directory}/jdk-bundle/java.sql:${project.build.directory}/jdk-bundle/java.naming</sigTestClasspath>
+                        <sigTestClasspath>${glassfish.root}/glassfish8/glassfish/modules/jakarta.servlet.jsp-api.jar:${glassfish.root}/glassfish8/glassfish/modules/jakarta.servlet-api.jar:${glassfish.root}/glassfish8/glassfish/modules/jakarta.el-api.jar</sigTestClasspath>
                     </systemProperties>
                 </configuration>
                 <executions>

--- a/glassfish-runner/signature/pom.xml
+++ b/glassfish-runner/signature/pom.xml
@@ -23,7 +23,6 @@
         <!-- Properties set in the JTE file -->
         <base.tck.dir>${project.build.directory}/jakartaee</base.tck.dir>
         <bin.dir>${base.tck.dir}/com/sun/ts/tests/signaturetest/signature-repository</bin.dir>
-        <jimage.dir>${project.build.directory}/jimage</jimage.dir>
         
         <!-- Note that currently, this must have src as the first directory as it is hard-coded in the test -->
         <signature.file.dir>${base.tck.dir}/src</signature.file.dir>
@@ -304,6 +303,7 @@
                 <glassfish-artifact-id>glassfish</glassfish-artifact-id>
                 <testGroups>platform</testGroups>
                 <tck.profile>${testGroups}</tck.profile>
+                <javaee.level>platform</javaee.level>
             </properties>
         </profile>
         <profile>
@@ -312,6 +312,8 @@
                 <glassfish-artifact-id>web</glassfish-artifact-id>
                 <testGroups>web</testGroups>
                 <tck.profile>${testGroups}</tck.profile>
+                <javaee.level>web</javaee.level>
+                <optional.tech.packages.to.ignore>jakarta.resource,jakarta.resource.cci,jakarta.resource.spi,jakarta.resource.spi.work,jakarta.resource.spi.endpoint,jakarta.resource.spi.security,jakarta.mail,jakarta.mail.event,jakarta.mail,jakarta.mail.event,jakarta.mail.internet,jakarta.mail.search,jakarta.mail.util,jakarta.security.jacc,jakarta.security.auth.message,jakarta.security.auth.message.callback,jakarta.security.auth.message.config,jakarta.security.auth.message.module</optional.tech.packages.to.ignore>
             </properties>
         </profile>
     </profiles>

--- a/glassfish-runner/signature/src/test/resources/ts.jte
+++ b/glassfish-runner/signature/src/test/resources/ts.jte
@@ -3,5 +3,6 @@ webServerPort=${webServerPort}
 ts_home=${project.build.directory}/jakartaee
 
 bin.dir=${bin.dir}
-jimage.dir=${jimage.dir}
-sigTestClasspath=${sigTestClasspath}${path.separator}${jimage.dir}/java.base${path.separator}${jimage.dir}/java.rmi${path.separator}${jimage.dir}/java.sql${path.separator}${jimage.dir}/java.naming
+sigTestClasspath=${sigTestClasspath}
+javaee.level=${javaee.level}
+optional.tech.packages.to.ignore=${optional.tech.packages.to.ignore}


### PR DESCRIPTION
…move the unneeded jimage.dir property and add the javaee.level and optional packages for web.

Update the pages-tck-run to remove the jimage.dir property.

This updates the Glassfish runner for fixes in #2026. This won't work until a new release of the `jakarta.tck:signaturetest` and `jakarta.tck:signaturevalidation` are released. 

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
