### PR TITLE
Application-managed persistence context should be auto joined to active JTA (Jakarta Transactions transaction)

### DIFF
--- a/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/appmanaged/AppManagedVehicleBean.java
+++ b/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/appmanaged/AppManagedVehicleBean.java
@@ -23,6 +23,7 @@ package com.sun.ts.tests.common.vehicle.appmanaged;
 import java.util.Properties;
 
 import com.sun.ts.lib.harness.RemoteStatus;
+import com.sun.ts.lib.harness.Status;
 import com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareBaseBean;
 import com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper;
 
@@ -53,6 +54,10 @@ public class AppManagedVehicleBean extends EJB3ShareBaseBean
         props.put("persistence.unit.name", "CTS-EM");
         try {
             setEntityManager(emf.createEntityManager());
+            if (! getEntityManager().isJoinedToTransaction()) {
+                return new RemoteStatus(Status.failed(
+                        "application-managed entity manager should be automatically joined to active Jakarta Transactions transaction"));
+            }
             RemoteStatus retValue;
             retValue = super.runTest(args, props);
             return retValue;


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2132 

**Describe the change**
Add check if application-managed persistence context is automatically joined to transaction when created  in stateful session bean business method.

**Additional context**
Some of the failures mentioned in https://github.com/jakartaee/platform-tck/issues/2120 could be caused if application-managed persistence contexts were not joined in https://github.com/jakartaee/platform-tck/blob/ef1ea623993e2d896b7555efff8f02e0acee27c2/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/appmanaged/AppManagedVehicleBean.java#L56 so adding a check to ensure the possible issue is detected if this ever does happen.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
