### PR TITLE
Address ee.jakarta.tck.persistence.core.annotations.version.Client* failures by allowing null to be used for initial version field/property value 

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client1.java
@@ -173,7 +173,9 @@ public class Client1 extends Client {
 				getEntityTransaction().commit();
 				Integer_Field a1 = getEntityManager().find(Integer_Field.class, "3");
 				if (a1 != null) {
-					if (a1.getVersion() > version) {
+					if (a1.getVersion() == null) {
+						logErr("version is null for updated entity");
+					} else if (version == null || a1.getVersion() > version) {
 						logTrace( "version:" + a1.getVersion());
 						pass = true;
 					} else {
@@ -223,7 +225,9 @@ public class Client1 extends Client {
 				getEntityTransaction().commit();
 				Integer_Property a1 = getEntityManager().find(Integer_Property.class, "4");
 				if (a1 != null) {
-					if (a1.getBasicInteger() > version) {
+					if (a1.getBasicInteger() == null) {
+						logErr("version is null for updated entity");
+					} else if (version == null || a1.getBasicInteger() > version) {
 						logTrace( "version:" + a1.getBasicInteger());
 						pass = true;
 					} else {

--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client2.java
@@ -175,7 +175,9 @@ public class Client2 extends Client {
 				ShortClass_Field a1 = getEntityManager().find(ShortClass_Field.class, "3");
 				log.info("shortFieldTest, a1="+a1);
 				if (a1 != null) {
-					if (a1.getVersion() > version) {
+					if (a1.getVersion() == null) {
+						logErr("version is null for updated entity");
+					} else if (version == null || a1.getVersion() > version) {
 						logTrace( "version:" + a1.getVersion());
 						pass = true;
 					} else {
@@ -230,7 +232,10 @@ public class Client2 extends Client {
 				getEntityTransaction().commit();
 				ShortClass_Property a1 = getEntityManager().find(ShortClass_Property.class, "4");
 				if (a1 != null) {
-					if (a1.getBasicShort() > version) {
+					if (a1.getBasicShort() == null) {
+						logErr("version is null for updated entity");
+					}
+					else if (version == null || a1.getBasicShort() > version) {
 						logTrace( "version:" + a1.getBasicShort());
 						pass = true;
 					} else {

--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client3.java
@@ -171,7 +171,9 @@ public class Client3 extends Client {
 				getEntityTransaction().commit();
 				LongClass_Field a1 = getEntityManager().find(LongClass_Field.class, "3");
 				if (a1 != null) {
-					if (a1.getVersion() > version) {
+					if (a1.getVersion() == null) {
+						logErr("version is null for updated entity");
+					} else if (version == null || a1.getVersion() > version) {
 						logTrace( "version:" + a1.getVersion());
 						pass = true;
 					} else {
@@ -221,7 +223,9 @@ public class Client3 extends Client {
 				getEntityTransaction().commit();
 				LongClass_Property a1 = getEntityManager().find(LongClass_Property.class, "4");
 				if (a1 != null) {
-					if (a1.getBasicLong() > version) {
+					if (a1.getBasicLong() == null) {
+						logErr("version is null for updated entity");
+					} else if (version == null || a1.getBasicLong() > version) {
 						logTrace( "version:" + a1.getBasicLong());
 						pass = true;
 					} else {

--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/version/Client4.java
@@ -78,7 +78,9 @@ public class Client4 extends Client {
 				getEntityTransaction().commit();
 				Timestamp_Field a1 = getEntityManager().find(Timestamp_Field.class, "1");
 				if (a1 != null) {
-					if (a1.getVersion().after(version)) {
+					if (a1.getVersion() == null) {
+						logErr("version is null for updated entity");
+					} else if (version == null || a1.getVersion().after(version)) {
 						logTrace( "version:" + a1.getVersion());
 						pass = true;
 					} else {
@@ -134,7 +136,9 @@ public class Client4 extends Client {
 				getEntityTransaction().commit();
 				Timestamp_Property a1 = getEntityManager().find(Timestamp_Property.class, "2");
 				if (a1 != null) {
-					if (a1.getBasicTimestamp().after(version)) {
+					if (a1.getBasicTimestamp() == null) {
+						logErr("version is null for updated entity");
+					} else if (version == null || a1.getBasicTimestamp().after(version)) {
 						logTrace( "version:" + a1.getBasicTimestamp());
 						pass = true;
 					} else {


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2112

**Related Issue(s)**
Specify any related issue(s) links.

**Describe the change**
EclipseLink version support can use Null for the initial version for certain cases.  This change is to allow null to be used for those cases.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
