### PR TITLE
update  ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.ClientAppmanagedTest to address java.lang.ClassNotFoundException: ee.jakarta.tck.persistence.common.schema30.CriteriaEntity error

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagedTest.java
@@ -144,6 +144,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.A.class,
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.B.class
             );
+            jpa_core_et_persist_manyXone.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagednotxTest.java
@@ -150,6 +150,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.en
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.A.class,
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.B.class
             );
+            jpa_core_et_persist_manyXone.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientPmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientPmservletTest.java
@@ -116,6 +116,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.entityt
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.A.class,
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.B.class
             );
+            jpa_core_et_persist_manyXone.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientPuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientPuservletTest.java
@@ -116,6 +116,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.entityt
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.A.class,
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.B.class
             );
+            jpa_core_et_persist_manyXone.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateful3Test.java
@@ -144,6 +144,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.A.class,
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.B.class
             );
+            jpa_core_et_persist_manyXone.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateless3Test.java
@@ -151,6 +151,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.entity
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.A.class,
                 ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.B.class
             );
+            jpa_core_et_persist_manyXone.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2111


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
