### PR TITLE
exclude other persistence tests previously excluded 

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientAppmanagedTest.java
@@ -227,12 +227,13 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
 //            super.mapKeyColumnInsertableFalseTest();
 //        }
 
-        @Test
-        @Override
-        @TargetVehicle("appmanaged")
-        public void mapKeyColumnUpdatableFalseTest() throws java.lang.Exception {
-            super.mapKeyColumnUpdatableFalseTest();
-        }
+// Exclude tests not meant to run with appmanaged as per https://github.com/jakartaee/platform-tck/blob/10.0.x/install/jakartaee/other/vehicle.properties#L121
+//        @Test
+//        @Override
+//        @TargetVehicle("appmanaged")
+//        public void mapKeyColumnUpdatableFalseTest() throws java.lang.Exception {
+//            super.mapKeyColumnUpdatableFalseTest();
+//        }
 
         @Test
         @Override

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeycolumn/ClientStateful3Test.java
@@ -227,12 +227,13 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
 //            super.mapKeyColumnInsertableFalseTest();
 //        }
 
-        @Test
-        @Override
-        @TargetVehicle("stateful3")
-        public void mapKeyColumnUpdatableFalseTest() throws java.lang.Exception {
-            super.mapKeyColumnUpdatableFalseTest();
-        }
+// Exclude tests not meant to run with appmanaged as per https://github.com/jakartaee/platform-tck/blob/10.0.x/install/jakartaee/other/vehicle.properties#L121
+//        @Test
+//        @Override
+//        @TargetVehicle("stateful3")
+//        public void mapKeyColumnUpdatableFalseTest() throws java.lang.Exception {
+//            super.mapKeyColumnUpdatableFalseTest();
+//        }
 
         @Test
         @Override

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/ClientAppmanagedTest.java
@@ -208,12 +208,13 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.cache.
 //            super.evictTest1();
 //        }
 
-        @Test
-        @Override
-        @TargetVehicle("appmanaged")
-        public void evictTest2() throws java.lang.Exception {
-            super.evictTest2();
-        }
+// Exclude tests not meant to run as per https://github.com/jakartaee/platform-tck/blob/10.0.x/install/jakartaee/other/vehicle.properties#L121
+//        @Test
+//        @Override
+//        @TargetVehicle("appmanaged")
+//        public void evictTest2() throws java.lang.Exception {
+//            super.evictTest2();
+//        }
 
         @Test
         @Override

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/cache/basicTests/ClientStateful3Test.java
@@ -208,12 +208,13 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.cache.b
 //            super.evictTest1();
 //        }
 
-        @Test
-        @Override
-        @TargetVehicle("stateful3")
-        public void evictTest2() throws java.lang.Exception {
-            super.evictTest2();
-        }
+// Exclude tests not meant to run as per https://github.com/jakartaee/platform-tck/blob/10.0.x/install/jakartaee/other/vehicle.properties#L121
+//        @Test
+//        @Override
+//        @TargetVehicle("stateful3")
+//        public void evictTest2() throws java.lang.Exception {
+//            super.evictTest2();
+//        }
 
         @Test
         @Override


### PR DESCRIPTION
exclude other persistence tests previously excluded via https://github.com/jakartaee/platform-tck/blob/10.0.x/install/jakartaee/other/vehicle.properties#L121

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2111


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
