### PR TITLE
TCK test for JTA #220

### DIFF
--- a/tcks/apis/transactions/pom.xml
+++ b/tcks/apis/transactions/pom.xml
@@ -35,6 +35,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <jakarta.transaction-api.version>2.0.2-SNAPSHOT</jakarta.transaction-api.version>
     </properties>
 
     <dependencyManagement>
@@ -54,6 +55,7 @@
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
+            <version>${jakarta.transaction-api.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.enterprise</groupId>

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClient.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClient.java
@@ -1,0 +1,211 @@
+/*
+ * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License v. 2.0, which is available at
+ * http://www.eclipse.org/legal/epl-2.0.
+ *
+ * This Source Code may also be made available under the following Secondary
+ * Licenses when the conditions for such availability set forth in the
+ * Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+ * version 2 with the GNU Classpath Exception, which is available at
+ * https://www.gnu.org/software/classpath/license.html.
+ *
+ * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+ */
+
+/*
+ * @(#)UserSetTransactionTimeoutClient.java	1.21 03/05/16
+ */
+
+package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
+
+import java.io.Serializable;
+import java.util.Properties;
+
+import com.sun.ts.lib.harness.ServiceEETest;
+import com.sun.ts.tests.jta.ee.common.Transact;
+import jakarta.transaction.RollbackException;
+import jakarta.transaction.Status;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.UserTransaction;
+
+/**
+ * The UserSetReadOnlyClient class tests setReadOnly() method of UserTransaction interface using
+ * Sun's J2EE Reference Implementation.
+ */
+
+public class UserSetReadOnlyClient extends ServiceEETest implements Serializable {
+    private static final String testName = "jta.ee.usertransaction.setreadonly";
+
+    private UserTransaction userTransaction = null;
+
+    public void setup(String[] args, Properties p) throws Exception {
+        try {
+            // Initializes the Environment
+            Transact.init();
+            logTrace("Test environment initialized");
+
+            // Gets the User Transaction
+            userTransaction = (UserTransaction) Transact.nctx.lookup("java:comp/UserTransaction");
+            logMsg("User Transaction object is Obtained");
+
+            if (userTransaction == null) {
+                logErr("Unable to get User Transaction" + " Instance : Could not proceed with" + " tests");
+                throw new Exception("couldnt proceed further");
+            } else if (userTransaction.getStatus() == Status.STATUS_ACTIVE) {
+                userTransaction.rollback();
+            }
+        } catch (Exception exception) {
+            logErr("Setup Failed!");
+            logTrace("Unable to get User Transaction Instance :" + " Could not proceed with tests");
+            throw new Exception("Setup Failed", exception);
+        }
+    }// End of setup
+
+    public static void main(String args[]) {
+        UserSetReadOnlyClient userSetTransTout = new UserSetReadOnlyClient();
+        com.sun.ts.lib.harness.Status s = userSetTransTout.run(args, System.out, System.err);
+        s.exit();
+
+    } // End of main
+
+    // Beginning of TestCases
+
+    /**
+     * @testName: testUserSetReadOnly001
+     * @test_Strategy: Before starting the User Transaction set the transaction time out as 10 seconds.Allow the thread to
+     * sleep for 30 seconds then call commit() User Transaction.
+     */
+    public void testUserSetReadOnly001() throws Exception {
+        boolean pass1 = false;
+        boolean pass2 = false;
+        boolean pass3 = false;
+
+        try {
+            if (!userTransaction.isReadOnly()) {
+                pass1 = true;
+            }
+
+            // Sets the readOnly value for the current transaction
+            userTransaction.setReadOnly(true);
+
+            // Starts a Global Transaction & associates with
+            // Current Thread.
+            userTransaction.begin();
+            logMsg("UserTransaction Started");
+
+            if (userTransaction.isReadOnly()) {
+                logMsg("UserTransaction readOnly is true");
+                pass2 = true;
+            }
+
+            // Commits the transaction.
+            userTransaction.commit();
+
+            if (!userTransaction.isReadOnly()) {
+                pass3 = true;
+            }
+
+            if (pass1 && pass2 && pass3) {
+                logMsg( "testUserSetReadOnly001 Passed" );
+            } else if (!pass1) {
+                throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
+            } else if (!pass2) {
+                throw new Exception("UserTransaction isReadOnly expected true on new active transaction after setReadOnly");
+            } else {
+                throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
+            }
+        } catch (Exception exception) {
+            logErr("Exception " + exception.toString() + " was caught");
+            throw new Exception("Exception was not thrown as" + " Expected in commit()", exception);
+        }
+
+    }// End of testUserSetReadOnly001
+
+    /**
+     * @testName: testUserSetReadOnly002
+     * @test_Strategy: Before starting the User Transaction set the transaction time out as 10 seconds.Allow the thread to
+     * sleep for 5 seconds then Call commit() User Transaction.Check the status of the User Transaction.
+     */
+
+    public void testUserSetReadOnly002() throws Exception {
+        boolean pass1 = false;
+        boolean pass2 = false;
+        boolean pass3 = false;
+
+        try {
+            if (!userTransaction.isReadOnly()) {
+                pass1 = true;
+            }
+            // Starts a Global Transaction & associates with
+            // Current Thread.
+            userTransaction.begin();
+            logMsg("UserTransaction Started");
+
+            // Sets the readOnly value for the current transaction
+            userTransaction.setReadOnly(true);
+
+            if (!userTransaction.isReadOnly()) {
+                pass2 = true;
+            }
+
+            // Commits the transaction.
+            userTransaction.commit();
+
+            if (!userTransaction.isReadOnly()) {
+                pass3 = true;
+            }
+
+            if (pass1 && pass2 && pass3) {
+                logMsg( "testUserSetReadOnly002 Passed" );
+            } else if (!pass1) {
+                throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
+            } else if (!pass2) {
+                throw new Exception("UserTransaction isReadOnly expected false on existing active transaction after setReadOnly");
+            } else {
+                throw new Exception("UserTransaction isReadOnly expected false on non active transaction");
+            }
+        } catch (SystemException system) {
+            logErr("Exception " + system.toString() + " was caught");
+            throw new Exception("UnExpected Exception was caught:" + " Failed", system);
+        } catch (Exception exception) {
+            logErr("Exception " + exception.toString() + " was caught");
+            throw new Exception("UnExpected Exception was caught:" + " Failed", exception);
+        }
+
+    }// End of testUserSetReadOnly002
+
+    public void cleanup() throws Exception {
+        try {
+            // Removing noisy stack trace.
+            if (userTransaction.getStatus() == Status.STATUS_ACTIVE) {
+                // Frees Current Thread, from Transaction
+                Transact.free();
+                try {
+                    userTransaction.rollback();
+                } catch (Exception exception) {
+                    throw new Exception(exception.getCause());
+                }
+                int retries = 1;
+                while ((userTransaction.getStatus() != Status.STATUS_NO_TRANSACTION) && (retries <= 5)) {
+                    logMsg("cleanup(): retry # " + retries);
+                    try {
+                        Thread.sleep(1000);
+                    } catch (Exception e) {
+                        throw new Exception(e.getCause());
+                    }
+                    retries++;
+                }
+                logMsg("Cleanup ok;");
+            } else {
+                logMsg("CleanUp not required as Transaction is not in Active state.");
+            }
+        } catch (Exception exception) {
+            logErr("Cleanup Failed", exception);
+            logTrace("Could not clean the environment");
+        }
+
+    }// End of cleanup
+
+}// End of UserSetReadOnlyClient

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientEjbTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientEjbTest.java
@@ -1,0 +1,131 @@
+package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
+
+import java.lang.System.Logger;
+import java.net.URL;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
+import org.jboss.shrinkwrap.api.spec.JavaArchive;
+
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("jta")
+@Tag("platform")
+@Tag("tck-appclient")
+
+public class UserSetReadOnlyClientEjbTest
+        extends UserSetReadOnlyClient {
+    static final String VEHICLE_ARCHIVE = "setreadonly_ejb_vehicle";
+
+    private static String packagePath = UserSetReadOnlyClientEjbTest.class.getPackageName().replace( ".", "/");
+
+    private static final Logger logger = System.getLogger( UserSetReadOnlyClientEjbTest.class.getName());
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    @Override
+    @AfterEach
+    public void cleanup() {
+        logger.log(Logger.Level.INFO, "cleanup ok");
+    }
+
+    @TargetsContainer("tck-appclient")
+    @OverProtocol("appclient")
+    @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+    public static EnterpriseArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        JavaArchive setreadonly_ejb_vehicle_client = ShrinkWrap.create(JavaArchive.class,
+                "setreadonly_ejb_vehicle_client.jar");
+        setreadonly_ejb_vehicle_client.addClasses(com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+                com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class, com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class,
+                Fault.class, com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class,
+                com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRunner.class, com.sun.ts.lib.harness.EETest.class,
+                com.sun.ts.lib.harness.ServiceEETest.class, SetupException.class,
+                com.sun.ts.tests.common.vehicle.VehicleClient.class, com.sun.ts.tests.jta.ee.common.Transact.class,
+                com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                com.sun.ts.tests.jta.ee.common.InitFailedException.class, UserSetReadOnlyClient.class,
+                UserSetReadOnlyClientEjbTest.class);
+        // The application-client.xml descriptor
+        URL resURL = UserSetReadOnlyClientEjbTest.class.getClassLoader().getResource( packagePath + "/ejb_vehicle_client.xml");
+        if (resURL != null) {
+            setreadonly_ejb_vehicle_client.addAsManifestResource(resURL, "application-client.xml");
+        }
+        resURL = UserSetReadOnlyClientEjbTest.class.getClassLoader()
+                .getResource(packagePath + "/setreadonly_ejb_vehicle_client.jar.sun-application-client.xml");
+        if (resURL != null) {
+            setreadonly_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
+        }
+        setreadonly_ejb_vehicle_client.addAsManifestResource(
+                new StringAsset("Main-Class: " + UserSetReadOnlyClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+        archiveProcessor.processClientArchive(setreadonly_ejb_vehicle_client, UserSetReadOnlyClientEjbTest.class,
+                resURL);
+
+        JavaArchive setreadonly_ejb_vehicle_ejb = ShrinkWrap.create(JavaArchive.class,
+                "setreadonly_ejb_vehicle_ejb.jar");
+        setreadonly_ejb_vehicle_ejb.addClasses(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+                Fault.class, com.sun.ts.tests.jta.ee.common.Transact.class,
+                com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                UserSetReadOnlyClient.class,
+                com.sun.ts.tests.common.vehicle.ejb.EJBVehicle.class, com.sun.ts.tests.jta.ee.common.InitFailedException.class,
+                com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+                com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote.class, com.sun.ts.lib.harness.EETest.class,
+                com.sun.ts.lib.harness.ServiceEETest.class, SetupException.class,
+                com.sun.ts.tests.common.vehicle.VehicleClient.class, UserSetReadOnlyClientEjbTest.class);
+        // The ejb-jar.xml descriptor
+        URL ejbResURL = UserSetReadOnlyClientEjbTest.class.getClassLoader().getResource( packagePath + "/ejb_vehicle_ejb.xml");
+        if (ejbResURL != null) {
+            setreadonly_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
+        }
+        // The sun-ejb-jar.xml file
+        ejbResURL = UserSetReadOnlyClientEjbTest.class.getClassLoader()
+                .getResource(packagePath + "/setreadonly_ejb_vehicle_ejb.jar.sun-ejb-jar.xml");
+        if (ejbResURL != null) {
+            setreadonly_ejb_vehicle_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
+        }
+        archiveProcessor.processEjbArchive( setreadonly_ejb_vehicle_ejb, UserSetReadOnlyClientEjbTest.class, ejbResURL);
+
+        EnterpriseArchive setreadonly_ejb_vehicle_ear = ShrinkWrap.create(EnterpriseArchive.class,
+                "setreadonly_ejb_vehicle.ear");
+        setreadonly_ejb_vehicle_ear.addAsModule(setreadonly_ejb_vehicle_ejb);
+        setreadonly_ejb_vehicle_ear.addAsModule(setreadonly_ejb_vehicle_client);
+
+        return setreadonly_ejb_vehicle_ear;
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejb")
+    public void testUserSetReadOnly001() throws Exception {
+        super.testUserSetReadOnly001();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("ejb")
+    public void testUserSetReadOnly002() throws Exception {
+        super.testUserSetReadOnly002();
+    }
+
+}

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientJspTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientJspTest.java
@@ -1,0 +1,107 @@
+package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
+
+import java.lang.System.Logger;
+import java.net.URL;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("jta")
+@Tag("platform")
+@Tag("web")
+@Tag("tck-javatest")
+
+public class UserSetReadOnlyClientJspTest
+        extends UserSetReadOnlyClient {
+    static final String VEHICLE_ARCHIVE = "setreadonly_jsp_vehicle";
+
+    private static String packagePath = UserSetReadOnlyClientJspTest.class.getPackageName().replace( ".", "/");
+
+    private static final Logger logger = System.getLogger( UserSetReadOnlyClientJspTest.class.getName());
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    @Override
+    @AfterEach
+    public void cleanup() {
+        logger.log(Logger.Level.INFO, "cleanup ok");
+    }
+
+    @TargetsContainer("tck-javatest")
+    @OverProtocol("javatest")
+    @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+    public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        WebArchive setreadonly_jsp_vehicle_web = ShrinkWrap.create(WebArchive.class, "setreadonly_jsp_vehicle_web.war");
+        setreadonly_jsp_vehicle_web.addClasses(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+                Fault.class, com.sun.ts.tests.jta.ee.common.Transact.class,
+                com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                UserSetReadOnlyClient.class,
+                com.sun.ts.tests.jta.ee.common.InitFailedException.class, com.sun.ts.tests.jta.ee.common.TransactionStatus.class,
+                com.sun.ts.tests.common.vehicle.VehicleRunnable.class, com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                com.sun.ts.tests.jta.ee.common.InitFailedException.class, com.sun.ts.lib.harness.EETest.class,
+                com.sun.ts.lib.harness.ServiceEETest.class, com.sun.ts.tests.jta.ee.common.TransactionStatus.class,
+                SetupException.class, com.sun.ts.tests.common.vehicle.VehicleClient.class,
+                UserSetReadOnlyClientJspTest.class);
+        // The web.xml descriptor
+        URL warResURL = UserSetReadOnlyClientJspTest.class.getClassLoader().getResource( packagePath + "/jsp_vehicle_web.xml");
+        if (warResURL != null) {
+            setreadonly_jsp_vehicle_web.addAsWebInfResource(warResURL, "web.xml");
+        }
+        warResURL = UserSetReadOnlyClientJspTest.class.getResource( "/vehicle/jsp/contentRoot/client.html");
+        setreadonly_jsp_vehicle_web.addAsWebResource(warResURL, "/client.html");
+        warResURL = UserSetReadOnlyClientJspTest.class.getResource( "/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
+        setreadonly_jsp_vehicle_web.addAsWebResource(warResURL, "/jsp_vehicle.jsp");
+
+        warResURL = UserSetReadOnlyClientJspTest.class.getClassLoader()
+                .getResource(packagePath + "/setreadonly_jsp_vehicle_web.war.sun-web.xml");
+        if (warResURL != null) {
+            setreadonly_jsp_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+        }
+        archiveProcessor.processWebArchive( setreadonly_jsp_vehicle_web, UserSetReadOnlyClientJspTest.class, warResURL);
+
+        return setreadonly_jsp_vehicle_web;
+        // EnterpriseArchive setreadonly_jsp_vehicle_ear = ShrinkWrap.create(EnterpriseArchive.class,
+        // "setreadonly_jsp_vehicle.ear");
+        // setreadonly_jsp_vehicle_ear.addAsModule(setreadonly_jsp_vehicle_web);
+        // return setreadonly_jsp_vehicle_ear;
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("jsp")
+    public void testUserSetReadOnly001() throws Exception {
+        super.testUserSetReadOnly001();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("jsp")
+    public void testUserSetReadOnly002() throws Exception {
+        super.testUserSetReadOnly002();
+    }
+
+}

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientServletTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/UserSetReadOnlyClientServletTest.java
@@ -1,0 +1,108 @@
+package com.sun.ts.tests.jta.ee.usertransaction.setreadonly;
+
+import java.lang.System.Logger;
+import java.net.URL;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OverProtocol;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
+import org.jboss.arquillian.junit5.ArquillianExtension;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+
+import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
+import tck.arquillian.protocol.common.TargetVehicle;
+
+@ExtendWith(ArquillianExtension.class)
+@Tag("jta")
+@Tag("platform")
+@Tag("web")
+@Tag("tck-javatest")
+
+public class UserSetReadOnlyClientServletTest
+        extends UserSetReadOnlyClient {
+    static final String VEHICLE_ARCHIVE = "setreadonly_servlet_vehicle";
+
+    private static String packagePath = UserSetReadOnlyClientServletTest.class.getPackageName().replace( ".", "/");
+
+    private static final Logger logger = System.getLogger( UserSetReadOnlyClientServletTest.class.getName());
+
+    @BeforeEach
+    void logStartTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "STARTING TEST : " + testInfo.getDisplayName());
+    }
+
+    @AfterEach
+    void logFinishTest(TestInfo testInfo) {
+        logger.log(Logger.Level.INFO, "FINISHED TEST : " + testInfo.getDisplayName());
+    }
+
+    @Override
+    @AfterEach
+    public void cleanup() {
+        logger.log(Logger.Level.INFO, "cleanup ok");
+    }
+
+    @TargetsContainer("tck-javatest")
+    @OverProtocol("javatest")
+    @Deployment(name = VEHICLE_ARCHIVE, order = 2)
+    public static WebArchive createDeploymentVehicle(@ArquillianResource TestArchiveProcessor archiveProcessor) {
+        // War
+        // the war with the correct archive name
+        WebArchive setreadonly_servlet_vehicle_web = ShrinkWrap.create(WebArchive.class,
+                "setreadonly_servlet_vehicle_web.war");
+        // The class files
+        setreadonly_servlet_vehicle_web.addClasses(com.sun.ts.tests.common.vehicle.VehicleRunnerFactory.class,
+                Fault.class, com.sun.ts.tests.jta.ee.common.Transact.class,
+                com.sun.ts.tests.jta.ee.common.InvalidStatusException.class,
+                UserSetReadOnlyClient.class,
+                com.sun.ts.tests.jta.ee.common.InitFailedException.class, com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class,
+                com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
+                com.sun.ts.tests.jta.ee.common.InvalidStatusException.class, com.sun.ts.tests.jta.ee.common.InitFailedException.class,
+                com.sun.ts.lib.harness.EETest.class, com.sun.ts.lib.harness.ServiceEETest.class,
+                com.sun.ts.tests.jta.ee.common.TransactionStatus.class, SetupException.class,
+                com.sun.ts.tests.common.vehicle.VehicleClient.class, UserSetReadOnlyClientServletTest.class);
+        // The web.xml descriptor
+        URL warResURL = UserSetReadOnlyClientServletTest.class.getClassLoader()
+                .getResource(packagePath + "/servlet_vehicle_web.xml");
+        if (warResURL != null) {
+            setreadonly_servlet_vehicle_web.setWebXML(warResURL);
+        }
+        warResURL = UserSetReadOnlyClientServletTest.class.getClassLoader()
+                .getResource(packagePath + "/setreadonly_servlet_vehicle_web.war.sun-web.xml");
+        if (warResURL != null) {
+            setreadonly_servlet_vehicle_web.addAsWebInfResource(warResURL, "sun-web.xml");
+        }
+        archiveProcessor.processWebArchive(setreadonly_servlet_vehicle_web, UserSetReadOnlyClientServletTest.class,
+                warResURL);
+
+        return setreadonly_servlet_vehicle_web;
+        // EnterpriseArchive setreadonly_servlet_vehicle_ear = ShrinkWrap.create(EnterpriseArchive.class,
+        // "setreadonly_servlet_vehicle.ear");
+        // setreadonly_servlet_vehicle_ear.addAsModule(setreadonly_servlet_vehicle_web);
+        // return setreadonly_servlet_vehicle_ear;
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("servlet")
+    public void testUserSetReadOnly001() throws Exception {
+        super.testUserSetReadOnly001();
+    }
+
+    @Test
+    @Override
+    @TargetVehicle("servlet")
+    public void testUserSetReadOnly002() throws Exception {
+        super.testUserSetReadOnly002();
+    }
+
+}

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/build.xml
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/build.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<project name="jta_ee_usertransaction_setreadonly" basedir="." default="usage">
+<import file="../../../../../../../../../bin/xml/ts.import.xml"/> 
+
+  <property name="includes"
+            value="com/sun/ts/tests/jta/ee/common/Transact.class,
+                   com/sun/ts/tests/jta/ee/common/TransactionStatus.class,
+                   com/sun/ts/tests/jta/ee/common/InvalidStatusException.class,
+                   com/sun/ts/tests/jta/ee/common/InitFailedException.class"/>
+  
+  <target name="package">
+      <ts.vehicles name="setreadonly">
+        <ejb-elements>
+          <fileset dir="${class.dir}" includes="${includes}"/>
+        </ejb-elements>
+        <servlet-elements>
+          <zipfileset dir="${class.dir}" includes="${includes}"
+                      prefix="WEB-INF/classes"/>
+        </servlet-elements>
+        <jsp-elements>
+          <zipfileset dir="${class.dir}" includes="${includes}"
+                      prefix="WEB-INF/classes"/>
+        </jsp-elements>
+      </ts.vehicles>
+  </target>
+
+</project>

--- a/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/appclient_vehicle_client.xml
+++ b/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/appclient_vehicle_client.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application-client version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd">
+  <description>TS app client UserSetReadOnly</description>
+  <display-name>setreadonly_client</display-name>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <ejb-ref-type>Session</ejb-ref-type>
+    <remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</remote>
+  </ejb-ref>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+    <res-sharing-scope>Shareable</res-sharing-scope>
+  </resource-ref>
+</application-client>

--- a/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/ejb_vehicle_client.xml
+++ b/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/ejb_vehicle_client.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<application-client version="10" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd">
+  <description>TS ejbvehicle client</description>
+  <display-name>setreadonly_ejb_vehicle_client</display-name>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <ejb-ref-type>Session</ejb-ref-type>
+    <remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</remote>
+  </ejb-ref>
+</application-client>

--- a/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/ejb_vehicle_ejb.xml
+++ b/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/ejb_vehicle_ejb.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018, 2024 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<ejb-jar version="4.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/ejb-jar_4_0.xsd">
+  <display-name>Ejb1</display-name>
+  <enterprise-beans>
+    <session>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <business-remote>com.sun.ts.tests.common.vehicle.ejb.EJBVehicleRemote</business-remote>
+      <ejb-class>com.sun.ts.tests.common.vehicle.ejb.EJBVehicle</ejb-class>
+      <session-type>Stateful</session-type>
+      <transaction-type>Bean</transaction-type>
+      <resource-ref>
+        <description>description</description>
+        <res-ref-name>jdbc/DB1</res-ref-name>
+        <res-type>javax.sql.DataSource</res-type>
+        <res-auth>Application</res-auth>
+        <res-sharing-scope>Shareable</res-sharing-scope>
+      </resource-ref>
+      <security-identity>
+        <use-caller-identity/>
+      </security-identity>
+    </session>
+  </enterprise-beans>
+</ejb-jar>

--- a/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/jsp_vehicle_web.xml
+++ b/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/jsp_vehicle_web.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+  <display-name>setreadonly_jsp_vehicle</display-name>
+  <servlet>
+    <servlet-name>jsp_vehicle</servlet-name>
+    <jsp-file>/jsp_vehicle.jsp</jsp-file>
+    <load-on-startup>0</load-on-startup>
+  </servlet>
+  <session-config>
+    <session-timeout>54</session-timeout>
+  </session-config>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+    <res-sharing-scope>Shareable</res-sharing-scope>
+  </resource-ref>
+</web-app>

--- a/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/servlet_vehicle_web.xml
+++ b/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/servlet_vehicle_web.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<web-app version="5.0" xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
+  <display-name>setreadonly_servlet_vehicle</display-name>
+  <servlet>
+    <servlet-name>Servlet_VehicleLogicalName</servlet-name>
+    <servlet-class>com.sun.ts.tests.common.vehicle.servlet.ServletVehicle</servlet-class>
+  </servlet>
+  <servlet-mapping>
+    <servlet-name>Servlet_VehicleLogicalName</servlet-name>
+    <url-pattern>/servlet_vehicle</url-pattern>
+  </servlet-mapping>
+  <session-config>
+    <session-timeout>54</session-timeout>
+  </session-config>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <res-type>javax.sql.DataSource</res-type>
+    <res-auth>Container</res-auth>
+    <res-sharing-scope>Shareable</res-sharing-scope>
+  </resource-ref>
+</web-app>

--- a/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_ejb_vehicle_client.jar.sun-application-client.xml
+++ b/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_ejb_vehicle_client.jar.sun-application-client.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-application-client PUBLIC "-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 8.0 Application Client 1.4//EN" "http://www.sun.com/software/sunone/appserver/dtds/sun-application-client_1_4-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-application-client>
+  <ejb-ref>
+    <ejb-ref-name>ejb/EJBVehicle</ejb-ref-name>
+    <jndi-name>setreadonly_ejb_vehicle</jndi-name>
+  </ejb-ref>
+</sun-application-client>

--- a/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_ejb_vehicle_ejb.jar.sun-ejb-jar.xml
+++ b/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_ejb_vehicle_ejb.jar.sun-ejb-jar.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-ejb-jar PUBLIC "-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 8.0 EJB 2.1//EN" "http://www.sun.com/software/sunone/appserver/dtds/sun-ejb-jar_2_1-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-ejb-jar>
+  <enterprise-beans>
+    <unique-id>0</unique-id>
+    <ejb>
+      <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
+      <jndi-name>setreadonly_ejb_vehicle</jndi-name>
+      <resource-ref>
+        <res-ref-name>jdbc/DB1</res-ref-name>
+        <jndi-name>jdbc/DB1</jndi-name>
+        <default-resource-principal>
+          <name>user1</name>
+          <password>password1</password>
+        </default-resource-principal>
+      </resource-ref>
+      <pass-by-reference>false</pass-by-reference>
+      <ior-security-config>
+        <transport-config>
+          <integrity>supported</integrity>
+          <confidentiality>supported</confidentiality>
+          <establish-trust-in-target>supported</establish-trust-in-target>
+          <establish-trust-in-client>supported</establish-trust-in-client>
+        </transport-config>
+        <as-context>
+          <auth-method>username_password</auth-method>
+          <realm>default</realm>
+          <required>false</required>
+        </as-context>
+        <sas-context>
+          <caller-propagation>supported</caller-propagation>
+        </sas-context>
+      </ior-security-config>
+      <is-read-only-bean>false</is-read-only-bean>
+      <refresh-period-in-seconds>-1</refresh-period-in-seconds>
+      <gen-classes/>
+    </ejb>
+  </enterprise-beans>
+</sun-ejb-jar>

--- a/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_jsp_vehicle_web.war.sun-web.xml
+++ b/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_jsp_vehicle_web.war.sun-web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 8.0 Servlet 2.4//EN" "http://www.sun.com/software/sunone/appserver/dtds/sun-web-app_2_4-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-web-app>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <jndi-name>jdbc/DB1</jndi-name>
+    <default-resource-principal>
+      <name>user1</name>
+      <password>password1</password>
+    </default-resource-principal>
+  </resource-ref>
+</sun-web-app>

--- a/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_servlet_vehicle_web.war.sun-web.xml
+++ b/tcks/apis/transactions/src/main/resources/com/sun/ts/tests/jta/ee/usertransaction/setreadonly/setreadonly_servlet_vehicle_web.war.sun-web.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE sun-web-app PUBLIC "-//Sun Microsystems, Inc.//DTD Sun ONE Application Server 8.0 Servlet 2.4//EN" "http://www.sun.com/software/sunone/appserver/dtds/sun-web-app_2_4-0.dtd">
+<!--
+
+    Copyright (c) 2018 Oracle and/or its affiliates. All rights reserved.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+
+<sun-web-app>
+  <resource-ref>
+    <res-ref-name>jdbc/DB1</res-ref-name>
+    <jndi-name>jdbc/DB1</jndi-name>
+    <default-resource-principal>
+      <name>user1</name>
+      <password>password1</password>
+    </default-resource-principal>
+  </resource-ref>
+</sun-web-app>


### PR DESCRIPTION
**Fixes Issue**
No Platform TCK issue yet.

**Related Issue(s)**
See JTA issue: https://github.com/jakartaee/transactions/issues/220

**Describe the change**
Added a test analogous to transaction timeout tests for `UserTransaction` to verify the `readOnly` hint is correctly propagated to a thread associated transaction.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
