### PR TITLE
Increase Jenkins JNLP memory to workaround OOM when collecting test results with failures

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,10 +126,10 @@ spec:
   - name: jnlp
     env:
       - name: JNLP_PROTOCOL_OPTS
-        value: "-XshowSettings:vm -Xmx2048m -Dsun.zip.disableMemoryMapping=true -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
+        value: "-XshowSettings:vm -Xmx3072m -Dsun.zip.disableMemoryMapping=true -Dorg.jenkinsci.remoting.engine.JnlpProtocol3.disabled=true"
     resources:
       limits:
-        memory: "3Gi"
+        memory: "4Gi"
   - name: jakartaeetck-ci
     image: jakartaee/cts-base:0.4
     command:


### PR DESCRIPTION


**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2103

**Describe the change**
https://ci.eclipse.org/jakartaee-tck/job/11/job/tck/job/jakarta-jdbc-tck-glassfish/ should not get java.lang.OutOfMemoryError

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
