### PR TITLE
fix classpath for appclient module Platform TCK tests.

### DIFF
--- a/glassfish-runner/platform/appclient-platform-tck/appclient-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/appclient-platform-tck/appclient-platform-tck-run/pom.xml
@@ -211,20 +211,6 @@
                                     <destFileName>tck-porting-lib.jar</destFileName>
                                 </artifactItem>
                                 <artifactItem>
-                                    <groupId>jakarta.tck</groupId>
-                                    <artifactId>appclient</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${glassfish.lib.dir}</outputDirectory>
-                                    <destFileName>appclient.jar</destFileName>
-                                </artifactItem>
-                                <artifactItem>
-                                    <groupId>jakarta.tck</groupId>
-                                    <artifactId>assembly-tck</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${glassfish.lib.dir}</outputDirectory>
-                                    <destFileName>assembly-tck.jar</destFileName>
-                                </artifactItem>
-                                <artifactItem>
                                     <groupId>jakarta.tck.arquillian</groupId>
                                     <artifactId>arquillian-protocol-lib</artifactId>
                                     <overWrite>true</overWrite>

--- a/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/ejbref/scope/Client.java
+++ b/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/ejbref/scope/Client.java
@@ -110,8 +110,8 @@ public class Client extends EETest {
 
         JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "appclient_dep_ejbref_scope_ejb.jar");
         ejb.addClasses(
-                com.sun.ts.tests.appclient.deploy.ejbref.casesens.ReferencedBean.class,
-                com.sun.ts.tests.appclient.deploy.ejbref.casesens.ReferencedBeanEJB.class,
+        		com.sun.ts.tests.appclient.deploy.ejbref.scope.ReferencedBean.class,
+        		com.sun.ts.tests.appclient.deploy.ejbref.scope.ReferencedBeanEJB.class,
                 com.sun.ts.tests.assembly.util.shared.ejbref.common.ReferencedBeanCode.class,
                 com.sun.ts.tests.common.ejb.wrappers.StatelessWrapper.class
         );


### PR DESCRIPTION
fix classpath for appclient module Platform TCK tests.
Please refer issue comment https://github.com/jakartaee/platform-tck/issues/1476#issuecomment-2873863295 for details of test failures.