### PR TITLE
update ee.jakarta.tck.persistence.core.criteriaapi.CriteriaQuery.Client7Stateless3Test to address ClassNotFoundException

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client7Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/Client7Stateless3Test.java
@@ -178,6 +178,8 @@ public class Client7Stateless3Test extends ee.jakarta.tck.persistence.core.crite
                 ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
                 ee.jakarta.tck.persistence.common.schema30.Country.class
             );
+
+            jpa_core_criteriaapi_CriteriaQuery.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client7.class.getResource("persistence.xml");
             if(parURL != null) {


### PR DESCRIPTION
Add missing class to ee.jakarta.tck.persistence.common.schema30.CriteriaEntity.Client7Stateless3Test deployment

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2111

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
