### PR TITLE
Defend against intermittent EJB failures

### DIFF
--- a/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/common/lite/EJBLiteClientBase.java
+++ b/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/common/lite/EJBLiteClientBase.java
@@ -22,6 +22,8 @@ package com.sun.ts.tests.ejb30.common.lite;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -375,6 +377,9 @@ public class EJBLiteClientBase extends ServiceEETest
 
   protected void appendReason(Object... oo) {
     for (Object o : oo) {
+      if (o instanceof Collection<?>) {
+        o = new ArrayList<>((Collection<?>) o); // Copy to prevent ConcurrentModificationException
+      }
       getReasonBuffer().append(o).append(System.getProperty("line.separator"));
     }
   }

--- a/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/common/lite/EJBLiteJsfClientBase.java
+++ b/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/common/lite/EJBLiteJsfClientBase.java
@@ -19,6 +19,8 @@ package com.sun.ts.tests.ejb30.common.lite;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -379,6 +381,9 @@ public class EJBLiteJsfClientBase extends ServiceEETest
 
   protected void appendReason(Object... oo) {
     for (Object o : oo) {
+      if (o instanceof Collection<?>) {
+        o = new ArrayList<>((Collection<?>) o); // Copy to prevent ConcurrentModificationException
+      }
       getReasonBuffer().append(o).append(System.getProperty("line.separator"));
     }
   }

--- a/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/timer/common/TimerUtil.java
+++ b/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/timer/common/TimerUtil.java
@@ -273,7 +273,7 @@ public final class TimerUtil {
 
   public static Timer createSecondLaterTimer(TimerService timerService,
       TimerConfig timerConfig) {
-    return createSecondLaterTimer(timerService, timerConfig, 1);
+    return createSecondLaterTimer(timerService, timerConfig, 2);
   }
 
   public static Timer createSecondLaterTimer(TimerService timerService,
@@ -286,7 +286,7 @@ public final class TimerUtil {
 
   public static Timer createSecondLaterTimer(TimerService timerService,
       TimerInfo info) {
-    return createSecondLaterTimer(timerService, info, 1);
+    return createSecondLaterTimer(timerService, info, 2);
   }
 
   public static Timer createSecondLaterTimer(TimerService timerService,


### PR DESCRIPTION
1) Timer tests using 1-second timers will sometimes fail with 'Timer does not exist' failures. We've had bugs opened in the past for these, and the solution there has been to bump these timers to use a 2 second duration so they don't expire before the test is able to perform its necessary test logic. This updates a couple cases that have been missed.

2) Make local copy of Collections to avoid ConcurrentModificationException
e.g.
java.util.ConcurrentModificationException
	at java.base/java.util.ArrayList$Itr.checkForComodification(ArrayList.java:1013)
	at java.base/java.util.ArrayList$Itr.next(ArrayList.java:967)
	at java.base/java.util.AbstractCollection.toString(AbstractCollection.java:456)
	at java.base/java.util.Collections$UnmodifiableCollection.toString(Collections.java:1047)
	at java.base/java.lang.String.valueOf(String.java:4992)
	at java.base/java.lang.StringBuilder.append(StringBuilder.java:173)
	at com.sun.ts.tests.ejb30.common.lite.EJBLiteJsfClientBase.appendReason(EJBLiteJsfClientBase.java:382)
        ...

Both changes have been tested against Open Liberty and have been deemed non-disruptive.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow