### PR TITLE
issues/2074 The Jakarta Web Profile tests should be updated to include appropriate @tag

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/cdi/ServletEMLookupTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/cdi/ServletEMLookupTest.java
@@ -9,6 +9,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
@@ -22,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * Test for EntityManager lookup via CDI
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("platform")
+@Tag("web")
 public class ServletEMLookupTest {
 
     @ArquillianResource

--- a/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/cdi/WSClientIT.java
+++ b/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/cdi/WSClientIT.java
@@ -23,6 +23,7 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -35,6 +36,8 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
  *                     ws_wait;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("platform")
+@Tag("web")
 public class WSClientIT extends WebSocketCommonClient {
 
 	private static final long serialVersionUID = 5295841512141568599L;

--- a/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticated/WSCClientIT.java
+++ b/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticated/WSCClientIT.java
@@ -26,6 +26,7 @@ import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -43,6 +44,8 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
  *                     password;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("platform")
+@Tag("web")
 public class WSCClientIT extends WebSocketCommonClient {
 
 	private static final long serialVersionUID = -5851958128006729743L;

--- a/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedlogoff/WSCClientIT.java
+++ b/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedlogoff/WSCClientIT.java
@@ -26,6 +26,7 @@ import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -43,6 +44,8 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
  *                     password;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("platform")
+@Tag("web")
 public class WSCClientIT extends WebSocketCommonClient {
 
 	private static final long serialVersionUID = -7084128651642590169L;

--- a/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedssl/WSCClientIT.java
+++ b/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/authenticatedssl/WSCClientIT.java
@@ -30,6 +30,7 @@ import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -48,6 +49,8 @@ import com.sun.ts.tests.websocket.common.util.IOUtil;
  *                     password;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("platform")
+@Tag("web")
 public class WSCClientIT extends WebSocketCommonClient {
 
 	private static final long serialVersionUID = -5851958128006729743L;

--- a/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/session/WSCClientIT.java
+++ b/tcks/apis/websocket/src/main/java/com/sun/ts/tests/websocket/platform/jakarta/websocket/server/handshakerequest/session/WSCClientIT.java
@@ -24,6 +24,7 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 
@@ -41,6 +42,8 @@ import jakarta.websocket.ClientEndpointConfig;
  *                     ws_wait;
  */
 @ExtendWith(ArquillianExtension.class)
+@Tag("platform")
+@Tag("web")
 public class WSCClientIT extends WebSocketCommonClient {
 
 	private static final long serialVersionUID = 3741198886806200627L;


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2074

**Describe the change**
Update tests needed for the Web Profile to include @tag("platform") + @tag("web") to ensure they are run for Web Profile testing.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
