### PR TITLE
Remove Extraneous Tags in JDBC TCK

### DIFF
--- a/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/escapeSyntax/scalar1/scalarClient1.java
+++ b/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/escapeSyntax/scalar1/scalarClient1.java
@@ -52,8 +52,6 @@ import com.sun.ts.tests.jdbc.ee.common.fnSchema;
 @ExtendWith(ArquillianExtension.class)
 @Tag("jdbc")
 @Tag("platform")
-@Tag("web")
-@Tag("tck-javatest")
 
 public class scalarClient1 extends ServiceEETest {
 	private static final String testName = "jdbc.ee.escapeSyntax";

--- a/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/resultSet/resultSet17/resultSetClient17.java
+++ b/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/resultSet/resultSet17/resultSetClient17.java
@@ -60,8 +60,6 @@ import com.sun.ts.tests.jdbc.ee.common.rsSchema;
 @ExtendWith(ArquillianExtension.class)
 @Tag("jdbc")
 @Tag("platform")
-@Tag("web")
-@Tag("tck-javatest")
 
 public class resultSetClient17 extends ServiceEETest implements Serializable {
 	private static final String testName = "jdbc.ee.resultSet.resultSet17";


### PR DESCRIPTION
Removes extra `web` tags. If you run the full TCK with the web group, 4 extra test classes will try to run that require an appclient vehicle because these tags are inherited.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
