### PR TITLE
connector javatest: copy arquillian-protocol-lib

### DIFF
--- a/glassfish-runner/connector-platform-tck/pom.xml
+++ b/glassfish-runner/connector-platform-tck/pom.xml
@@ -159,6 +159,19 @@
                                     <outputDirectory>${glassfish.lib.dir}</outputDirectory>
                                     <destFileName>arquillian-protocol-lib.jar</destFileName>
                                 </artifactItem>
+                                <!-- 
+                                    AppClientDeploymentPackager & JavaTestDeploymentPackager needs this on the Eclipse CI since 
+                                    it can't fully resolve jakarta.tck.arquillian:arquillian-protocol-lib in code for some reason.
+                                -->
+                                <artifactItem>
+                                    <groupId>jakarta.tck.arquillian</groupId>
+                                    <artifactId>arquillian-protocol-lib</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/protocol</outputDirectory>
+                                    <destFileName>protocol.jar</destFileName>
+                                </artifactItem>
+
                             </artifactItems>
                         </configuration>
                     </execution>
@@ -433,19 +446,6 @@
                                             <destFileName>arquillian-protocol-lib.jar</destFileName>
                                         </artifactItem>
 
-                                        <!-- 
-                                            AppClientDeploymentPackager needs this on the Eclipse CI since it can't fully resolve
-                                            jakarta.tck.arquillian:arquillian-protocol-lib in code for some reason.
-                                        -->
-                                        <artifactItem>
-                                            <groupId>jakarta.tck.arquillian</groupId>
-                                            <artifactId>arquillian-protocol-lib</artifactId>
-                                            <!-- <version>${jakarta.tck.arquillian.version}</version> -->
-                                            <type>jar</type>
-                                            <overWrite>true</overWrite>
-                                            <outputDirectory>${project.build.directory}/protocol</outputDirectory>
-                                            <destFileName>protocol.jar</destFileName>
-                                        </artifactItem>
                                     </artifactItems>
                                 </configuration>
                             </execution>


### PR DESCRIPTION
**Describe the change**
- The arquillian-protocol-lib is required to be copied to resolve errors in javatests when using 11.0.1-M4 version of the TCK to avoid errors like below

>     Failed to resolve protocol.jar. You either need a jakarta.tck.arquillian:arquillian-protocol-lib dependency in the runner pom.xml or a downloaded target/protocol/protocol.jar file.
>     The runner pom needs to be pom.xml or the path needs to be set by the system property tck.arquillian.protocol.runnerPom

**Additional context**
- Connector test failures reported in https://github.com/jakartaee/platform-tck/issues/2281#issuecomment-2889973835 
- Jenkins job with failures : https://ci.eclipse.org/jakartaee-tck/job/11/job/tck/job/jakarta-connector-tck-glassfish/43/ 
