### PR TITLE
Fix NoClassDefFoundError for org.apache.commons.lang3 classes in ejb timer tests

### DIFF
--- a/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/timer/schedule/expire/ClientEjbliteservletTest.java
+++ b/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/timer/schedule/expire/ClientEjbliteservletTest.java
@@ -78,6 +78,8 @@ public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb30.timer.sched
             // commons lang jar
             ejb30_timer_schedule_expire_ejbliteservlet_vehicle_web.addClasses(
                     org.apache.commons.lang3.StringUtils.class,
+                    org.apache.commons.lang3.stream.Streams.class,
+                    org.apache.commons.lang3.stream.LangCollectors.class,
                     org.apache.commons.lang3.time.DateUtils.class
             );
 

--- a/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejspTest.java
+++ b/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjblitejspTest.java
@@ -79,6 +79,8 @@ public class ClientEjblitejspTest extends com.sun.ts.tests.ejb32.lite.timer.sche
             // commons lang jar
             ejb32_lite_timer_schedule_expire_ejblitejsp_vehicle_web.addClasses(
                     org.apache.commons.lang3.StringUtils.class,
+                    org.apache.commons.lang3.stream.Streams.class,
+                    org.apache.commons.lang3.stream.LangCollectors.class,
                     org.apache.commons.lang3.time.DateUtils.class
             );
             // The web.xml descriptor

--- a/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservlet2Test.java
+++ b/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservlet2Test.java
@@ -80,6 +80,8 @@ public class ClientEjbliteservlet2Test extends com.sun.ts.tests.ejb32.lite.timer
             // commons lang jar
             ejb32_lite_timer_schedule_expire_ejbliteservlet2_vehicle_web.addClasses(
                     org.apache.commons.lang3.StringUtils.class,
+                    org.apache.commons.lang3.stream.Streams.class,
+                    org.apache.commons.lang3.stream.LangCollectors.class,
                     org.apache.commons.lang3.time.DateUtils.class
             );
             // The web.xml descriptor

--- a/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservletTest.java
+++ b/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/ClientEjbliteservletTest.java
@@ -80,6 +80,8 @@ public class ClientEjbliteservletTest extends com.sun.ts.tests.ejb32.lite.timer.
             // commons lang jar
             ejb32_lite_timer_schedule_expire_ejbliteservlet_vehicle_web.addClasses(
                     org.apache.commons.lang3.StringUtils.class,
+                    org.apache.commons.lang3.stream.Streams.class,
+                    org.apache.commons.lang3.stream.LangCollectors.class,
                     org.apache.commons.lang3.time.DateUtils.class
             );
             // The web.xml descriptor

--- a/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejsfTest.java
+++ b/tcks/apis/enterprise-beans/ejb32/src/main/java/com/sun/ts/tests/ejb32/lite/timer/schedule/expire/JsfClientEjblitejsfTest.java
@@ -79,6 +79,8 @@ public class JsfClientEjblitejsfTest extends com.sun.ts.tests.ejb32.lite.timer.s
             // commons lang jar
             ejb32_lite_timer_schedule_expire_ejblitejsf_vehicle_web.addClasses(
                     org.apache.commons.lang3.StringUtils.class,
+                    org.apache.commons.lang3.stream.Streams.class,
+                    org.apache.commons.lang3.stream.LangCollectors.class,
                     org.apache.commons.lang3.time.DateUtils.class
             );
             // The web.xml descriptor


### PR DESCRIPTION
**Describe the change**
- Add missing classes causing java.lang.NoClassDefFoundError for EJB30/EJB32 timer tests.

**Additional context**
- Comment : https://github.com/jakartaee/platform-tck/issues/2281#issuecomment-2889973835 reports the test failures in 3 & 4.
- Related PR https://github.com/jakartaee/platform-tck/pull/2315


