### PR TITLE
appclient prototype changes

### DIFF
--- a/glassfish-runner/platform/appclient-platform-tck/src/test/resources/arquillian.xml
+++ b/glassfish-runner/platform/appclient-platform-tck/src/test/resources/arquillian.xml
@@ -52,7 +52,7 @@
             <property name="cmdLineArgSeparator">\\</property>
             <!-- Pass ENV vars here -->
             <property name="clientEnvString">PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
-                APPCPATH=${glassfish.home}/glassfish/lib/arquillian-protocol-lib.jar:${glassfish.home}/glassfish/lib/tck-porting-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${glassfish.home}/glassfish/modules/security.jar</property>
+                AS_JAVA=${env.JAVA_HOME};APPCPATH=${glassfish.home}/glassfish/lib/arquillian-protocol-lib.jar:${glassfish.home}/glassfish/lib/tck-porting-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${glassfish.home}/glassfish/modules/security.jar</property>
             <property name="clientDir">${project.basedir}</property>
             <property name="workDir">${ts.home}/tmp</property>
             <property name="tsJteFile">${ts.home}/bin/ts.jte</property>

--- a/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/compat9_10/appclient_dep_compat9_10_client.jar.sun-application-client.xml
+++ b/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/compat9_10/appclient_dep_compat9_10_client.jar.sun-application-client.xml
@@ -21,6 +21,6 @@
 <sun-application-client>
   <ejb-ref>
     <ejb-ref-name>ejb/TestBean</ejb-ref-name>
-    <jndi-name/>
+    <jndi-name>corbaname:iiop:localhost:3700#java:global/appclient_dep_ejblink_casesens/appclient_dep_compat9_10_ejb/TestBean!com.sun.ts.tests.appclient.deploy.compat9_10.TestBean</jndi-name>
   </ejb-ref>
 </sun-application-client>


### PR DESCRIPTION
Set the AS_JAVA client env var to ${env.JAVA_HOME} to avoid default java not honoring the JAVA_HOME value.

Add example of jndi-name setting for appclient ejb lookup in the sun-application-client.xml descriptor to a COS naming service value that uses the portable global jndi name.


**Related Issue(s)**
Related to #2150

**Describe the change**
Set the appclient 

