### PR TITLE
Get Mail Platform TCK into a Runnable State

### DIFF
--- a/glassfish-runner/mail-platform-tck/pom.xml
+++ b/glassfish-runner/mail-platform-tck/pom.xml
@@ -361,6 +361,7 @@
                                 <ts.home>${project.basedir}${file.separator}jakartaeetck</ts.home>
                                 <project.basedir>${project.basedir}</project.basedir>
                                 <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                                <ts.work.dir>${project.build.directory}</ts.work.dir>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>
@@ -390,6 +391,7 @@
                                 <ts.home>${project.basedir}${file.separator}jakartaeetck</ts.home>
                                 <project.basedir>${project.basedir}</project.basedir>
                                 <arquillian.xml>arquillian.xml</arquillian.xml>
+                                <ts.work.dir>${project.build.directory}</ts.work.dir>
                             </systemPropertyVariables>
                         </configuration>
                     </execution>

--- a/glassfish-runner/mail-platform-tck/pom.xml
+++ b/glassfish-runner/mail-platform-tck/pom.xml
@@ -356,9 +356,9 @@
                                 <additionalClasspathElement>${glassfish.module.dir}/glassfish-naming.jar</additionalClasspathElement>
                             </additionalClasspathElements>
                             <systemPropertyVariables>
-                                <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                                <glassfish.home>${glassfish.home}</glassfish.home>
                                 <java.naming.factory.initial>com.sun.enterprise.naming.impl.SerialInitContextFactory</java.naming.factory.initial>
-                                <ts.home>${env.TS_HOME}</ts.home>
+                                <ts.home>${project.basedir}${file.separator}jakartaeetck</ts.home>
                                 <project.basedir>${project.basedir}</project.basedir>
                                 <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>
@@ -385,9 +385,9 @@
                                 <additionalClasspathElement>${glassfish.module.dir}/glassfish-naming.jar</additionalClasspathElement>
                             </additionalClasspathElements>
                             <systemPropertyVariables>
-                                <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                                <glassfish.home>${glassfish.home}</glassfish.home>
                                 <java.naming.factory.initial>com.sun.enterprise.naming.impl.SerialInitContextFactory</java.naming.factory.initial>
-                                <ts.home>${env.TS_HOME}</ts.home>
+                                <ts.home>${project.basedir}${file.separator}jakartaeetck</ts.home>
                                 <project.basedir>${project.basedir}</project.basedir>
                                 <arquillian.xml>arquillian.xml</arquillian.xml>
                             </systemPropertyVariables>

--- a/glassfish-runner/mail-platform-tck/src/test/resources/appclient-arquillian.xml
+++ b/glassfish-runner/mail-platform-tck/src/test/resources/appclient-arquillian.xml
@@ -26,7 +26,7 @@
                 -Djdk.tls.client.enableSessionTicketExtension=false \
                 -Djdk.tls.server.enableSessionTicketExtension=false \
                 -Djava.security.policy=${glassfish.home}/glassfish/lib/appclient/client.policy \
-                -Dcts.tmp=${ts.home}/tmp \
+                -Dcts.tmp=${ts.work.dir}/tmp \
                 -Djava.security.auth.login.config=${glassfish.home}/glassfish/lib/appclient/appclientlogin.conf \
                 -Djava.protocol.handler.pkgs=javax.net.ssl \
                 -Djavax.net.ssl.keyStore=${ts.home}/bin/certificates/clientcert.jks \
@@ -54,7 +54,7 @@
             <property name="clientEnvString">PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
                 APPCPATH=${glassfish.home}/glassfish/lib/arquillian-protocol-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${glassfish.home}/glassfish/modules/security.jar</property>
             <property name="clientDir">${project.basedir}</property>
-            <property name="workDir">${ts.home}/tmp</property>
+            <property name="workDir">${ts.work.dir}/tmp</property>
             <property name="tsJteFile">${ts.home}/bin/ts.jte</property>
             <property name="tsSqlStmtFile">${ts.home}/bin/tssql.stmt</property>
             <property name="trace">true</property>

--- a/glassfish-runner/mail-platform-tck/src/test/resources/arquillian.xml
+++ b/glassfish-runner/mail-platform-tck/src/test/resources/arquillian.xml
@@ -22,7 +22,7 @@
             <property name="clientEarDir">target/appclient</property>
             <property name="unpackClientEar">true</property>
             <property name="clientDir">${project.basedir}</property>
-            <property name="workDir">${ts.home}/tmp</property>
+            <property name="workDir">${ts.work.dir}/tmp</property>
             <property name="tsJteFile">${ts.home}/bin/ts.jte</property>
             <property name="tsSqlStmtFile">${ts.home}/bin/tssql.stmt</property>
             <property name="trace">true</property>

--- a/glassfish-runner/pom.xml
+++ b/glassfish-runner/pom.xml
@@ -54,7 +54,7 @@
         <module>mail-platform-tck</module>
         <module>messaging-platform-tck</module>
         <module>messaging-tck</module>
-        <module>pages-debugging-other</module>
+        <module>pages-debugging-other-tck</module>
         <module>pages-platform-extra-tck</module>
         <module>pages-tck</module>
         <module>persistence-platform-tck</module>


### PR DESCRIPTION
**Fixes Issue**
None that I could find

**Related Issue(s)**
None

**Describe the change**
Gets the Mail TCK into a runnable state, as it doesn't currently resolve.
This is done by removing an undefined (and redundant) property.
Also fixes an incorrect module name under `glassfish-runner`.

I've also removed the need to define the TS_HOME environment variable and set it to glassfish-runner/mail-platform-tck/jakartaeetck, as the runner doesn't seem to actually expect it to be variable? It uses this directory to find the certificates and config files. 
To coincide with this, I have made a distinction between the home and work directories so that it does not leave config files the runner generates behind in there (which git is not configured to ignore).

Please correct me if this is in fact meant to be adjustable and I will remove those commits.

**Additional context**
I could not find an active Jenkins job for the Mail TCK in the Eclipse CI, I assume it is meant to be [this one](https://ci.eclipse.org/jakartaee-tck/job/11/job/tck/job/other/job/eftl-mail-tck-build-run/) but it's inactive.
If there is one and everything is green please feel free to disregard this PR (and point me at where this is please!).

The TCK does not pass for me locally on Java 17 or 21, but it at least now runs.
A few tests pass, but then the TCK seems to hit some ClassNotFoundExceptions on its own test classes (for a yet to be discerned reason), and then hangs.

ClassNotFound:
```
03-20-2025 10:27:56:  TRACE: #######  Value of harness.socket.retry.count is "10"
03-20-2025 10:27:56:  TRACE: #######  Value of harness.log.port is "2000"
03-20-2025 10:27:56:  TRACE: #######  Actual bind value of harness.log.port is "2000"
03-20-2025 10:27:56:  TRACE: Check if called from within test process, inTestHarness= true
03-20-2025 10:27:56:  TRACE: in ServiceEETest.run(), this URL is:  file:/home/andrew/Git/Platform-TCK/glassfish-runner/mail-platform-tck/target/appclient/internetMimeMultipart_appclient_vehicle_client.jar
03-20-2025 10:27:56:  TRACE: VehicleClient URL is:  file:/home/andrew/Git/Platform-TCK/glassfish-runner/mail-platform-tck/target/appclient/internetMimeMultipart_appclient_vehicle_client.jar
03-20-2025 10:27:56:  TRACE: VehicleClient class check if is vehicle class =  yes, is a com.sun.ts.tests.common.vehicle.VehicleClient
03-20-2025 10:27:56:  TRACE: in ServiceEETest.run() method
03-20-2025 10:27:56:  TRACE: Vehicle to be used for this test is:  appclient
java.lang.NoClassDefFoundError: com/sun/ts/tests/javamail/ee/internetMimeMultipart/NullOutputStream
        at java.base/java.lang.Class.forName0(Native Method)
        at java.base/java.lang.Class.forName(Class.java:421)
        at java.base/java.lang.Class.forName(Class.java:412)
        at com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.run(EmptyVehicleRunner.java:39)
        at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:119)
        at com.sun.ts.lib.harness.EETest.getPropsReady(EETest.java:440)
        at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:220)
        at com.sun.ts.lib.harness.EETest.run(EETest.java:254)
        at com.sun.ts.tests.common.vehicle.VehicleClient.main(VehicleClient.java:37)
Caused by: java.lang.ClassNotFoundException: com.sun.ts.tests.javamail.ee.internetMimeMultipart.NullOutputStream
        at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
        at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
        at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
        ... 9 more
STATUS:Failed.Vehicle runner failed
```

Hang:
```
INFO: [APPCLIENT-out] ************************************************************
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd outputLineReceived
INFO: [APPCLIENT-out] * props file set to "/tmp/andrew-cts-props.txt"
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd outputLineReceived
INFO: [APPCLIENT-out] ************************************************************
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd outputLineReceived
INFO: [APPCLIENT-out] 03-20-2025 10:28:03:  TRACE: #######  Value of harness.socket.retry.count is "10"
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd outputLineReceived
INFO: [APPCLIENT-out] 03-20-2025 10:28:03:  TRACE: #######  Value of harness.log.port is "2000"
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd outputLineReceived
INFO: [APPCLIENT-out] 03-20-2025 10:28:03:  TRACE: #######  Actual bind value of harness.log.port is "2000"
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err] Exception in thread "main" java.lang.NoClassDefFoundError: com/sun/ts/tests/javamail/ee/internetMimeMultipart/NullOutputStream
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at java.base/java.lang.Class.forName0(Native Method)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at java.base/java.lang.Class.forName(Class.java:421)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at java.base/java.lang.Class.forName(Class.java:412)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at com.sun.ts.lib.harness.EETest.getPropsReady(EETest.java:424)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at com.sun.ts.lib.harness.ServiceEETest.run(ServiceEETest.java:220)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at com.sun.ts.lib.harness.EETest.run(EETest.java:254)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at com.sun.ts.tests.common.vehicle.VehicleClient.main(VehicleClient.java:37)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err] Caused by: java.lang.ClassNotFoundException: com.sun.ts.tests.javamail.ee.internetMimeMultipart.NullOutputStream
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:641)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:188)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
INFO: [APPCLIENT-err]   at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:526)
Mar 20, 2025 10:28:03 AM tck.arquillian.protocol.appclient.AppClientCmd errorLineReceived
```