### PR TITLE
Only include the Platform TCK user guide in the release

### DIFF
--- a/release/src/main/assembly/assembly.xml
+++ b/release/src/main/assembly/assembly.xml
@@ -38,6 +38,8 @@
             <outputDirectory>guides</outputDirectory>
             <source>../tcks/profiles/platform/docs/userguide/platform/target/generated-docs/Jakarta-Platform-TCK-Users-Guide.pdf</source>
         </file>
+        <!--  https://github.com/jakartaee/platform-tck/issues/2043 only include the Platform TCK user guide in the release.  
+              The below TCK user guides are not using when testing EE 11 compatibility.
         <file>
             <outputDirectory>guides</outputDirectory>
             <source>../tcks/apis/transactions/docs/userguide/target/generated-docs/Jakarta-Transactions-TCK-Users-Guide.pdf</source>
@@ -58,6 +60,7 @@
             <outputDirectory>guides</outputDirectory>
             <source>../tcks/apis/persistence/persistence-outside-container/docs/userguide/target/generated-docs/Jakarta-Persistence-TCK-Users-Guide.pdf</source>
         </file>
+        -->
     </files>
 
     <fileSets>


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2043

**Related Issue(s)**
See feedback and discussion on https://eclipsefoundationhq.slack.com/archives/C0131MLD538/p1741266453814539

**Describe the change**
Update release to not include the other user guides.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
