### PR TITLE
rename ejb reference for failing xa tests.

### DIFF
--- a/tcks/profiles/platform/xa/src/main/java/com/sun/ts/tests/xa/ee/resXcomp1/ClientEJB.java
+++ b/tcks/profiles/platform/xa/src/main/java/com/sun/ts/tests/xa/ee/resXcomp1/ClientEJB.java
@@ -126,7 +126,7 @@ public class ClientEJB extends Client implements Serializable {
   
   
   public String getTxRef() {
-	   return "java:comp/env/ejb/MyEjbReferenceEJB";
+	   return "java:comp/env/ejb/MyEjbReference";
  }
 
   /* Run test */

--- a/tcks/profiles/platform/xa/src/main/java/com/sun/ts/tests/xa/ee/resXcomp1/xa_resXcomp1_ejb_vehicle_ejb.jar.sun-ejb-jar.xml
+++ b/tcks/profiles/platform/xa/src/main/java/com/sun/ts/tests/xa/ee/resXcomp1/xa_resXcomp1_ejb_vehicle_ejb.jar.sun-ejb-jar.xml
@@ -25,7 +25,7 @@
       <ejb-name>com_sun_ts_tests_common_vehicle_ejb_EJBVehicle</ejb-name>
       <jndi-name>xa_resXcomp1_ejb_vehicle</jndi-name>
       <ejb-ref>
-        <ejb-ref-name>ejb/MyEjbReferenceEJB</ejb-ref-name>
+        <ejb-ref-name>ejb/MyEjbReference</ejb-ref-name>
         <jndi-name>xa_resXcomp1_ejb_TxRequired_TxBeanEJB1</jndi-name>
       </ejb-ref>
       <resource-ref>


### PR DESCRIPTION
rename ejb reference for failing GF 7.0.23 and 8.0.0-JDK17-M10 xa tests