### PR TITLE
Correct jsonb/p runners for appclient tests

### DIFF
--- a/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
@@ -42,9 +42,10 @@
         <glassfish.version>8.0.0-JDK17-M9</glassfish.version>
         
         <jakarta.tck.arquillian.version>11.0.8</jakarta.tck.arquillian.version>
-        <jakarta.tck.common.version>11.0.0</jakarta.tck.common.version>
+        <jakarta.tck.common.version>11.0.7</jakarta.tck.common.version>
+        <tck.artifactId>jsonb-platform-tck</tck.artifactId>
         <tck.version>11.0.1-SNAPSHOT</tck.version>
-        <ts.home>/jakartaeetck</ts.home>
+        <ts.home>./jakartaeetck</ts.home>
     </properties>
     
     <dependencyManagement>
@@ -89,7 +90,7 @@
         <!-- The actual TCK containing the tests -->
         <dependency>
             <groupId>jakarta.tck</groupId>
-            <artifactId>jsonb-platform-tck</artifactId>
+            <artifactId>${tck.artifactId}</artifactId>
             <version>${tck.version}</version>
         </dependency>
     
@@ -203,7 +204,7 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <dependenciesToScan>jakarta.tck:jsonb-platform-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
                             <groups>${javatest-testGroups}</groups>
                             <includes>
                                 <include>com/sun/ts/tests/jsonb/cdi/**/*Servlet*.java</include>
@@ -219,8 +220,8 @@
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <dependenciesToScan>jakarta.tck:jsonb-platform-tck</dependenciesToScan>
-                            <groups>tck-javatest</groups>
+                            <dependenciesToScan>jakarta.tck:${tck.artifactId}</dependenciesToScan>
+                            <groups>${javatest-testGroups}</groups>
                             <includes>
                                 <include>com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/*Servlet*.java</include>
                                 <include>com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/*Jsp*.java</include>
@@ -291,10 +292,10 @@
                                         </artifactItem>
                                         <artifactItem>
                                             <groupId>jakarta.tck</groupId>
-                                            <artifactId>jsonp-platform-tck</artifactId>
+                                            <artifactId>${tck.artifactId}</artifactId>
                                             <overWrite>true</overWrite>
                                             <outputDirectory>${project.build.directory}/lib</outputDirectory>
-                                            <destFileName>jsonp-platform-tck.jar</destFileName>
+                                            <destFileName>jsonb-platform-tck.jar</destFileName>
                                         </artifactItem>
                                         <artifactItem>
                                             <groupId>jakarta.tck.arquillian</groupId>
@@ -357,6 +358,7 @@
                                         <java.io.tmpdir>/tmp</java.io.tmpdir>
                                         <project.basedir>${project.basedir}</project.basedir>
                                         <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                                        <ts.home>${ts.home}</ts.home>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -386,6 +388,7 @@
                                         <java.io.tmpdir>/tmp</java.io.tmpdir>
                                         <project.basedir>${project.basedir}</project.basedir>
                                         <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                                        <ts.home>${ts.home}</ts.home>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>

--- a/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
@@ -42,9 +42,9 @@
         <glassfish.version>8.0.0-JDK17-M10</glassfish.version>
         
         <jakarta.tck.arquillian.version>11.0.8</jakarta.tck.arquillian.version>
-        <jakarta.tck.common.version>11.0.0</jakarta.tck.common.version>
+        <jakarta.tck.common.version>11.0.7</jakarta.tck.common.version>
         <tck.version>11.0.1-SNAPSHOT</tck.version>
-        <ts.home>/jakartaeetck</ts.home>
+        <ts.home>./jakartaeetck</ts.home>
     </properties>
 
     <dependencyManagement>
@@ -370,6 +370,7 @@
                                         <java.io.tmpdir>/tmp</java.io.tmpdir>
                                         <project.basedir>${project.basedir}</project.basedir>
                                         <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                                        <ts.home>${ts.home}</ts.home>
                                     </systemPropertyVariables>
                                 </configuration>
                             </execution>
@@ -402,6 +403,7 @@
                                         <java.io.tmpdir>/tmp</java.io.tmpdir>
                                         <project.basedir>${project.basedir}</project.basedir>
                                         <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                                        <ts.home>${ts.home}</ts.home>
                                     </systemPropertyVariables>
                                     <properties>
                                         <configurationParameters>


### PR DESCRIPTION
**Describe the change**
- The jsonp/b runners need correction to run the appclient tests. It seems the appclient tests were not run from CI. This should enable the appclient tests also to run now.
