### PR TITLE
Update Stateful3VehicleBean + AppManagedVehicleBean to Transactional.TxType.REQUIRED

### DIFF
--- a/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/appmanaged/AppManagedVehicleBean.java
+++ b/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/appmanaged/AppManagedVehicleBean.java
@@ -34,6 +34,8 @@ import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.PersistenceUnit;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.Transactional;
 
 @Stateful(name = "AppManagedVehicleBean")
 public class AppManagedVehicleBean extends EJB3ShareBaseBean
@@ -50,6 +52,7 @@ public class AppManagedVehicleBean extends EJB3ShareBaseBean
     private EntityManagerFactory emf;
 
     // ================== business methods ====================================
+    @Transactional(Transactional.TxType.REQUIRED)
     public RemoteStatus runTest(String[] args, Properties props) {
         props.put("persistence.unit.name", "CTS-EM");
         try {

--- a/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/stateful3/Stateful3VehicleBean.java
+++ b/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/stateful3/Stateful3VehicleBean.java
@@ -37,6 +37,8 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.PersistenceUnit;
+import jakarta.transaction.Transaction;
+import jakarta.transaction.Transactional;
 
 @Stateful(name = "Stateful3VehicleBean")
 public class Stateful3VehicleBean extends EJB3ShareBaseBean
@@ -67,6 +69,7 @@ public class Stateful3VehicleBean extends EJB3ShareBaseBean
 
     // ================== business methods ====================================
     @Remove
+    @Transactional(Transactional.TxType.REQUIRED)
     public RemoteStatus runTest(String[] args, Properties props) {
         RemoteStatus retValue;
         props.put("persistence.unit.name", "CTS-EM");


### PR DESCRIPTION
ClientAppmanagedTest.mapKeyColumnInsertableFalseTest  + ClientStateful3Test.mapKeyColumnInsertableFalseTest seem to fail still.  Try adding Transactional.TxType.REQUIRED which should be the default.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
