### PR TITLE
Exclude the jms_optional, javaee_optional tests

### DIFF
--- a/release/EXCLUDES.adoc
+++ b/release/EXCLUDES.adoc
@@ -1,2 +1,6 @@
 * tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/Client.java
 * tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/language/Client6.java
+* tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientAppclientTest.java
+* tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientEjbTest.java
+* tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientJspTest.java
+* tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientServletTest.java

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/ClientTest.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/annotations/ClientTest.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -23,14 +24,13 @@ import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 import tck.arquillian.protocol.common.TargetVehicle;
 
 
-
+@Disabled("https://github.com/jakartaee/platform-tck/issues/2231")
 @ExtendWith(ArquillianExtension.class)
 @Tag("jms")
 @Tag("jms_optional")
 @Tag("platform_optional")
 @Tag("web_optional")
 @Tag("tck-appclient")
-
 @TestMethodOrder(MethodOrderer.MethodName.class)
 public class ClientTest extends com.sun.ts.tests.jms.ee20.resourcedefs.annotations.Client {
     /**

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientAppclientTest.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientAppclientTest.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import tck.arquillian.protocol.common.TargetVehicle;
 
 
 
+@Disabled("https://github.com/jakartaee/platform-tck/issues/2231")
 @ExtendWith(ArquillianExtension.class)
 @Tag("jms")
 @Tag("jms_optional")

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientEjbTest.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientEjbTest.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import tck.arquillian.protocol.common.TargetVehicle;
 
 
 
+@Disabled("https://github.com/jakartaee/platform-tck/issues/2231")
 @ExtendWith(ArquillianExtension.class)
 @Tag("jms")
 @Tag("jms_optional")

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientJspTest.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientJspTest.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import tck.arquillian.protocol.common.TargetVehicle;
 
 
 
+@Disabled("https://github.com/jakartaee/platform-tck/issues/2231")
 @ExtendWith(ArquillianExtension.class)
 @Tag("jms")
 @Tag("jms_optional")

--- a/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientServletTest.java
+++ b/tcks/apis/messaging/messaging-inside-container/src/main/java/com/sun/ts/tests/jms/ee20/resourcedefs/descriptor/ClientServletTest.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.api.exporter.ZipExporter;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -24,6 +25,7 @@ import tck.arquillian.protocol.common.TargetVehicle;
 
 
 
+@Disabled("https://github.com/jakartaee/platform-tck/issues/2231")
 @ExtendWith(ArquillianExtension.class)
 @Tag("jms")
 @Tag("jms_optional")


### PR DESCRIPTION
Exclude the jms_optional, javaee_optional tests in the com.sun.ts.tests.jms.ee20.resourcedefs.* package.


**Fixes Issue**
Fixes #2231

