### PR TITLE
Update jpa runner dependencies and appclient config

### DIFF
--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
@@ -438,9 +438,9 @@
                                 <configuration>
                                     <includes>
                                         <!--
-                                        <include>ee/jakarta/tck/persistence/**/*Test.java</include>
-                                        -->
                                         <include>ee.jakarta.tck.persistence.ee.packaging.appclient.annotation.ClientTest</include>
+                                        -->
+                                        <include>ee/jakarta/tck/persistence/**/*Test.java</include>
                                     </includes>
                                     <!-- Should this not just be tck-appclient ? -->
                                     <groups>${includeGroups}</groups>

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
@@ -42,9 +42,9 @@
         <glassfish.version>8.0.0-JDK17-M10</glassfish.version>
         <jakarta.platform.version>11.0.0-RC1</jakarta.platform.version>
 
-        <jakarta.tck.arquillian.version>11.0.8</jakarta.tck.arquillian.version>
-        <jakarta.tck.common.version>11.0.2</jakarta.tck.common.version>
-        <tck.test.persistence.version>11.0.0</tck.test.persistence.version>
+        <jakarta.tck.arquillian.version>11.0.10</jakarta.tck.arquillian.version>
+        <jakarta.tck.common.version>11.0.8</jakarta.tck.common.version>
+        <tck.test.persistence.version>11.0.1-M5</tck.test.persistence.version>
         
         <ts.home>./jakartaeetck</ts.home>
     </properties>
@@ -437,7 +437,10 @@
                                 </goals>
                                 <configuration>
                                     <includes>
+                                        <!--
                                         <include>ee/jakarta/tck/persistence/**/*Test.java</include>
+                                        -->
+                                        <include>ee.jakarta.tck.persistence.ee.packaging.appclient.annotation.ClientTest</include>
                                     </includes>
                                     <!-- Should this not just be tck-appclient ? -->
                                     <groups>${includeGroups}</groups>

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/src/test/resources/appclient-arquillian.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/src/test/resources/appclient-arquillian.xml
@@ -12,7 +12,58 @@
   </extension>
 
   <group qualifier="glassfish-servers" default="true">
-    <container qualifier="tck-appclient" default="true">
+
+      <container qualifier="tck-appclient" default="true">
+          <configuration>
+              <property name="allowConnectingToRunningServer">false</property>
+              <property name="debug">false</property>
+              <property name="suspend">false</property>
+          </configuration>
+
+          <protocol type="appclient">
+              <property name="runClient">true</property>
+              <property name="runAsVehicle">true</property>
+              <property name="clientEarDir">target/appclient</property>
+              <property name="unpackClientEar">true</property>
+              <!-- Need to populate from ts.jte command.testExecuteAppClient setting for glassfish -->
+              <property name="clientCmdLineString">${env.JAVA_HOME}/bin/java \
+                  --add-opens \
+                  java.base/java.lang=ALL-UNNAMED \
+                  -cp \
+                  ${glassfish.home}/glassfish/lib/gf-client.jar:${clientStubJar} \
+                  -Djava.system.class.loader=org.glassfish.appclient.client.acc.agent.ACCAgentClassLoader \
+                  -Dcom.sun.aas.configRoot=${glassfish.home}/glassfish/config \
+                  -Dcts.tmp=${ts.home}/tmp \
+                  -Doracle.jdbc.J2EE13Compliant=true \
+                  -Doracle.jdbc.mapDateToTimestamp \
+                  -Dlog.file.location=${glassfish.home}/glassfish/domains/domain1/logs \
+                  -Dri.log.file.location=${glassfish.home}/glassfish/domains/domain1/logs \
+                  -DwebServerHost.2=localhost \
+                  -DwebServerPort.2=8080 \
+                  -javaagent:${glassfish.home}/glassfish/lib/gf-client.jar=arg=-configxml,arg=${glassfish.home}/glassfish/domains/domain1/config/glassfish-acc.xml,client=jar=${clientStubJar},arg=-name,arg=${clientAppArchiveName} \
+                  org.glassfish.appclient.client.AppClientGroupFacade
+              </property>
+              <property name="cmdLineArgSeparator">\\</property>
+              <!-- Pass ENV vars here -->
+              <property name="clientEnvString">PATH=${env.PATH};LD_LIBRARY_PATH=${glassfish.home}/lib;AS_DEBUG=true;
+                  APPCPATH=${clientEarLibClasspath}:${glassfish.home}/glassfish/modules/security.jar</property>
+              <property name="clientDir">${project.basedir}</property>
+              <property name="clientStubsCmdLine">${glassfish.home}/glassfish/bin/asadmin \
+                  get-client-stubs \
+                  --appName \
+                  ${deploymentName} \
+                  target
+              </property>
+              <property name="clientStubsJarSuffix">Client</property>
+              <property name="workDir">${ts.home}/tmp</property>
+              <property name="tsJteFile">jakartaeetck/bin/ts.jte</property>
+              <property name="tsSqlStmtFile">sql/derby/derby.dml.sql</property>
+              <property name="trace">true</property>
+              <property name="clientTimeout">20000</property>
+          </protocol>
+      </container>
+
+      <container qualifier="tck-appclient-old">
         <configuration>
             <property name="glassFishHome">target/glassfish8</property>
             <property name="allowConnectingToRunningServer">true</property>


### PR DESCRIPTION
With this I see the `ee.jakarta.tck.persistence.ee.packaging.appclient.annotation.ClientTest` passing:

```bash
starksm@Scotts-Mac-Studio persistence-platform-tck-run % mvn -Pstaging test-compile failsafe:integration-test@jpa-tests-appclient
...
May 19, 2025 11:45:35 PM org.eclipse.persistence.session./file:/Users/starksm/Dev/Jakarta/platform-tck/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/target/jpa_ee_packaging_appclient_annotationClient/jpa_ee_packaging_appclient_annotation_client.jar_CTS-APPCLIENT-ANNOTATED
INFO: EclipseLink, version: Eclipse Persistence Services - 5.0.0-B03.v202409121024-4a7149f0cd04d7466837d70f68abb743c88acb83
STATUS:Passed.
May 19, 2025 11:45:36 PM tck.arquillian.protocol.appclient.DeploymentMonitorProvider onDeployment
INFO: Deployment event observed: org.jboss.arquillian.container.spi.client.deployment.Deployment@2cc61b3b, currentMonitor: DeploymentMonitor{name='jpa_ee_packaging_appclient_annotation', status=NEEDS_STUBS}
May 19, 2025 11:45:36 PM tck.arquillian.protocol.appclient.DeploymentMonitor dispose
INFO: jpa_ee_packaging_appclient_annotation, disposed
May 19, 2025 11:45:36 PM tck.arquillian.protocol.appclient.DeploymentMonitor <init>
INFO: jpa_ee_packaging_appclient_annotation, deployed
May 19, 2025 11:45:36 PM tck.arquillian.protocol.appclient.DeploymentMonitorProvider onUndeployment
INFO: Undeployment event observed: org.jboss.arquillian.container.spi.client.deployment.Deployment@2cc61b3b, currentMonitor: DeploymentMonitor{name='jpa_ee_packaging_appclient_annotation', status=NEEDS_STUBS}
May 19, 2025 11:45:36 PM tck.arquillian.protocol.appclient.DeploymentMonitor undeploy
INFO: jpa_ee_packaging_appclient_annotation, undeployed
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 17.67 s -- in ee.jakarta.tck.persistence.ee.packaging.appclient.annotation.ClientTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  23.895 s
[INFO] Finished at: 2025-05-19T23:45:38-06:00
[INFO] ------------------------------------------------------------------------
```

