### PR TITLE
Exclude remaining ten Persistence failures

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientAppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientAppmanagednotxTest.java
@@ -10,6 +10,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -222,6 +223,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.en
             super.cascadeAllMXMTest3();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("appmanagedNoTx")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientStateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXmany/ClientStateless3Test.java
@@ -10,6 +10,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -223,6 +224,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.entity
             super.cascadeAllMXMTest3();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("stateless3")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientAppmanagedTest.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -201,6 +202,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             super.cascadeAllMX1Test1();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("appmanaged")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientAppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientAppmanagednotxTest.java
@@ -10,6 +10,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -207,6 +208,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.en
             super.cascadeAllMX1Test1();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("appmanagedNoTx")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientStateful3Test.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -201,6 +202,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             super.cascadeAllMX1Test1();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("stateful3")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientStateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/cascadeall/manyXone/ClientStateless3Test.java
@@ -10,6 +10,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -208,6 +209,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.entity
             super.cascadeAllMX1Test1();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("stateless3")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagedTest.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -202,6 +203,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.entity
             super.persistMX1Test1();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("appmanaged")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientAppmanagednotxTest.java
@@ -10,6 +10,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -208,6 +209,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.en
             super.persistMX1Test1();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("appmanagedNoTx")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateful3Test.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -202,6 +203,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.entityt
             super.persistMX1Test1();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("stateful3")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/entitytest/persist/manyXone/ClientStateless3Test.java
@@ -10,6 +10,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -209,6 +210,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.entity
             super.persistMX1Test1();
         }
 
+        @Disabled
         @Test
         @Override
         @TargetVehicle("stateless3")


### PR DESCRIPTION
**Fixes Issue**

https://github.com/jakartaee/platform-tck/issues/2111

**Describe the change**
Disable remaining ten tests that still fail with GlassFish 8 (+ GlassFish 7).  See comment https://github.com/jakartaee/platform-tck/issues/2111#issuecomment-2873921368

> The following tests will be marked @disabled:
> 
>     ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXmany.ClientAppmanagednotxTest.cascadeAllMXMTest4
>     ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXmany.ClientStateless3Test.cascadeAllMXMTest4
>     ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXone.ClientAppmanagedTest.cascadeAllMX1Test2
>     ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXone.ClientAppmanagednotxTest.cascadeAllMX1Test2
>     ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXone.ClientStateful3Test.cascadeAllMX1Test2
>     ee.jakarta.tck.persistence.core.entitytest.cascadeall.manyXone.ClientStateless3Test.cascadeAllMX1Test2
>     ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.ClientAppmanagedTest.persistMX1Test2
>     ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.ClientAppmanagednotxTest.persistMX1Test2
>     ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.ClientStateful3Test.persistMX1Test2
>     ee.jakarta.tck.persistence.core.entitytest.persist.manyXone.ClientStateless3Test.persistMX1Test2
> 

pmservlet + puservlet vehicles pass all of the above tests.
**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
