### PR TITLE
Revert back to 11.0.0-SNAPSHOT

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -29,7 +29,7 @@
   <modelVersion>4.0.0</modelVersion>  
   <groupId>jakarta.tck</groupId>  
   <artifactId>artifacts-bom</artifactId>
-  <version>11.0.1-SNAPSHOT</version>
+  <version>11.0.0-SNAPSHOT</version>
   <packaging>pom</packaging>
   <name>Jakarta EE TCK Artifacts BOM</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>project</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>project</name>
     <description>platform-tcks-parent</description>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>release</artifactId>

--- a/tcks/apis/cdi-ee-tck/tck/pom.xml
+++ b/tcks/apis/cdi-ee-tck/tck/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>cdi-tck-ee-impl</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>CDI EE Integration TCK Test Suite</name>
     <description>CDI EE Integration TCK tests</description>

--- a/tcks/apis/connector/pom.xml
+++ b/tcks/apis/connector/pom.xml
@@ -28,7 +28,7 @@
     
     <groupId>jakarta.tck</groupId>
     <artifactId>connector</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>Jakarta Connector</name>
     <description>Jakarta Connector</description>

--- a/tcks/apis/enterprise-beans/ejb30/pom.xml
+++ b/tcks/apis/enterprise-beans/ejb30/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>ejb30</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>ejb30</name>

--- a/tcks/apis/enterprise-beans/ejb32/pom.xml
+++ b/tcks/apis/enterprise-beans/ejb32/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>ejb32</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>EJB32</name>

--- a/tcks/apis/expression-language/expression-language-inside-container/pom.xml
+++ b/tcks/apis/expression-language/expression-language-inside-container/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>el-platform-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>el</name>
     <description>Expression Language EE Tests</description>

--- a/tcks/apis/javamail/pom.xml
+++ b/tcks/apis/javamail/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>javamail</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>Jakarta Mail 2.1</name>
     <description>Jakarta Mail 2.1 TCK</description>

--- a/tcks/apis/jsonb/pom.xml
+++ b/tcks/apis/jsonb/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonb-platform-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>Jakarta JSON Binding</name>
     <description>Jakarta JSON Binding extra platform tests</description>

--- a/tcks/apis/jsonp/pom.xml
+++ b/tcks/apis/jsonp/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonp-platform-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>Jakarta JSON Processing</name>
     <description>Jakarta JSON Processing extra platform tests</description>

--- a/tcks/apis/messaging/messaging-inside-container/pom.xml
+++ b/tcks/apis/messaging/messaging-inside-container/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jms-platform-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Jakarta Messaging</name>

--- a/tcks/apis/pages/pom.xml
+++ b/tcks/apis/pages/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>pages-platform-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Jakarta Pages Tests</name>

--- a/tcks/apis/persistence/persistence-inside-container/common/pom.xml
+++ b/tcks/apis/persistence/persistence-inside-container/common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>persistence-platform-tck</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>persistence-platform-tck-common</artifactId>

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/pom.xml
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>persistence-platform-tck</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>persistence-platform-tck-tests</artifactId>

--- a/tcks/apis/persistence/persistence-inside-container/pom.xml
+++ b/tcks/apis/persistence/persistence-inside-container/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>persistence-platform-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>Jakarta Persistence Platform TCK</name>

--- a/tcks/apis/persistence/persistence-inside-container/procedures/pom.xml
+++ b/tcks/apis/persistence/persistence-inside-container/procedures/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>persistence-platform-tck</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>persistence-platform-tck-dbprocedures</artifactId>

--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/pom.xml
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>persistence-platform-tck</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>persistence-platform-tck-spec-tests</artifactId>

--- a/tcks/apis/rest/pom.xml
+++ b/tcks/apis/rest/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>rest-platform-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>Jakarta REST Tests</name>
     <description>Jakarta REST Tests for Jakarta EE Platform</description>

--- a/tcks/apis/tags/pom.xml
+++ b/tcks/apis/tags/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>tags-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>Jakarta Tags TCK</name>
     <description>This module contains all the tests for the Jakarta Tags TCK</description>

--- a/tcks/apis/transactions/pom.xml
+++ b/tcks/apis/transactions/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>transactions-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>Jakarta Transactions</name>
     <description>Jakarta Transactions</description>

--- a/tcks/apis/websocket/pom.xml
+++ b/tcks/apis/websocket/pom.xml
@@ -27,7 +27,7 @@
     <artifactId>websocket-tck-platform-tests</artifactId>
     <packaging>jar</packaging>
     <name>Jakarta Websocket TCK Platform Tests</name>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     
 
     <dependencies>

--- a/tcks/profiles/core-profile-tck/ca-sigtest/pom.xml
+++ b/tcks/profiles/core-profile-tck/ca-sigtest/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>common-annotations</artifactId>
 

--- a/tcks/profiles/core-profile-tck/cdi-tck-suite/pom.xml
+++ b/tcks/profiles/core-profile-tck/cdi-tck-suite/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>cdi-lite-tck-suite</artifactId>

--- a/tcks/profiles/core-profile-tck/jsonp-tck-ext/pom.xml
+++ b/tcks/profiles/core-profile-tck/jsonp-tck-ext/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>core-tck-jsonp-extension</artifactId>

--- a/tcks/profiles/core-profile-tck/pom.xml
+++ b/tcks/profiles/core-profile-tck/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>jakarta.tck.coreprofile</groupId>
     <artifactId>core-tck-parent</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta Core TCK</name>
 

--- a/tcks/profiles/core-profile-tck/restful-tck-suite/pom.xml
+++ b/tcks/profiles/core-profile-tck/restful-tck-suite/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>rest-tck-suite</artifactId>

--- a/tcks/profiles/core-profile-tck/tck-dist/pom.xml
+++ b/tcks/profiles/core-profile-tck/tck-dist/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/tcks/profiles/core-profile-tck/tck/pom.xml
+++ b/tcks/profiles/core-profile-tck/tck/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <groupId>jakarta.tck.coreprofile</groupId>
         <artifactId>core-tck-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
     </parent>
     <artifactId>core-profile-tck-impl</artifactId>
     <name>Jakarta Core Profile TCK Test Suite</name>

--- a/tcks/profiles/platform/appclient/pom.xml
+++ b/tcks/profiles/platform/appclient/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>appclient</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>APPCLIENT</name>
     <description>APPCLIENT</description>

--- a/tcks/profiles/platform/assembly/pom.xml
+++ b/tcks/profiles/platform/assembly/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>assembly-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>assembly-tck</name>
     <description>ASSEMBLY</description>

--- a/tcks/profiles/platform/docs/userguide/platform/pom.xml
+++ b/tcks/profiles/platform/docs/userguide/platform/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>jakarta.tck-user-guide-parent</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>jakarta.jakartaee-tck-user-guide</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Eclipse Foundation Technology Compatibility Kit User's Guide for Jakarta EE Platform, Enterprise Edition, Release 11.0 ${project.version}</name>
 

--- a/tcks/profiles/platform/docs/userguide/pom.xml
+++ b/tcks/profiles/platform/docs/userguide/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jakarta.tck-user-guide-parent</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Eclipse Foundation Technology Compatibility Kit User's Guides for Jakarta EE ${project.version}</name>
 

--- a/tcks/profiles/platform/integration/pom.xml
+++ b/tcks/profiles/platform/integration/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>integration</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>Integration</name>
     <description>Integration</description>

--- a/tcks/profiles/platform/javaee/pom.xml
+++ b/tcks/profiles/platform/javaee/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>javaee-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>javaee</name>
     <description>javaee</description>

--- a/tcks/profiles/platform/jdbc/pom.xml
+++ b/tcks/profiles/platform/jdbc/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jdbc-platform-tck</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>jdbc-platform-tck</name>
     <description>JDBC Platform Tests</description>

--- a/tcks/profiles/platform/signaturevalidation/pom.xml
+++ b/tcks/profiles/platform/signaturevalidation/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
         <relativePath>../../../../pom.xml</relativePath>
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>signaturevalidation</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>signaturevalidation</name>

--- a/tcks/profiles/platform/xa/pom.xml
+++ b/tcks/profiles/platform/xa/pom.xml
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>xa</artifactId>
-    <version>11.0.1-SNAPSHOT</version>
+    <version>11.0.0-SNAPSHOT</version>
 
     <name>XA</name>
     <description>XA</description>

--- a/tools/smoke/pom.xml
+++ b/tools/smoke/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>jakarta.tck</groupId>
         <artifactId>project</artifactId>
-        <version>11.0.1-SNAPSHOT</version>
+        <version>11.0.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
Address build failure in https://ci.eclipse.org/jakartaee-tck/job/11/job/stage-artifacts/job/TCKDistRelease/62/console

> [ERROR] The build could not read 1 project -> [Help 1]
> [ERROR]   
> [ERROR]   The project jakarta.tck:release:11.0.1-SNAPSHOT (/home/jenkins/agent/workspace/11/stage-artifacts/TCKDistRelease/release/pom.xml) has 25 errors
> [ERROR]     Non-resolvable import POM: The following artifacts could not be resolved: jakarta.tck:artifacts-bom:pom:11.0.1-SNAPSHOT (absent): Could not find artifact jakarta.tck:artifacts-bom:pom:11.0.1-SNAPSHOT @ line 34, column 25 -> [Help 2]
> 