### PR TITLE
assembly tck : use portable jndi for lookup

### DIFF
--- a/glassfish-runner/platform/assembly-tck/assembly-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/assembly-tck/assembly-platform-tck-run/pom.xml
@@ -40,7 +40,7 @@
         <!-- Use JDK17 to run with GF 8.0.0-JDK17-M5 -->
         <glassfish.version>8.0.0-JDK17-M10</glassfish.version>
         <jakarta.platform.version>11.0.0-RC1</jakarta.platform.version>
-        <jakarta.tck.arquillian.version>11.0.3</jakarta.tck.arquillian.version>
+        <jakarta.tck.arquillian.version>11.0.5</jakarta.tck.arquillian.version>
         <junit.jupiter.version>5.10.2</junit.jupiter.version>
         <tck.artifactId>assembly-tck</tck.artifactId>
         <tck.version>11.0.1-SNAPSHOT</tck.version>
@@ -390,15 +390,7 @@
                                 <!-- <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/gf-client.jar</additionalClasspathElement> -->
                             </additionalClasspathElements>
                             <includes>
-                                <include>com/sun/ts/tests/assembly/altDD/Client.java</include>
-                                <include>com/sun/ts/tests/assembly/classpath/appclient/Client.java</include>
-                                <include>com/sun/ts/tests/assembly/classpath/ejb/Client.java</include>
-                                <include>com/sun/ts/tests/assembly/compat/cocktail/compat9_10/Client.java</include>
-                                <include>com/sun/ts/tests/assembly/compat/single/compat9_10/Client.java</include>
-                                <include>com/sun/ts/tests/assembly/compat/standalone/jar/compat9_10/Client.java</include>
-                                <include>com/sun/ts/tests/assembly/compat/standalone/war/compat9_10/Client.java</include>
-                                <include>com/sun/ts/tests/assembly/standalone/jar/Client.java</include>
-                                <include>com/sun/ts/tests/assembly/standalone/war/Client.java</include>
+                                <include>com/sun/ts/tests/assembly/**/Client.java</include>
                             </includes>
                             <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
                             <systemPropertyVariables>

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/altDD/Client.java
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/altDD/Client.java
@@ -141,8 +141,6 @@ public class Client extends EETest {
     if (ejbResURL != null) {
       assembly_altDD_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
     }
-    assembly_altDD_ejb.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"),
-        "MANIFEST.MF");
 
     archiveProcessor.processEjbArchive(assembly_altDD_ejb, Client.class, ejbResURL);
 
@@ -160,8 +158,6 @@ public class Client extends EETest {
     if (earResURL != null) {
       assembly_altDD_ear.addAsManifestResource(earResURL, "application.xml");
     }
-    assembly_altDD_ear.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"),
-        "MANIFEST.MF");
 
     archiveProcessor.processEarArchive(assembly_altDD_ear, Client.class, earResURL);
 

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/altDD/assembly_altDD_client.jar.sun-application-client.xml
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/altDD/assembly_altDD_client.jar.sun-application-client.xml
@@ -21,6 +21,7 @@
 <sun-application-client>
   <ejb-ref>
     <ejb-ref-name>ejb/myPainter</ejb-ref-name>
-    <jndi-name/>
+    <!-- <jndi-name/> -->
+    <jndi-name>java:global/assembly_altDD/assembly_altDD_ejb/Bean1!com.sun.ts.tests.assembly.altDD.PainterBean</jndi-name>
   </ejb-ref>
 </sun-application-client>

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/classpath/ejb/assembly_classpath_ejb_client.jar.sun-application-client.xml
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/classpath/ejb/assembly_classpath_ejb_client.jar.sun-application-client.xml
@@ -22,5 +22,6 @@
   <ejb-ref>
     <ejb-ref-name>ejb/TestBean</ejb-ref-name>
     <jndi-name/>
+    <jndi-name>java:global/assembly_classpath_ejb/assembly_classpath_ejb_ejb/TestBean!com.sun.ts.tests.assembly.classpath.ejb.TestBean</jndi-name>
   </ejb-ref>
 </sun-application-client>

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/cocktail/compat9_10/Client.java
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/cocktail/compat9_10/Client.java
@@ -139,8 +139,6 @@ public class Client extends EETest {
       assembly_compat_cocktail_compat9_10_jar1_ejb.addAsManifestResource(resURL, "sun-ejb-jar.xml");
     }
 
-    // assembly_compat_cocktail_compat9_10_jar1_ejb.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"),
-    //     "MANIFEST.MF");
     archiveProcessor.processEjbArchive(assembly_compat_cocktail_compat9_10_jar1_ejb, Client.class, resURL);
     
     JavaArchive assembly_compat_cocktail_compat9_10_jar2_ejb = ShrinkWrap.create(JavaArchive.class, "assembly_compat_cocktail_compat9_10_jar2_ejb.jar");
@@ -161,8 +159,6 @@ public class Client extends EETest {
       assembly_compat_cocktail_compat9_10_jar2_ejb.addAsManifestResource(resURL, "sun-ejb-jar.xml");
     }
 
-    // assembly_compat_cocktail_compat9_10_jar2_ejb.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"),
-    //     "MANIFEST.MF");
     archiveProcessor.processEjbArchive(assembly_compat_cocktail_compat9_10_jar1_ejb, Client.class, resURL);
 
 
@@ -231,8 +227,6 @@ public class Client extends EETest {
     if (earResURL != null) {
       assembly_compat_cocktail_compat9_10.addAsManifestResource(earResURL, "application.xml");
     }
-    // assembly_compat_cocktail_compat9_10
-    //     .addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
     archiveProcessor.processEarArchive(assembly_compat_cocktail_compat9_10, Client.class, earResURL);
 
     return assembly_compat_cocktail_compat9_10;

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/cocktail/compat9_10/assembly_compat_cocktail_compat9_10_another_client.jar.sun-application-client.xml
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/cocktail/compat9_10/assembly_compat_cocktail_compat9_10_another_client.jar.sun-application-client.xml
@@ -21,10 +21,12 @@
 <sun-application-client>
   <ejb-ref>
     <ejb-ref-name>ejb/Vision</ejb-ref-name>
-    <jndi-name/>
+    <!-- <jndi-name/> -->
+    <jndi-name>java:global/assembly_compat_cocktail_compat9_10/assembly_compat_cocktail_compat9_10_jar1_ejb/ReferencedBean1!com.sun.ts.tests.assembly.compat.cocktail.compat9_10.ReferencedBean</jndi-name>
   </ejb-ref>
   <ejb-ref>
     <ejb-ref-name>ejb/Music</ejb-ref-name>
-    <jndi-name/>
+    <!-- <jndi-name/> -->
+    <jndi-name>java:global/assembly_compat_cocktail_compat9_10/assembly_compat_cocktail_compat9_10_jar2_ejb/ReferencedBean2!com.sun.ts.tests.assembly.compat.cocktail.compat9_10.ReferencedBean</jndi-name>
   </ejb-ref>
 </sun-application-client>

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/cocktail/compat9_10/assembly_compat_cocktail_compat9_10_client.jar.sun-application-client.xml
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/cocktail/compat9_10/assembly_compat_cocktail_compat9_10_client.jar.sun-application-client.xml
@@ -21,10 +21,12 @@
 <sun-application-client>
   <ejb-ref>
     <ejb-ref-name>ejb/Vision</ejb-ref-name>
-    <jndi-name/>
+    <!-- <jndi-name/> -->
+    <jndi-name>java:global/assembly_compat_cocktail_compat9_10/assembly_compat_cocktail_compat9_10_jar1_ejb/ReferencedBean1!com.sun.ts.tests.assembly.compat.cocktail.compat9_10.ReferencedBean</jndi-name>
   </ejb-ref>
   <ejb-ref>
     <ejb-ref-name>ejb/Music</ejb-ref-name>
-    <jndi-name/>
+    <!-- <jndi-name/> -->
+    <jndi-name>java:global/assembly_compat_cocktail_compat9_10/assembly_compat_cocktail_compat9_10_jar2_ejb/ReferencedBean2!com.sun.ts.tests.assembly.compat.cocktail.compat9_10.ReferencedBean</jndi-name>
   </ejb-ref>
 </sun-application-client>

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/single/compat9_10/Client.java
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/single/compat9_10/Client.java
@@ -123,8 +123,7 @@ public class Client extends EETest {
     if (resURL != null) {
       assembly_compat_single_compat9_10_client.addAsManifestResource(resURL, "application-client.xml");
     }
-    resURL = Client.class.getClassLoader()
-        .getResource("assembly_compat_single_compat9_10_client.jar.sun-application-client.xml");
+    resURL = Client.class.getResource("assembly_compat_single_compat9_10_client.jar.sun-application-client.xml");
     if (resURL != null) {
       assembly_compat_single_compat9_10_client.addAsManifestResource(resURL, "sun-application-client.xml");
     }
@@ -135,8 +134,6 @@ public class Client extends EETest {
     JavaArchive assembly_compat_single_compat9_10_ejb = ShrinkWrap.create(JavaArchive.class,
         "assembly_compat_single_compat9_10_ejb.jar");
     assembly_compat_single_compat9_10_ejb.addClasses(
-        // com.sun.ts.tests.assembly.classpath.ejb.TestBean.class,
-        // com.sun.ts.tests.assembly.classpath.ejb.TestBeanEJB.class,
         com.sun.ts.tests.assembly.compat.single.compat9_10.TestBean.class,
         com.sun.ts.tests.assembly.compat.single.compat9_10.TestBeanEJB.class,
         com.sun.ts.lib.util.RemoteLoggingInitException.class,
@@ -147,13 +144,10 @@ public class Client extends EETest {
     if (ejbResURL != null) {
       assembly_compat_single_compat9_10_ejb.addAsManifestResource(ejbResURL, "ejb-jar.xml");
     }
-    ejbResURL = Client.class.getClassLoader()
-        .getResource("assembly_compat_single_compat9_10_ejb.jar.sun-ejb-jar.xml");
+    ejbResURL = Client.class.getResource("assembly_compat_single_compat9_10_ejb.jar.sun-ejb-jar.xml");
     if (ejbResURL != null) {
       assembly_compat_single_compat9_10_ejb.addAsManifestResource(ejbResURL, "sun-ejb-jar.xml");
     }
-    // assembly_compat_single_compat9_10_ejb
-    //     .addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
     archiveProcessor.processEjbArchive(assembly_compat_single_compat9_10_ejb, Client.class, ejbResURL);
 
     EnterpriseArchive assembly_compat_single_compat9_10_ear = ShrinkWrap.create(EnterpriseArchive.class,
@@ -161,13 +155,12 @@ public class Client extends EETest {
     assembly_compat_single_compat9_10_ear.addAsModule(assembly_compat_single_compat9_10_client);
     assembly_compat_single_compat9_10_ear.addAsModule(assembly_compat_single_compat9_10_ejb);
 
-    // URL earResURL = Client.class.getResource("application.xml");
-    // if (earResURL != null) {
-    //   assembly_compat_single_compat9_10_ear.addAsManifestResource(earResURL, "application.xml");
-    // }
-    // assembly_compat_single_compat9_10_ear
-    //     .addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
-    // archiveProcessor.processEarArchive(assembly_compat_single_compat9_10_ear, Client.class, earResURL);
+    URL earResURL = Client.class.getResource("application.xml");
+    if (earResURL != null) {
+      assembly_compat_single_compat9_10_ear.addAsManifestResource(earResURL, "application.xml");
+    }
+    archiveProcessor.processEarArchive(assembly_compat_single_compat9_10_ear, Client.class, earResURL);
+    
 
     return assembly_compat_single_compat9_10_ear;
   }

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/single/compat9_10/application-client.xml
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/single/compat9_10/application-client.xml
@@ -20,8 +20,8 @@
 <application-client xmlns="https://jakarta.ee/xml/ns/jakartaee"
 	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-	      https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd"
-	      version="9">
+	      https://jakarta.ee/xml/ns/jakartaee/application-client_10.xsd"
+	      version="10">
 
   <description>client for TS assembly compat single compat9_10 test</description>
   <display-name>assembly_compat_single_compat9_10_client</display-name>

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/single/compat9_10/application.xml
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/single/compat9_10/application.xml
@@ -17,7 +17,11 @@
 
 -->
 
-<application xmlns="https://jakarta.ee/xml/ns/jakartaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="10" xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/application_10.xsd">
+<application xmlns="https://jakarta.ee/xml/ns/jakartaee"
+	      xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	      xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+	      https://jakarta.ee/xml/ns/jakartaee/application-client_9.xsd"
+	      version="9">
 
   <display-name>assembly_compat_single_compat9_10</display-name>
   <description>Application description</description>

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/single/compat9_10/assembly_compat_single_compat9_10_client.jar.sun-application-client.xml
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/single/compat9_10/assembly_compat_single_compat9_10_client.jar.sun-application-client.xml
@@ -21,6 +21,7 @@
 <sun-application-client>
   <ejb-ref>
     <ejb-ref-name>ejb/TestBean</ejb-ref-name>
-    <jndi-name/>
+    <!-- <jndi-name/> -->
+    <jndi-name>java:global/assembly_compat_single_compat9_10/assembly_compat_single_compat9_10_ejb/TestBean!com.sun.ts.tests.assembly.compat.single.compat9_10.TestBean</jndi-name>
   </ejb-ref>
 </sun-application-client>

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/standalone/jar/compat9_10/Client.java
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/compat/standalone/jar/compat9_10/Client.java
@@ -143,8 +143,6 @@ public class Client extends EETest {
     if (earResURL != null) {
       assembly_compat_standalone_jar_compat9_10_ear.addAsManifestResource(earResURL, "application.xml");
     }
-    // assembly_compat_standalone_jar_compat9_10_ear
-    //     .addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
     archiveProcessor.processEarArchive(assembly_compat_standalone_jar_compat9_10_ear, Client.class, earResURL);
     return assembly_compat_standalone_jar_compat9_10_ear;
   }
@@ -172,8 +170,6 @@ public class Client extends EETest {
     if(resURL != null) {
       assembly_compat_standalone_jar_compat9_10_component_ejb.addAsManifestResource(resURL, "sun-ejb-jar.xml");
     }
-    // assembly_compat_standalone_jar_compat9_10_component_ejb
-    //     .addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
     archiveProcessor.processEjbArchive(assembly_compat_standalone_jar_compat9_10_component_ejb, Client.class, resURL);
 
     return assembly_compat_standalone_jar_compat9_10_component_ejb;


### PR DESCRIPTION
**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/1477

**Describe the change**
- Use portable jndi names in sun descriptors to fix NameNotFoundException while lookup for glassfish test runs.
- Fixes 5 test failures in assembly tck.
- Pending 1 test failure in assembly tck to be resolved : com/sun/ts/tests/assembly/altDD/Client.java#testAppclient with below exception. 

> 04-29-2025 23:15:51:  ERROR: [Client] Expected java:comp/env/myCountry name to be France, not Spain
> STATUS:Failed.Test case throws exception: Alternative DD test failed!com.sun.ts.lib.harness.EETest$Fault: Alternative DD test failed!
> 04-29-2025 23:15:51:  ERROR: Alternative DD test failed!
> 

