### PR TITLE
[2268] Log an error message when the strategy fails for the WebTestCase.

### DIFF
--- a/tools/common/src/main/java/com/sun/ts/tests/common/webclient/WebTestCase.java
+++ b/tools/common/src/main/java/com/sun/ts/tests/common/webclient/WebTestCase.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import com.sun.ts.lib.util.TestUtil;
@@ -165,11 +166,12 @@ public class WebTestCase implements TestCase {
         } catch (Throwable t) {
             String message = t.getMessage();
             throw new TestFailureException(
-                    "[FATAL] Unexpected failure during " + "test execution." + (message == null ? t.toString() : message), t);
+                    "[FATAL] Unexpected failure during test execution." + (message == null ? t.toString() : message), t);
         }
 
         // Validate this test case instance
         if (!_strategy.validate(this)) {
+            LOGGER.log(Level.SEVERE, String.format("[FAILED] Request: %s%nResponse: %s", _request, _response));
             throw new TestFailureException("Test FAILED!");
         }
 


### PR DESCRIPTION
**Fixes Issue**
fixes #2268 

**Describe the change**
Logs an error message when the strategy fails in the `WebTestCase`. This logs the request and response for better understanding of the error.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
