### PR TITLE
Simplify requirements for sigtest runner and allow it to use staging repo

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -94,6 +94,7 @@
         <artifactId>shrinkwrap-resolver-depchain</artifactId>
         <version>${shrinkwrap.resolver.version}</version>
         <type>pom</type>
+        <scope>import</scope>
       </dependency>
 
       <!-- Jakarta TCK Test Artifacts -->
@@ -281,7 +282,26 @@
         <artifactId>shrinkwrap-api</artifactId>
         <version>1.2.6</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-api</artifactId>
+        <version>${shrinkwrap.resolver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+        <version>${shrinkwrap.resolver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-api-maven</artifactId>
+        <version>${shrinkwrap.resolver.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jboss.shrinkwrap.resolver</groupId>
+        <artifactId>shrinkwrap-resolver-spi-maven</artifactId>
+        <version>${shrinkwrap.resolver.version}</version>
+      </dependency>
     </dependencies> 
   </dependencyManagement> 
 </project>

--- a/glassfish-runner/signature/pom.xml
+++ b/glassfish-runner/signature/pom.xml
@@ -47,26 +47,13 @@
         <!-- Note that currently, this must have src as the first directory as it is hard-coded in the test -->
         <signature.file.dir>${base.tck.dir}/src</signature.file.dir>
         
-        <version.jakarta.ee.platform.tck.signaturevalidation>11.0.0</version.jakarta.ee.platform.tck.signaturevalidation>
-        <version.jakarta.tck.arquillian>11.0.0</version.jakarta.tck.arquillian>
-
-        <version.jakarta.ee.platform.tck.common>11.0.0-RC6</version.jakarta.ee.platform.tck.common>
-        <version.jakarta.ee.platform.tck.signaturetest>11.0.0-RC8</version.jakarta.ee.platform.tck.signaturetest>
+        <version.jakarta.tck>11.0.1-SNAPSHOT</version.jakarta.tck>
         <version.jakarta.tck.sigtest-maven-plugin>2.6</version.jakarta.tck.sigtest-maven-plugin>
-        
-        <version.org.jboss.shrinkwrap.resolver>3.1.4</version.org.jboss.shrinkwrap.resolver>
     </properties>
     
-    <!-- The Junit5 test frameworks -->
+    <!-- Import the tck relevant boms -->
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>5.12.0</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.jboss.arquillian</groupId>
                 <artifactId>arquillian-bom</artifactId>
@@ -75,24 +62,25 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <groupId>jakarta.tck</groupId>
+                <artifactId>artifacts-bom</artifactId>
+                <version>${version.jakarta.tck}</version>
+                <type>pom</type>
+                <scope>import</scope>
             </dependency>
         </dependencies>
+
     </dependencyManagement>
 
     <dependencies>
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>signaturevalidation</artifactId>
-            <version>${version.jakarta.ee.platform.tck.signaturevalidation}</version>
         </dependency>
 
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>signaturetest</artifactId>
-            <version>${version.jakarta.ee.platform.tck.signaturetest}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>
@@ -101,38 +89,19 @@
         </dependency>
 
         <!-- Jakarta TCK tools dependencies -->
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>common</artifactId>
-            <version>${version.jakarta.ee.platform.tck.common}</version>
-        </dependency>
-        
+
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-javatest</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>tck-porting-lib</artifactId>
-            <version>${version.jakarta.tck.arquillian}</version>
         </dependency>
 
         <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-container-spi</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-container-test-spi</artifactId>
         </dependency>
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>
@@ -143,34 +112,8 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
-            <version>1.2.6</version>
         </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-depchain</artifactId>
-            <version>${version.org.jboss.shrinkwrap.resolver}</version>
-            <type>pom</type>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-api</artifactId>
-            <version>${version.org.jboss.shrinkwrap.resolver}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
-            <version>${version.org.jboss.shrinkwrap.resolver}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-api-maven</artifactId>
-            <version>${version.org.jboss.shrinkwrap.resolver}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-spi-maven</artifactId>
-            <version>${version.org.jboss.shrinkwrap.resolver}</version>
-        </dependency>
+
     </dependencies>
 
     <build>
@@ -229,7 +172,7 @@
                                 <artifactItem>
                                     <groupId>jakarta.tck</groupId>
                                     <artifactId>signaturevalidation</artifactId>
-                                    <version>${version.jakarta.ee.platform.tck.signaturevalidation}</version>
+                                    <version>${version.jakarta.tck}</version>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${base.tck.dir}</outputDirectory>
                                     <includes>**/sig-test.map,**/sig-test-pkg-list.txt</includes>
@@ -237,7 +180,7 @@
                                 <artifactItem>
                                     <groupId>jakarta.tck</groupId>
                                     <artifactId>signaturevalidation</artifactId>
-                                    <version>${version.jakarta.ee.platform.tck.signaturevalidation}</version>
+                                    <version>${version.jakarta.tck}</version>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${signature.file.dir}</outputDirectory>
                                     <includes>**/*.sig</includes>

--- a/glassfish-runner/signature/pom.xml
+++ b/glassfish-runner/signature/pom.xml
@@ -27,7 +27,7 @@
     <groupId>jakarta</groupId>
     <artifactId>signature-tck-runner</artifactId>
     <version>11.0.0</version>
-    <name>WildFly: Jakarta EE Signature TCK Runner</name>
+    <name>GlassFish: Jakarta EE Signature TCK Runner</name>
 
     <properties>
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>

--- a/glassfish-runner/signature/src/test/resources/arquillian.xml
+++ b/glassfish-runner/signature/src/test/resources/arquillian.xml
@@ -21,12 +21,6 @@
                 <property name="trace">true</property>
                 <property name="workDir">${project.build.directory}</property>
                 <property name="tsJteFile">${project.build.directory}/test-classes/ts.jte</property>
-                <property name="runClient">true</property>
-                <property name="runAsVehicle">true</property>
-                <property name="clientEarDir">target/appclient</property>
-                <property name="unpackClientEar">true</property>
-                <property name="clientDir">${project.basedir}</property>
-                <property name="clientTimeout">20000</property>
             </protocol>
         </container>
     </group>

--- a/tcks/profiles/platform/signaturevalidation/pom.xml
+++ b/tcks/profiles/platform/signaturevalidation/pom.xml
@@ -53,11 +53,6 @@
             <artifactId>shrinkwrap-api</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.shrinkwrap.resolver</groupId>
-            <artifactId>shrinkwrap-resolver-depchain</artifactId>
-            <type>pom</type>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
         </dependency>

--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureServletTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureServletTest.java
@@ -158,8 +158,10 @@ public class ClientSignatureServletTest extends JakartaEESigTest implements Seri
 
         // add jakarta.tck:sigtest-maven-plugin jar to the war
         // Import Maven runtime dependencies
+        String profiles = System.getProperty("active.profiles", "");
+        String[] activeMavenProfiles = !profiles.isEmpty() ? profiles.split(",") : new String[] {};
         File[] files = Maven.resolver()
-                .loadPomFromFile("pom.xml")
+                .loadPomFromFile("pom.xml", activeMavenProfiles)
                 .resolve("jakarta.tck:sigtest-maven-plugin", "jakarta.tck:signaturetest")
                 .withoutTransitivity()
                 .asFile();


### PR DESCRIPTION
- Add a active.profiles system property that sets the active profile to use for resolution
- Correctly include the resolver dependencies in the jakarta.tck:artifacts-bom
- Use the jakarta.tck:artifacts-bom in sigtest runner and cleanup the dependencies
- Remove invalid properties for javatest arquillian.xml

**Fixes Issue**
Fixes #2140

**Related Issue(s)**
#1836 

**Describe the change**
The ClientSignatureServletTest will look for an active.profiles system property that allows the maven resolver to load the project pom.xm with those profiles enabled. This allows the sigtest to run against the staged artifacts.

**Additional context**
I was adding the section in the userguide on running the signature tests and when it would not run because of the staging profile not being used I looked into how this could be added and how the runner pom could be simplified.
