### PR TITLE
Update the TCK Troubleshooting documentation

### DIFF
--- a/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/troubleshooting.adoc
+++ b/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/troubleshooting.adoc
@@ -38,6 +38,14 @@ Please verify that the property log.file.location exists in ts.jte
 Resolution: +
 You may have the `log.file.location` set in the ts.jte file, but if your Jakarta Persistence integration eagerly loads the testcase custom persistence provider, it may do so before the `log.file.location` property is set by the TCK harness code. To resolve this issue, you can set the `log.file.location` system property in your server configuration.
 
+* Problem: +
+When running signature tests you see the test has failed, but there is no indication as to why.
++
+Resolution: +
+The signature test driver uses a `java.lang.System.Logger`. Since the tests runs in a deployment, the failure messages
+are logged via the servers log configuration. If you prefer to see the failure reason with the assertion failure,
+simply add a console handler/appender to your logging configuration.
+
 [[support]]
 == Support
 

--- a/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/troubleshooting.adoc
+++ b/tcks/profiles/platform/docs/userguide/platform/src/main/asciidoc/troubleshooting.adoc
@@ -16,7 +16,8 @@ This section lists common problems that you may encounter as you run the Jakarta
 * Problem: +
 When you start the Jakarta Platform, Enterprise Edition CI, Eclipse {glassfish_version} on
 Windows by using the `javaee -verbose` command, the system may not find
-the specified path and could display one of the following errors: +
+the specified path and could display one of the following errors:
++
 [source,bash]
 ----
 "Verify that JAVA_HOME is set correctly"
@@ -28,12 +29,12 @@ installed and set `JAKARTAEE_HOME` to the location of the Jakarta Platform, Ente
 
 * Problem: +
 When running the Jakarta Persistence TCK tests you see an error log message containing:
++
 [source,bash]
 ----
 LogFileProcessor setup failed
 Please verify that the property log.file.location exists in ts.jte
 ----
-
 Resolution: +
 You may have the `log.file.location` set in the ts.jte file, but if your Jakarta Persistence integration eagerly loads the testcase custom persistence provider, it may do so before the `log.file.location` property is set by the TCK harness code. To resolve this issue, you can set the `log.file.location` system property in your server configuration.
 
@@ -43,5 +44,3 @@ You may have the `log.file.location` set in the ts.jte file, but if your Jakarta
 Jakarta EE is a community sponsored and community supported project. If you need additional assistance, you can reach out to the specific developer community. You will find the list of all Eclipse EE4J projects at `https://projects.eclipse.org/projects/ee4j`. All the sub-projects are listed. Each project page has details regarding how to contact their developer community.
 
 For Jakarta EE TCK specific issues, you can reach out to the Jakarta EE TCK project team via the resources listed at `https://projects.eclipse.org/projects/ee4j.jakartaee-tck`.
-
-I


### PR DESCRIPTION
If needed I can file an issue for this.

The first commit makes some small changes for formatting purposes.

The second commit adds a problem/resolution for not seeing the signature test failures.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
