### PR TITLE
Disable Platform Persistence TRACE logging for junit.log.traceflag, harness.log.traceflag, cts.harness.debug

### DIFF
--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/jakartaeetck/bin/ts.jte
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/jakartaeetck/bin/ts.jte
@@ -1429,7 +1429,7 @@ optional.tech.packages.to.ignore=jakarta.xml.bind
 ########################################################################
 harness.temp.directory=${ts.home}/tmp
 harness.log.port=2000
-harness.log.traceflag=true
+harness.log.traceflag=false
 harness.executeMode=0
 harness.socket.retry.count=10
 harness.log.delayseconds=1

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/platform_pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/platform_pom.xml
@@ -316,9 +316,9 @@
                             list-file-users
                         </glassfish.postBootCommands>
                         
-                        <junit.log.traceflag>true</junit.log.traceflag>
-                        <harness.log.traceflag>true</harness.log.traceflag>
-                        <cts.harness.debug>true</cts.harness.debug>
+                        <junit.log.traceflag>false</junit.log.traceflag>
+                        <harness.log.traceflag>false</harness.log.traceflag>
+                        <cts.harness.debug>false</cts.harness.debug>
                         <project.basedir>${project.basedir}</project.basedir>
                         <log.file.location>/tmp</log.file.location>
                     </systemPropertyVariables>

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
@@ -316,9 +316,9 @@
                             list-file-users
                         </glassfish.postBootCommands>
                         
-                        <junit.log.traceflag>true</junit.log.traceflag>
-                        <harness.log.traceflag>true</harness.log.traceflag>
-                        <cts.harness.debug>true</cts.harness.debug>
+                        <junit.log.traceflag>false</junit.log.traceflag>
+                        <harness.log.traceflag>false</harness.log.traceflag>
+                        <cts.harness.debug>false</cts.harness.debug>
                         <project.basedir>${project.basedir}</project.basedir>
                         <log.file.location>/tmp</log.file.location>
                     </systemPropertyVariables>


### PR DESCRIPTION
**Describe the change**
Reduce trace log output for Platform Persistence test run

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
