### PR TITLE
disable JDBC trace as possible workaround for https://github.com/jakartaee/platform-tck/issues/2103

### DIFF
--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/jakartaeetck/bin/ts.jte
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/jakartaeetck/bin/ts.jte
@@ -1429,7 +1429,7 @@ optional.tech.packages.to.ignore=jakarta.xml.bind
 ########################################################################
 harness.temp.directory=${ts.home}/tmp
 harness.log.port=2000
-harness.log.traceflag=true
+harness.log.traceflag=false
 harness.executeMode=0
 harness.socket.retry.count=10
 harness.log.delayseconds=1


### PR DESCRIPTION


**Fixes Issue**
Hopefully it helps https://github.com/jakartaee/platform-tck/issues/2103 for JDBC tests running out of memory post testing in https://ci.eclipse.org/jakartaee-tck/job/11/job/tck/job/jakarta-jdbc-tck-glassfish/

**Describe the change**
disable trace logging in ts.jte file for JDBC tests.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
