### PR TITLE
Revert "Bump org.seleniumhq.selenium:selenium-chromium-driver from 4.24.0 to 4.32.0"

### DIFF
--- a/tcks/apis/cdi-ee-tck/tck/pom.xml
+++ b/tcks/apis/cdi-ee-tck/tck/pom.xml
@@ -161,7 +161,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-chromium-driver</artifactId>
-            <version>4.32.0</version>
+            <version>4.24.0</version>
         </dependency>
         
         <dependency>


### PR DESCRIPTION
Reverts jakartaee/platform-tck#2254

The upgrade creates compilation errors due to API changes.