### PR TITLE
signature runner : install tck, specify versions

### DIFF
--- a/glassfish-runner/signature/platform_pom.xml
+++ b/glassfish-runner/signature/platform_pom.xml
@@ -47,9 +47,10 @@
         <!-- Note that currently, this must have src as the first directory as it is hard-coded in the test -->
         <signature.file.dir>${base.tck.dir}/src</signature.file.dir>
         
-        <jakarta.tck.arquillian.version>11.0.7</jakarta.tck.arquillian.version>
-        <version.jakarta.tck>11.0.1-SNAPSHOT</version.jakarta.tck>
+        <jakarta.tck.arquillian.version>11.0.9</jakarta.tck.arquillian.version>
         <version.jakarta.tck.sigtest-maven-plugin>2.6</version.jakarta.tck.sigtest-maven-plugin>
+        <tck.version>11.0.1-SNAPSHOT</tck.version>
+        <tck.signaturetest.version>11.0.0</tck.signaturetest.version>
     </properties>
     
     <!-- Import the tck relevant boms -->
@@ -65,7 +66,7 @@
             <dependency>
                 <groupId>jakarta.tck</groupId>
                 <artifactId>artifacts-bom</artifactId>
-                <version>${version.jakarta.tck}</version>
+                <version>${tck.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -77,11 +78,13 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>signaturevalidation</artifactId>
+            <version>${tck.version}</version>
         </dependency>
 
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>signaturetest</artifactId>
+            <version>${tck.signaturetest.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>
@@ -94,20 +97,24 @@
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-javatest</artifactId>
+            <version>${jakarta.tck.arquillian.version}</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>arquillian-protocol-appclient</artifactId>
+            <version>${jakarta.tck.arquillian.version}</version>
         </dependency>
 
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
             <artifactId>tck-porting-lib</artifactId>
+            <version>${jakarta.tck.arquillian.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.jboss.arquillian.junit5</groupId>
             <artifactId>arquillian-junit5-container</artifactId>
+            <version>1.9.4.Final</version>
         </dependency>
         <dependency>
             <groupId>org.omnifaces.arquillian</groupId>
@@ -118,6 +125,7 @@
         <dependency>
             <groupId>org.jboss.shrinkwrap</groupId>
             <artifactId>shrinkwrap-api</artifactId>
+            <version>1.2.6</version>
         </dependency>
 
     </dependencies>
@@ -179,7 +187,7 @@
                                 <artifactItem>
                                     <groupId>jakarta.tck</groupId>
                                     <artifactId>signaturevalidation</artifactId>
-                                    <version>${version.jakarta.tck}</version>
+                                    <version>${tck.version}</version>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${base.tck.dir}</outputDirectory>
                                     <includes>**/sig-test.map,**/sig-test-pkg-list.txt</includes>
@@ -187,7 +195,7 @@
                                 <artifactItem>
                                     <groupId>jakarta.tck</groupId>
                                     <artifactId>signaturevalidation</artifactId>
-                                    <version>${version.jakarta.tck}</version>
+                                    <version>${tck.version}</version>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>${signature.file.dir}</outputDirectory>
                                     <includes>**/*.sig</includes>
@@ -284,4 +292,29 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>full</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
+                <testGroups>platform</testGroups>
+                <tck.profile>${testGroups}</tck.profile>
+                <javaee.level>platform</javaee.level>
+            </properties>
+        </profile>
+        <profile>
+            <id>web</id>
+            <properties>
+                <glassfish-artifact-id>web</glassfish-artifact-id>
+                <testGroups>web</testGroups>
+                <tck.profile>${testGroups}</tck.profile>
+                <javaee.level>web</javaee.level>
+                <optional.tech.packages.to.ignore>jakarta.resource,jakarta.resource.cci,jakarta.resource.spi,jakarta.resource.spi.work,jakarta.resource.spi.endpoint,jakarta.resource.spi.security,jakarta.mail,jakarta.mail.event,jakarta.mail,jakarta.mail.event,jakarta.mail.internet,jakarta.mail.search,jakarta.mail.util,jakarta.security.jacc,jakarta.security.auth.message,jakarta.security.auth.message.callback,jakarta.security.auth.message.config,jakarta.security.auth.message.module</optional.tech.packages.to.ignore>
+            </properties>
+        </profile>
+    </profiles>
 </project>

--- a/glassfish-runner/signature/pom-install.xml
+++ b/glassfish-runner/signature/pom-install.xml
@@ -1,0 +1,102 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright (c) 2025 Contributors to the Eclipse Foundation.
+
+    This program and the accompanying materials are made available under the
+    terms of the Eclipse Public License v. 2.0, which is available at
+    http://www.eclipse.org/legal/epl-2.0.
+
+    This Source Code may also be made available under the following Secondary
+    Licenses when the conditions for such availability set forth in the
+    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
+    version 2 with the GNU Classpath Exception, which is available at
+    https://www.gnu.org/software/classpath/license.html.
+
+    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>1.0.9</version>
+        <relativePath />
+    </parent>
+
+    <groupId>jakarta.tck</groupId>
+    <artifactId>signature-tck-install</artifactId>
+    <version>11.0.1</version>
+    <packaging>pom</packaging>
+    <name>TCK: Install Jakarta Signature Platform TCK</name>
+
+    <properties>
+        <tck.test.signature.platform.file>jakartaeetck-${tck.test.signaturevalidation.version}-dist.zip</tck.test.signature.platform.file>
+        <tck.test.signature.platform.url>https://download.eclipse.org/ee4j/jakartaee-tck/jakartaee11/staged/eftl/${tck.test.signature.platform.file}</tck.test.signature.platform.url>
+        <tck.test.signaturevalidation.version>11.0.1-M4</tck.test.signaturevalidation.version>
+        <tck.test.signature.version>11.0.0</tck.test.signature.version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <version>1.13.0</version>
+                <configuration>
+                    <url>${tck.test.signature.platform.url}</url>
+                    <unpack>true</unpack>
+                    <outputDirectory>${project.build.directory}</outputDirectory>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>download-signaturevalidation-tck</id>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            
+            <plugin>
+                <artifactId>maven-install-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>install-signaturetest-jar</id>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <file>${project.build.directory}/jakartaeetck/artifacts/signaturetest-${tck.test.signature.version}.jar</file>
+                            <groupId>jakarta.tck</groupId>
+                            <artifactId>signaturetest</artifactId>
+                            <version>${tck.test.signature.version}</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>install-signaturevalidation-tck-jar</id>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <file>${project.build.directory}/jakartaeetck/artifacts/signaturevalidation-${tck.test.signaturevalidation.version}.jar</file>
+                            <groupId>jakarta.tck</groupId>
+                            <artifactId>signaturevalidation</artifactId>
+                            <version>${tck.test.signaturevalidation.version}</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
+
+                </executions>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>


### PR DESCRIPTION
**Describe the change**

Signature TCK Runner
- Use pom-install.xml to download and install the tck jars from staged location 
`mvn clean install  -f pom-install.xml -Dtck.test.signaturevalidation.version=11.0.1-M4 `
- Specify the missing tck versions in platform_pom.xml to avoid errors when running milestone/specified versions of TCK.



