### PR TITLE
exclude ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.ClientAppmanagedTest and ee.jakarta.tck.persistence.core.annotations.mapkeycolumn.ClientStateful3Test from running mapKeyColumnInsertableFalseTest

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
@@ -219,12 +219,13 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
             super.annotationMapKeyColumnTest3();
         }
 
-        @Test
-        @Override
-        @TargetVehicle("appmanaged")
-        public void mapKeyColumnInsertableFalseTest() throws java.lang.Exception {
-            super.mapKeyColumnInsertableFalseTest();
-        }
+// Exclude tests not meant to run with appmanaged as per https://github.com/jakartaee/platform-tck/blob/10.0.x/install/jakartaee/other/vehicle.properties#L121
+//        @Test
+//        @Override
+//        @TargetVehicle("appmanaged")
+//        public void mapKeyColumnInsertableFalseTest() throws java.lang.Exception {
+//            super.mapKeyColumnInsertableFalseTest();
+//        }
 
         @Test
         @Override

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
@@ -219,12 +219,13 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
             super.annotationMapKeyColumnTest3();
         }
 
-        @Test
-        @Override
-        @TargetVehicle("stateful3")
-        public void mapKeyColumnInsertableFalseTest() throws java.lang.Exception {
-            super.mapKeyColumnInsertableFalseTest();
-        }
+// Exclude tests not meant to run with stateful3 as per https://github.com/jakartaee/platform-tck/blob/10.0.x/install/jakartaee/other/vehicle.properties#L121
+//        @Test
+//        @Override
+//        @TargetVehicle("stateful3")
+//        public void mapKeyColumnInsertableFalseTest() throws java.lang.Exception {
+//            super.mapKeyColumnInsertableFalseTest();
+//        }
 
         @Test
         @Override


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2120

Exclude specific tests on certain vehicles as was done in EE 10 via https://github.com/jakartaee/platform-tck/blob/10.0.x/install/jakartaee/other/vehicle.properties#L121

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
