### PR TITLE
Fix jakartaee/persistence#713, TCK should not try to lookup by time value with fractional seconds

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/datetime/Client.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/datetime/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -109,7 +109,7 @@ public class Client extends PMClientBase {
     private static final LocalTime LOCAL_TIME_DEF = LocalTime.of(0, 0, 0);
 
     /** LocalTime constant. */
-    private static final LocalTime LOCAL_TIME = LocalTime.now();
+    private static final LocalTime LOCAL_TIME = LocalTime.now().withNano(0);
 
     /** Default LocalDateTime constant. */
     private static final LocalDateTime LOCAL_DATE_TIME_DEF = LocalDateTime.of(1970, 1, 1, 0, 0, 0);

--- a/tcks/apis/persistence/persistence-outside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/datetime/Client.java
+++ b/tcks/apis/persistence/persistence-outside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/datetime/Client.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2024 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -111,7 +111,7 @@ public class Client extends PMClientBase {
     private static final LocalTime LOCAL_TIME_DEF = LocalTime.of(0, 0, 0);
 
     /** LocalTime constant. */
-    private static final LocalTime LOCAL_TIME = LocalTime.now();
+    private static final LocalTime LOCAL_TIME = LocalTime.now().withNano(0);
 
     /** Default LocalDateTime constant. */
     private static final LocalDateTime LOCAL_DATE_TIME_DEF = LocalDateTime.of(1970, 1, 1, 0, 0, 0);


### PR DESCRIPTION
**Fixes Issue**
jakartaee/persistence#713

**Describe the change**
TCK should not try to lookup by time value with fractional seconds

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
