### PR TITLE
Tests for ELAwareBeanManager

### DIFF
--- a/tcks/apis/cdi-ee-tck/tck/pom.xml
+++ b/tcks/apis/cdi-ee-tck/tck/pom.xml
@@ -51,6 +51,12 @@
 
         <dependency>
             <groupId>jakarta.enterprise</groupId>
+            <artifactId>jakarta.enterprise.cdi-el-api</artifactId>
+            <version>4.1.0</version>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.enterprise</groupId>
             <artifactId>cdi-tck-api</artifactId>
             <version>4.1.0</version>
         </dependency>

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/el/ELAwareBeanManagerTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/el/ELAwareBeanManagerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * This program and the accompanying materials are made available under the
+ * Apache Software License 2.0 which is available at:
+ * https://www.apache.org/licenses/LICENSE-2.0.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+package org.jboss.cdi.tck.tests.extensions.beanManager.el;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.cdi.Sections;
+import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.jboss.test.audit.annotations.SpecAssertion;
+import org.jboss.test.audit.annotations.SpecVersion;
+import org.testng.annotations.Test;
+
+import jakarta.enterprise.context.Dependent;
+import jakarta.enterprise.inject.Default;
+import jakarta.enterprise.inject.spi.Bean;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.spi.el.ELAwareBeanManager;
+
+@SpecVersion(spec = "cdi", version = "4.1")
+public class ELAwareBeanManagerTest extends AbstractTest {
+
+    @Deployment
+    public static WebArchive createTestArchive() {
+        return new WebArchiveBuilder().withTestClassPackage(ELAwareBeanManagerTest.class).build();
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.EL_INTEGRATION_API, id = "a")
+    public void testBeanManagerImplementsELAwareBeanManager() {
+        assert getCurrentManager() instanceof ELAwareBeanManager;
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.EL_INTEGRATION_API, id = "ba")
+    public void testContainerProvidesELAwareBeanManagerBean() {
+        assert getBeans(ELAwareBeanManager.class).size() > 0;
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.EL_INTEGRATION_API, id = "bb")
+    public void testELAwareBeanManagerBeanIsDependentScoped() {
+        Bean<ELAwareBeanManager> beanManager = getBeans(ELAwareBeanManager.class).iterator().next();
+        assert beanManager.getScope().equals(Dependent.class);
+    }
+
+    @Test
+    @SpecAssertion(section = Sections.EL_INTEGRATION_API, id = "bc")
+    public void testELAwareBeanManagerBeanHasCurrentBinding() {
+        Bean<ELAwareBeanManager> beanManager = getBeans(ELAwareBeanManager.class).iterator().next();
+        assert beanManager.getQualifiers().contains(Default.Literal.INSTANCE);
+    }
+    
+    @Test
+    @SpecAssertion(section = Sections.EL_INTEGRATION_API, id = "c")
+    public void testELAwareBeanManagerCastFromCdiCurrent() {
+        assert CDI.current().getBeanManager() instanceof ELAwareBeanManager;
+    }
+}

--- a/tcks/apis/cdi-ee-tck/tck/src/main/resources/tck-audit-cdi.xml
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/resources/tck-audit-cdi.xml
@@ -11670,4 +11670,28 @@
         </assertion>
     </section>
 
+    <section id="el_integration_api" title="Unified EL integration API" level="3">
+        <assertion id="a">
+            <text>The |BeanManager| implementation in Jakarta EE must also implement |ELAwareBeanManager|</text>
+        </assertion>
+
+        <group>
+            <text>The container provides a built-in bean with bean type |ELAwareBeanManager|, scope |@Dependent| and qualifier |@Default|</text>
+
+            <assertion id="ba">
+                <text>Test the type</text>
+            </assertion>
+            <assertion id="bb">
+                <text>Test the scope</text>
+            </assertion>
+            <assertion id="bc">
+                <text>Test the qualifier</text>
+            </assertion>
+        </group>
+
+        <assertion id="c">
+            <text>An |ELAwareBeanManager| may be obtained by using |CDI.current().getBeanManager()| and casting</text>
+        </assertion>
+    </section>
+
 </specification>


### PR DESCRIPTION
**Fixes Issue**
#2082

**Related Issue(s)**
`ELAwareBeanManager` was created and EL related methods on `BeanManager` were deprecated in jakartaee/cdi#644

**Describe the change**

Add tests for the `ELAwareBeanManager` bean.

The methods on this interface also exist on `BeanManager` and are still tested in the CDI TCK, so we're only testing that the builtin bean is present and that the `BeanManager` implementation can be cast to `ELAwareBeanManager`.

**Additional context**

I realise this may be too late to include in 11 and should have been submitted much earlier. We only realised we'd missed these tests recently.

I have run these tests locally against Open Liberty.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
