### PR TITLE
By default run `web` tests and for `platform` also run the `appclient` tests.

### DIFF
--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
@@ -323,6 +323,52 @@
                         <log.file.location>/tmp</log.file.location>
                     </systemPropertyVariables>
                 </configuration>
+
+                <executions>
+                    <execution>
+                        <id>jpa-tests-cdi</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>ee/jakarta/tck/persistence/ee/cdi/*Test.java</include>
+                            </includes>
+
+                            <skipITs>${cdi.skip}</skipITs>
+
+                            <systemPropertyVariables>
+                                <arquillian.xml>rest-arquillian.xml</arquillian.xml>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+
+                    <execution>
+                        <id>jpa-tests-javatest</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <!--
+                                <include>ee/jakarta/tck/persistence/**/*Test.java</include>
+                                <include>ee/jakarta/tck/persistence/core/annotations/basic/*Test.java</include>
+                                <include>ee/jakarta/tck/persistence/**/*Test.java</include>
+                                -->
+                                <include>ee/jakarta/tck/persistence/**/*Test.java</include>
+
+                            </includes>
+                            <groups>web</groups>
+
+                            <systemPropertyVariables>
+                                <arquillian.xml>arquillian.xml</arquillian.xml>
+                                <ts.home>${ts.home}</ts.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>
@@ -389,8 +435,6 @@
                                         <include>ee/jakarta/tck/persistence/core/annotations/basic/*Test.java</include>
                                         <include>ee/jakarta/tck/persistence/core/annotations/basic/Client1AppmanagednotxTest.java</include>
                                         <include>ee/jakarta/tck/persistence/core/inheritance/abstractentity/Client*Test.java</include>
-
-                                        <include>ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/*Test.java</include>
                                         -->
                                         <include>ee/jakarta/tck/persistence/**/*Test.java</include>
 
@@ -406,74 +450,6 @@
                         </executions>
                     </plugin>
                 </plugins>
-            </build>
-
-        </profile>
-        <profile>
-            <id>web</id>
-            <properties>
-                <glassfish-artifact-id>web</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-javatest</artifactId>
-                    <version>${jakarta.tck.arquillian.version}</version>
-                </dependency>
-            </dependencies>
-
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
-                        <executions>
-                        <execution>
-                            <id>jpa-tests-cdi</id>
-                            <goals>
-                                <goal>integration-test</goal>
-                                <goal>verify</goal>
-                            </goals>
-                            <configuration>
-                                <includes>
-                                    <include>ee/jakarta/tck/persistence/ee/cdi/*Test.java</include>
-                                </includes>
-                                <excludedGroups>tck-appclient,tck-javatest</excludedGroups>
-
-                                <skipITs>${cdi.skip}</skipITs>
-
-                                <systemPropertyVariables>
-                                    <arquillian.xml>rest-arquillian.xml</arquillian.xml>
-                                </systemPropertyVariables>
-                            </configuration>
-                        </execution>
-
-                        <execution>
-                            <id>jta-tests-javatest</id>
-                            <goals>
-                                <goal>integration-test</goal>
-                                <goal>verify</goal>
-                            </goals>
-                            <configuration>
-                                <includes>
-                                    <!--
-                                    <include>ee/jakarta/tck/persistence/**/*Test.java</include>
-                                    <include>ee/jakarta/tck/persistence/core/annotations/basic/*Test.java</include>
-                                    <include>ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/*Test.java</include>
-                                    -->
-                                    <include>ee/jakarta/tck/persistence/**/*Test.java</include>
-                                </includes>
-                                <groups>web</groups>
-
-                                <systemPropertyVariables>
-                                    <arquillian.xml>arquillian.xml</arquillian.xml>
-                                    <ts.home>${ts.home}</ts.home>
-                                </systemPropertyVariables>
-                            </configuration>
-                        </execution>
-                    </executions>
-                </plugin>
-            </plugins>
             </build>
         </profile>
     </profiles>


### PR DESCRIPTION
Should help address https://github.com/jakartaee/platform-tck/issues/2129

**Describe the change**
Revert the 894f5004450d1315003b65535f20fc1bd6f80d98 manually such that we always run the web (equivalent of ee/jakarta/tck/persistence/**/*Pmservlet*Test.java + ee/jakarta/tck/persistence/**/*Puservlet*Test.java tests) and full will run the web + platform tests


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
