### PR TITLE
Update GF Arquillian container to 1.8 to support setting app name

### DIFF
--- a/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-run/pom.xml
+++ b/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-run/pom.xml
@@ -109,14 +109,12 @@
         <dependency>
             <groupId>jakarta.ejb</groupId>
             <artifactId>jakarta.ejb-api</artifactId>
-            <version>${version.jakarta.ejb}</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>${version.jakarta.enterprise}</version>
             <scope>test</scope>
             <!-- CDI references wrong version of annotations -->
             <exclusions>
@@ -129,13 +127,11 @@
         <dependency>
             <groupId>jakarta.inject</groupId>
             <artifactId>jakarta.inject-api</artifactId>
-            <version>${version.jakarta.inject}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>${version.jakarta.servlet}</version>
             <scope>test</scope>
         </dependency>
 
@@ -197,7 +193,6 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap.descriptors</groupId>
             <artifactId>shrinkwrap-descriptors-impl-base</artifactId>
-            <version>2.0.0</version>
         </dependency>
 
         <!--
@@ -206,7 +201,7 @@
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>1.7</version>
+            <version>1.8</version>
             <scope>test</scope>
         </dependency>
 
@@ -335,9 +330,8 @@
             </plugin>
 
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.5.2</version>
+                <version>3.5.3</version>
                 <configuration>
                     <includes>
                         <include>**/*Test.java</include>
@@ -390,7 +384,6 @@
     <reporting>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-report-plugin</artifactId>
                 <version>3.5.3</version>
                 <configuration>
@@ -421,7 +414,6 @@
                                     <groups>${groups}</groups>
                                     <excludes>
                                         <!-- These tests for various reasons fail -->
-                                        <exclude>com.sun.ts.tests.ejb30.assembly.initorder.warejb.ClientTest</exclude>
                                         <exclude>com.sun.ts.tests.ejb30.lite.singleton.concurrency.container.annotated.ClientEjblitejspTest</exclude>
                                         <exclude>com.sun.ts.tests.ejb30.lite.singleton.concurrency.container.annotated.ClientEjbliteservlet2Test</exclude>
                                         <exclude>com.sun.ts.tests.ejb30.lite.singleton.concurrency.container.annotated.ClientEjbliteservletTest</exclude>


### PR DESCRIPTION
Fixes #2295 

**Fixes Issue**
#2295

**Related Issue(s)**
https://github.com/eclipse-ee4j/glassfish/issues/25494

**Describe the change**
Updated the GlassFish Arquillian container plugin to 1.8. This does not (by default) set the name of the application anymore. With this change the name can now be set by application.xml.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
