### PR TITLE
Add more appclient signaturevalidation changes for GlassFish runner

### DIFF
--- a/glassfish-runner/signature/platform_pom.xml
+++ b/glassfish-runner/signature/platform_pom.xml
@@ -1,0 +1,287 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2025 Contributors to the Eclipse Foundation.
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+    
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+    
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+-->
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.9</version>
+        <relativePath />
+    </parent>
+
+    <groupId>jakarta</groupId>
+    <artifactId>signature-platform-tck-runner</artifactId>
+    <version>11.0.0</version>
+    <name>GlassFish: Jakarta EE Signature TCK Runner</name>
+
+    <properties>
+        <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>
+        <glassfish.root>${project.build.directory}</glassfish.root>
+        <glassfish.version>8.0.0-JDK17-M10</glassfish.version>
+        <glassfish.version.main>8</glassfish.version.main>
+        <glassfish-artifact-id>glassfish</glassfish-artifact-id>
+        
+        <!-- Remnants from ancient TCK -->
+        <webServerHost>localhost</webServerHost>
+        <webServerPort>8080</webServerPort>
+        
+        <!-- Properties set in the JTE file -->
+        <base.tck.dir>${project.build.directory}/jakartaee</base.tck.dir>
+        <bin.dir>${base.tck.dir}/com/sun/ts/tests/signaturetest/signature-repository</bin.dir>
+        
+        <!-- Note that currently, this must have src as the first directory as it is hard-coded in the test -->
+        <signature.file.dir>${base.tck.dir}/src</signature.file.dir>
+        
+        <jakarta.tck.arquillian.version>11.0.7</jakarta.tck.arquillian.version>
+        <version.jakarta.tck>11.0.1-SNAPSHOT</version.jakarta.tck>
+        <version.jakarta.tck.sigtest-maven-plugin>2.6</version.jakarta.tck.sigtest-maven-plugin>
+    </properties>
+    
+    <!-- Import the tck relevant boms -->
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.arquillian</groupId>
+                <artifactId>arquillian-bom</artifactId>
+                <version>1.9.3.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>jakarta.tck</groupId>
+                <artifactId>artifacts-bom</artifactId>
+                <version>${version.jakarta.tck}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>signaturevalidation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>signaturetest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>sigtest-maven-plugin</artifactId>
+            <version>${version.jakarta.tck.sigtest-maven-plugin}</version>
+        </dependency>
+
+        <!-- Jakarta TCK tools dependencies -->
+
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-javatest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-appclient</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>tck-porting-lib</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.omnifaces.arquillian</groupId>
+            <artifactId>arquillian-glassfish-server-managed</artifactId>
+            <version>1.7</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.shrinkwrap</groupId>
+            <artifactId>shrinkwrap-api</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <testResources>
+            <testResource>
+                <directory>src/test/resources</directory>
+                <filtering>true</filtering>
+                <includes>
+                    <include>arquillian.xml</include>
+                    <include>appclient-arquillian.xml</include>
+                    <include>ts.jte</include>
+                </includes>
+            </testResource>
+        </testResources>
+        
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.14.0</version>
+                <configuration>
+                    <release>17</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>001-unpack</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.distributions</groupId>
+                                    <artifactId>${glassfish-artifact-id}</artifactId>
+                                    <version>${glassfish.version}</version>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    
+                    <execution>
+                        <id>extract-sigtest-files</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>signaturevalidation</artifactId>
+                                    <version>${version.jakarta.tck}</version>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${base.tck.dir}</outputDirectory>
+                                    <includes>**/sig-test.map,**/sig-test-pkg-list.txt</includes>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>signaturevalidation</artifactId>
+                                    <version>${version.jakarta.tck}</version>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${signature.file.dir}</outputDirectory>
+                                    <includes>**/*.sig</includes>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        
+            <plugin>
+                <artifactId>maven-antrun-plugin</artifactId>
+                <version>3.1.0</version>
+                <executions>
+                    <execution>
+                        <id>configure-client-classpath</id>
+                        <phase>generate-test-resources</phase>
+                        <goals>
+                            <goal>run</goal>
+                        </goals>
+                        <configuration>
+                            <!-- Export the properties defined below so they can be used for the signature tests -->
+                            <exportAntProperties>true</exportAntProperties>
+                            <target>
+                                <fileset id="jakarta-api-jars"
+                                         dir="${glassfish.home}/glassfish/modules/">
+                                    <!-- Jakarta API's needed on the test class path -->
+                                    <include name="jakarta.*"/>
+                                </fileset>
+                                
+                                <pathconvert pathsep=","
+                                             property="jakarta.api.jars" refid="jakarta-api-jars"/>
+                                <pathconvert pathsep="${path.separator}"
+                                             property="sigTestClasspath" refid="jakarta-api-jars"/>
+                            </target>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <dependenciesToScan>
+                        <dependency>jakarta.tck:signaturevalidation</dependency>
+                    </dependenciesToScan>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>signaturevalidation-${tck.profile}</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>**/*Test</include>
+                            </includes>
+                            <excludes>
+                                <exclude>**/ClientSignatureAppClientTest.java</exclude>
+                            </excludes>
+                            <groups>${tck.profile}</groups>
+                            <additionalClasspathElements>
+                                <!-- Include the libraries from the server on the test class path -->
+                                <!--suppress MavenModelInspection -->
+                                <additionalClasspathElement>${jakarta.api.jars}</additionalClasspathElement>
+                            </additionalClasspathElements>
+                            
+                            <systemPropertyVariables>
+                                <glassfish.home>${glassfish.home}</glassfish.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>signature-tests-appclient</id>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                        <configuration>
+                            <includes>
+                                <include>com/sun/ts/tests/signaturetest/ClientSignatureAppClientTest.java</include>
+                            </includes>
+                            <groups>platform</groups>
+                            <excludedGroups>web</excludedGroups>
+                            <systemPropertyVariables>
+                                <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                                <ts.home>${ts.home}</ts.home>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/glassfish-runner/signature/src/test/resources/appclient-arquillian.xml
+++ b/glassfish-runner/signature/src/test/resources/appclient-arquillian.xml
@@ -26,22 +26,6 @@
             <property name="unpackClientEar">true</property>
             <!-- Need to populate from ts.jte command.testExecuteAppClient setting for glassfish -->
             <property name="clientCmdLineString">${glassfish.home}/glassfish/bin/appclient \
-                -Djdk.tls.client.enableSessionTicketExtension=false \
-                -Djdk.tls.server.enableSessionTicketExtension=false \
-                -Djava.security.policy=${glassfish.home}/glassfish/lib/appclient/client.policy \
-                -Dcts.tmp=${ts.home}/tmp \
-                -Djava.security.auth.login.config=${glassfish.home}/glassfish/lib/appclient/appclientlogin.conf \
-                -Djava.protocol.handler.pkgs=javax.net.ssl \
-                -Djavax.net.ssl.keyStore=${ts.home}/bin/certificates/clientcert.jks \
-                -Djavax.net.ssl.keyStorePassword=changeit \
-                -Djavax.net.ssl.trustStore=${glassfish.home}/glassfish/domains/domain1/config/cacerts.jks \
-                -Djavax.xml.parsers.SAXParserFactory=com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl \
-                -Djavax.xml.parsers.DocumentBuilderFactory=com.sun.org.apache.xerces.internal.jaxp.DocumentBuilderFactoryImpl \
-                -Djavax.xml.transform.TransformerFactory=com.sun.org.apache.xalan.internal.xsltc.trax.TransformerFactoryImpl \
-                -Dorg.xml.sax.driver=com.sun.org.apache.xerces.internal.parsers.SAXParser \
-                -Dorg.xml.sax.parser=org.xml.sax.helpers.XMLReaderAdapter \
-                -Doracle.jdbc.J2EE13Compliant=true \
-                -Doracle.jdbc.mapDateToTimestamp \
                 -Dstartup.login=false \
                 -Dauth.gui=false \
                 -Dlog.file.location=${glassfish.home}/glassfish/domains/domain1/logs \
@@ -57,11 +41,10 @@
             <!-- <property name="clientEnvString">PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
                 APPCPATH=${glassfish.home}/glassfish/lib/arquillian-protocol-lib.jar:${glassfish.home}/glassfish/lib/tck-porting-lib.jar:target/appclient/lib/arquillian-core.jar:target/appclient/lib/arquillian-junit5.jar:${glassfish.home}/glassfish/modules/security.jar</property> -->
             <property name="clientEnvString">AS_JAVA=${env.JAVA_HOME};PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
-                APPCPATH=target/appclient/lib/arquillian-protocol-lib.jar</property>
+                APPCPATH=target/appclient/lib/arquillian-protocol-lib.jar;target/appclient/lib/sigtest-maven-plugin-2.6.jar;target/appclient/lib/signaturetest-11.0.0.jar</property>
             <property name="clientDir">${project.basedir}</property>
-            <property name="workDir">/tmp</property>
-            <property name="tsJteFile">jakartaeetck/bin/ts.jte</property>
-            <property name="tsSqlStmtFile">sql/derby/derby.dml.sql</property>
+            <property name="workDir">${project.build.directory}</property>
+            <property name="tsJteFile">${project.build.directory}/test-classes/ts.jte</property>
             <property name="trace">true</property>
             <property name="clientTimeout">20000</property>
         </protocol>

--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureAppClientTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureAppClientTest.java
@@ -44,31 +44,31 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @ExtendWith(ArquillianExtension.class)
 @Tag("signaturetest")
 @Tag("platform")
+@Tag("tck-appclient")
 public class ClientSignatureAppClientTest extends JakartaEESigTest implements Serializable {
-    static final String VEHICLE_ARCHIVE = "signaturetest_ClientSignatureServletTest_servlet_vehicle_web.war";
 
     @TargetsContainer("tck-appclient")
     @OverProtocol("appclient")
     @Deployment(name = "appclient", testable = true)
     public static EnterpriseArchive createDeployment(@ArquillianResource TestArchiveProcessor archiveProcessor) {
 
-        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "rsMeta_appclient_vehicle_client.jar");
+        JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "ClientSignatureAppClientTest_client.jar");
         archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
         archive.addPackages(true, "com.sun.ts.lib.harness");
+        archive.addPackages(true, "com.sun.ts.tests.signaturetest");
         archive.addClasses(ClientSignatureAppClientTest.class,
                 JakartaEESigTest.class,
                 SigTestEE.class,
-                com.sun.ts.lib.harness.EETest.class,
                 Fault.class,
                 SetupException.class,
-                com.sun.ts.lib.harness.ServiceEETest.class,
-                com.sun.ts.lib.harness.Status.class,
                 com.sun.ts.lib.util.TestUtil.class
         );
         // The appclient-client descriptor
         URL appClientUrl = ClientSignatureAppClientTest.class.getResource("application-client.xml");
         if (appClientUrl != null) {
             archive.addAsManifestResource(appClientUrl, "application-client.xml");
+        } else {
+            throw new IllegalStateException("missing application-client.xml");
         }
         archive.addAsManifestResource(
                 new StringAsset("Main-Class: " + "com.sun.ts.tests.common.vehicle.VehicleClient" + "\n"),


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2210

**Describe the change**
Add platform_pom.xml for running Platform tests.

Output of running `mvn clean install -f platform_pom.xml `:

```
[INFO] Results:
[INFO]
[ERROR] Errors:
[ERROR]   ClientSignatureEJBTest.signatureTest »  Test case throws exception: SigTestEE.signatureTest() failed!, diffs found
[ERROR]   ClientSignatureJspTest.signatureTest »  Test case throws exception: SigTestEE.signatureTest() failed!, diffs found
[ERROR]   ClientSignatureServletTest.signatureTest »  Test case throws exception: SigTestEE.signatureTest() failed!, diffs found
[INFO]
[ERROR] Tests run: 3, Failures: 0, Errors: 3, Skipped: 0
...
Running com.sun.ts.tests.signaturetest.ClientSignatureAppClientTest
Caused by: java.lang.ClassNotFoundException: com.sun.tdk.signaturetest.SignatureTest
[ERROR] Errors:
[ERROR]   ClientSignatureAppClientTest.signatureTest »  Test case throws exception: signatureTest failed with an unexpected exception
[INFO]
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0
[INFO]
```


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
