### PR TITLE
Add an excluded test list

### DIFF
--- a/release/CHECKLIST.md
+++ b/release/CHECKLIST.md
@@ -11,6 +11,7 @@
     - [ ] jakarta.tck.common.version
     - [ ] jakarta.tck.sigtest.version
 - [ ] Ensure the release/README.adoc has updated release note highlights
+- [ ] Ensure the release/README.adoc has updated excluded tests
 - [ ] Drop any previously staged release using its staging repository id and the
   https://ci.eclipse.org/jakartaee-tck/job/DropStagingRepo/ job if this is a restage
 - [ ] Delete any previous tag before running the https://ci.eclipse.org/jakartaee-tck/job/11/job/stage-artifacts/job/TCKDistRelease/ job if this is a restage

--- a/release/EXCLUDES.adoc
+++ b/release/EXCLUDES.adoc
@@ -1,0 +1,2 @@
+* tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/Client.java
+* tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6.java

--- a/release/README.adoc
+++ b/release/README.adoc
@@ -76,3 +76,8 @@ The Jakarta EE TCK release has been ported to use Arquillian and Junit 5 as the 
 * The distribution includes an artifacts/artifacts-bom-11.0.0-*.pom bom type file that can be used to import the TCK artifacts into your project.
 * The distribution includes an artifacts/artifacts-sums.txt that provides the SHA1 and MD5 checksums for the TCK artifacts as they exist in the staging repository or Maven Central. This can be used to double check the integrity of the artifacts.
 
+== Excluded Tests
+
+The following tests are annotated as disabled due to exclusions:
+
+include::EXCLUDES.adoc[]

--- a/release/src/main/assembly/assembly.xml
+++ b/release/src/main/assembly/assembly.xml
@@ -14,6 +14,10 @@
             <source>README.adoc</source>
             <filtered>true</filtered>
         </file>
+        <file>
+            <source>EXCLUDES.adoc</source>
+            <filtered>false</filtered>
+        </file>
         <!-- This is the final EFTL license -->
         <file>
             <source>../LICENSE.md</source>


### PR DESCRIPTION
There is a release/EXCLUDES.adoc that lists the path in the platform-tck for tests annotated with `@Disabled`. This is linked to as the last section in the release/README.adoc as well.

**Fixes Issue**
Fixes #2232

