### PR TITLE
add condition check if entitymanager is joined to transaction to ee.jakarta.tck.persistence.core.annotations.version.Client2Stateful3Test#shortClassPropertyTest

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
@@ -213,6 +213,11 @@ public class Client2 extends Client {
 	public void shortClassPropertyTest() throws Exception {
 		boolean pass = false;
 		try {
+			if (! getEntityManager().isJoinedToTransaction()) {
+				throw new Exception("shortClassPropertyTest failed because there the persistence context " +
+						"is not joined to the transaction " +
+						getEntityTransaction() != null ? getEntityTransaction().getClass().getName() : "getEntityTransaction() returns null" );
+			}
 			ShortClass_Property a = getEntityManager().find(ShortClass_Property.class, "4");
 			if (a != null) {
 				logTrace( "version:" + a.getBasicShort());


### PR DESCRIPTION


**Fixes Issue**
Maybe help with https://github.com/jakartaee/platform-tck/issues/2112 by adding condition check that will fail with an obvious message if the test condition is wrong.

**Describe the change**
More specifically, we will check if the entitymanager is joined to a transaction.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
