### PR TITLE
update tck version in runners to use 11.0.1-SNAPSHOT by default

### DIFF
--- a/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
@@ -27,14 +27,14 @@
     </parent>
 
     <artifactId>expression-language-extra-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Expression Language Platform Substitute TCK</name>
 
     <properties>
         <tck.test.expression-language-extra.file>jakartaeetck-${tck.test.expression-language-extra.version}-dist.zip</tck.test.expression-language-extra.file>
         <tck.test.expression-language-extra.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.expression-language-extra.file}</tck.test.expression-language-extra.url>
-        <tck.test.expression-language-extra.version>${project.version}</tck.test.expression-language-extra.version>
+        <tck.test.expression-language-extra.version>11.0.1-SNAPSHOT</tck.test.expression-language-extra.version>
     </properties>
 
     <build>

--- a/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-run/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-run/pom.xml
@@ -35,7 +35,7 @@
         <glassfish.version>8.0.0-M10</glassfish.version>
         
         <jakarta.platform.version>11.0.0-RC1</jakarta.platform.version>
-        <tck.version>11.0.0</tck.version>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
         <ts.home>./jakartaeetck</ts.home>
     </properties>
 

--- a/glassfish-runner/expression-language-platform-subst-tck/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>expression-language-platform-subst-tck</artifactId>
-    <version>6.0.0-SNAPSHOT</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-install/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonb-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta JSON-B Extra TCK</name>
 
@@ -36,7 +36,7 @@
         <tck.test.jsonb.extra.file>jakartaeetck-${tck.test.jsonb.version}-dist.zip</tck.test.jsonb.extra.file>
         <tck.test.jsonb.extra.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.jsonb.extra.file}</tck.test.jsonb.extra.url>
         
-        <tck.test.jsonb.version>${project.version}</tck.test.jsonb.version>
+        <tck.test.jsonb.version>11.0.1-SNAPSHOT</tck.test.jsonb.version>
     </properties>
 
     <build>

--- a/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
@@ -27,7 +27,7 @@
     
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsonb-platform-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -43,7 +43,7 @@
         
         <jakarta.tck.arquillian.version>11.0.0</jakarta.tck.arquillian.version>
         <jakarta.tck.common.version>11.0.0</jakarta.tck.common.version>
-        <tck.version>3.0.0-M1</tck.version>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
         <ts.home>/jakartaeetck</ts.home>
     </properties>
     

--- a/glassfish-runner/jsonb-platform-extra-tck/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonp-platform-extra-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-install/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonp-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta JSON-P Extra TCK</name>
 
@@ -36,7 +36,7 @@
         <tck.test.jsonp.extra.file>jakartaeetck-${tck.test.jsonp.version}-dist.zip</tck.test.jsonp.extra.file>
         <tck.test.jsonp.extra.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.jsonp.extra.file}</tck.test.jsonp.extra.url>
         
-        <tck.test.jsonp.version>${project.version}</tck.test.jsonp.version>
+        <tck.test.jsonp.version>11.0.1-SNAPSHOT</tck.test.jsonp.version>
     </properties>
 
     <build>

--- a/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
@@ -27,7 +27,7 @@
     
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsonp-platform-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -43,7 +43,7 @@
         
         <jakarta.tck.arquillian.version>11.0.0</jakarta.tck.arquillian.version>
         <jakarta.tck.common.version>11.0.0</jakarta.tck.common.version>
-        <tck.version>${project.version}</tck.version>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
         <ts.home>/jakartaeetck</ts.home>
     </properties>
 

--- a/glassfish-runner/jsonp-platform-extra-tck/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonb-platform-extra-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/mail-platform-tck/mail-platform-tck-install/pom.xml
+++ b/glassfish-runner/mail-platform-tck/mail-platform-tck-install/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>mail-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Mail TCK</name>
 
@@ -36,7 +36,7 @@
         <tck.test.mail.file>jakartaeetck-${tck.test.mail.version}-dist.zip</tck.test.mail.file>
         <tck.test.mail.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.mail.file}</tck.test.mail.url>
         
-        <tck.test.mail.version>${project.version}</tck.test.mail.version>
+        <tck.test.mail.version>11.0.1-SNAPSHOT</tck.test.mail.version>
     </properties>
 
     <build>

--- a/glassfish-runner/mail-platform-tck/mail-platform-tck-run/pom.xml
+++ b/glassfish-runner/mail-platform-tck/mail-platform-tck-run/pom.xml
@@ -32,7 +32,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.mail-platform-tck-run</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>

--- a/glassfish-runner/mail-platform-tck/pom.xml
+++ b/glassfish-runner/mail-platform-tck/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>mail-platform-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/messaging-platform-tck/messaging-platform-tck-run/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/messaging-platform-tck-run/pom.xml
@@ -25,7 +25,7 @@
 
    <groupId>jakarta.tck</groupId>
    <artifactId>messaging-platform-tck-run</artifactId>
-   <version>11.0.0</version>
+   <version>11.0.1</version>
    <packaging>jar</packaging>
 
    <properties>

--- a/glassfish-runner/messaging-platform-tck/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>messaging-platform-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-install/pom.xml
@@ -27,14 +27,14 @@
     </parent>
 
     <artifactId>pages-extra-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Pages Platform Extra TCK</name>
 
     <properties>
         <tck.test.pages-extra.file>jakartaeetck-${tck.test.pages-extra.version}-dist.zip</tck.test.pages-extra.file>
         <tck.test.pages-extra.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.pages-extra.file}</tck.test.pages-extra.url>
-        <tck.test.pages-extra.version>${project.version}</tck.test.pages-extra.version>
+        <tck.test.pages-extra.version>11.0.1-SNAPSHOT</tck.test.pages-extra.version>
 
     </properties>
 

--- a/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-run/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsp-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -34,7 +34,7 @@
         <jakarta.platform.version>11.0.0-RC1</jakarta.platform.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.artifactId>pages-platform-tck</tck.artifactId>
-        <tck.version>11.0.0</tck.version>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
     </properties>
 
     <!-- The Junit5 test frameworks -->

--- a/glassfish-runner/platform/assembly-tck/assembly-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/assembly-tck/assembly-platform-tck-install/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>assembly-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Assembly TCK</name>
 

--- a/glassfish-runner/platform/assembly-tck/assembly-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/assembly-tck/assembly-platform-tck-run/pom.xml
@@ -26,7 +26,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.assembly-tck-run</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-install/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>integration-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Integration TCK</name>
 

--- a/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-run/pom.xml
@@ -25,7 +25,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.integration-platform-tck-run</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-install/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>javaee-module-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Javaee Module TCK</name>
 

--- a/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-run/pom.xml
@@ -24,7 +24,7 @@
     </parent>
     <groupId>jakarta</groupId>
     <artifactId>glassfish.javaee-module-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>jar</packaging>
 
     <properties>

--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-install/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <tck.test.jdbc.file>jakartaeetck-${tck.test.jdbc.version}-dist.zip</tck.test.jdbc.file>
         <tck.test.jdbc.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.jdbc.file}</tck.test.jdbc.url>
-        <tck.test.jdbc.version>11.0.0</tck.test.jdbc.version>
+        <tck.test.jdbc.version>11.0.1-SNAPSHOT</tck.test.jdbc.version>
     </properties>
 
     <build>

--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/pom.xml
@@ -28,7 +28,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jdbc-platform-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>jar</packaging>
     <properties>
         <arquillian.core.version>1.9.1.Final</arquillian.core.version>
@@ -39,7 +39,7 @@
         <ts.home>./jakartaeetck</ts.home>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <sql.directory>./sql</sql.directory>
-        <tck.version>11.0.0</tck.version>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
         <jakarta.tck.arquillian.version>11.0.0</jakarta.tck.arquillian.version>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <!-- Use JDK17 to run with GF-8.0.0-JDK17-M7 -->
@@ -71,7 +71,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>jdbc-platform-tck</artifactId>
-            <version>${project.version}</version>
+            <version>${tck.version}</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.container</groupId>

--- a/glassfish-runner/platform/jdbc-platform-tck/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/pom.xml
@@ -27,7 +27,7 @@
     </parent>
 
     <artifactId>jdbc-platform-tck</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-install/pom.xml
@@ -27,14 +27,14 @@
     </parent>
 
     <artifactId>rest-extra-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta REST Platform Extra TCK</name>
 
     <properties>
         <tck.test.rest-extra.file>jakartaeetck-${tck.test.rest-extra.version}-dist.zip</tck.test.rest-extra.file>
         <tck.test.rest-extra.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.rest-extra.file}</tck.test.rest-extra.url>
-        <tck.test.rest-extra.version>${project.version}</tck.test.rest-extra.version>
+        <tck.test.rest-extra.version>11.0.1-SNAPSHOT</tck.test.rest-extra.version>
     </properties>
 
     <build>

--- a/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-run/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish-restful-tests</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
 
     <name>TCK: Run Jakarta REST Platform Extra TCK</name>
     <description>
@@ -43,7 +43,7 @@
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <!-- Use JDK17 to run with GF-8.0.0-JDK17-M7 -->
         <glassfish.version>8.0.0-JDK17-M9</glassfish.version>
-        <tck.version>11.0.0</tck.version>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
     </properties>
 
     <!-- The Junit5 test frameworks -->

--- a/glassfish-runner/tags-tck/tags-tck-install/pom.xml
+++ b/glassfish-runner/tags-tck/tags-tck-install/pom.xml
@@ -27,14 +27,14 @@
     </parent>
 
     <artifactId>tags-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta tags TCK</name>
 
     <properties>
         <tck.test.tags.file>jakartaeetck-${tck.test.tags.version}-dist.zip</tck.test.tags.file>
         <tck.test.tags.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.tags.file}</tck.test.tags.url>
-        <tck.test.tags.version>${project.version}</tck.test.tags.version>
+        <tck.test.tags.version>11.0.1-SNAPSHOT</tck.test.tags.version>
     </properties>
 
     <build>

--- a/glassfish-runner/tags-tck/tags-tck-run/pom.xml
+++ b/glassfish-runner/tags-tck/tags-tck-run/pom.xml
@@ -33,7 +33,7 @@
         <glassfish.version>8.0.0-M10</glassfish.version>
         <glassfish.version.main>8</glassfish.version.main>
         <jakarta.platform.version>11.0.0-RC1</jakarta.platform.version>
-        <tck.version>${project.version}</tck.version>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
         <jakarta.tck.tags.version>${tck.version}</jakarta.tck.tags.version>
     </properties>
 

--- a/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
+++ b/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
@@ -27,14 +27,14 @@
     </parent>
 
     <artifactId>transactions-tck-install</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Transactions TCK</name>
 
     <properties>
         <tck.test.transactions.file>jakartaeetck-${tck.test.transactions.version}-dist.zip</tck.test.transactions.file>
         <tck.test.transactions.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.transactions.file}</tck.test.transactions.url>
-        <tck.test.transactions.version>${project.version}</tck.test.transactions.version>
+        <tck.test.transactions.version>11.0.1-SNAPSHOT</tck.test.transactions.version>
     </properties>
 
     <build>

--- a/glassfish-runner/transactions-tck/transactions-tck-run/pom.xml
+++ b/glassfish-runner/transactions-tck/transactions-tck-run/pom.xml
@@ -26,7 +26,7 @@
     </parent>
 
     <artifactId>transactions-tck-run</artifactId>
-    <version>11.0.0</version>
+    <version>11.0.1</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -45,7 +45,7 @@
         
         <jakarta.tck.common.version>11.0.0</jakarta.tck.common.version>
         <jakarta.tck.arquillian.version>11.0.0</jakarta.tck.arquillian.version>
-        <tck.version>${project.version}</tck.version>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
         <jakarta.tck.transactions.version>${tck.version}</jakarta.tck.transactions.version>
     </properties>
 

--- a/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
@@ -40,7 +40,7 @@
         <tck.test.websocket.extra.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.websocket.extra.file}</tck.test.websocket.extra.url>
         
         <tck.test.websocket.version>2.2.0</tck.test.websocket.version>
-        <tck.test.websocket.extra.version>11.0.0</tck.test.websocket.extra.version>
+        <tck.test.websocket.extra.version>11.0.1-SNAPSHOT</tck.test.websocket.extra.version>
     </properties>
 
     <build>

--- a/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-run/pom.xml
@@ -40,7 +40,7 @@
         <glassfish.root>${project.build.directory}</glassfish.root>
         <glassfish.version>8.0.0-M9</glassfish.version>
 
-        <tck.version>11.0.0</tck.version>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
         <jakarta.tck.websocket.version>2.2.0</jakarta.tck.websocket.version>
         <tck.test.websocket.extra.version>${tck.version}</tck.test.websocket.extra.version>
         


### PR DESCRIPTION
**Describe the change**
- By default use the latest 11.0.1-SNAPSHOT dist from the staged location in the glassfish runners.
