### PR TITLE
Remove technologies from Platform TCK user guide that were removed for EE 11

### DIFF
--- a/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/intro.adoc
+++ b/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/intro.adoc
@@ -152,20 +152,6 @@ The complete list of Jakarta EE {tck_version} technologies for the Platform can 
 * Jakarta Transactions
 * Jakarta WebSocket
 
-The following (removed from Jakarta EE {tck_version} Platform) technologies may be tested via the Jakarta EE Platform TCK:
-
-* Jakarta Enterprise Beans entity beans and associated Jakarta Enterprise Beans QL
-* Jakarta Enterprise Beans embeddable container 
-
-The following optional technologies may also be tested via the Jakarta EE Platform TCK:
-
-* Jakarta Enterprise Beans 2.x API group 
-* Jakarta Enterprise Beans Container Managed Persistence, Bean Managed Persistence
-* Jakarta Enterprise Web Services 
-* Jakarta SOAP with Attachments 
-* Jakarta XML Binding 
-* Jakarta XML Web Services
-
 Jakarta EE {tck_version} Platform TCK provides compatibility certification verification for implementations contained in the Platform for the following component specifications:
 
 * Jakarta Annotations


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2045

**Describe the change**
Update user guide to not mention technologies that are not required for EE 11.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
