### PR TITLE
signature test : remove maven resolver

### DIFF
--- a/glassfish-runner/signature/platform_pom.xml
+++ b/glassfish-runner/signature/platform_pom.xml
@@ -175,7 +175,34 @@
                             </artifactItems>
                         </configuration>
                     </execution>
-                    
+
+                    <execution>
+                        <id>002-copy-lib</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>process-test-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>signaturetest</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                                    <destFileName>signaturetest.jar</destFileName>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>sigtest-maven-plugin</artifactId>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}/lib</outputDirectory>
+                                    <destFileName>sigtest-maven-plugin.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
                     <execution>
                         <id>extract-sigtest-files</id>
                         <phase>process-test-resources</phase>

--- a/glassfish-runner/signature/src/main/java/org/glassfish/signature/tck/GlassfishLoadableExtension.java
+++ b/glassfish-runner/signature/src/main/java/org/glassfish/signature/tck/GlassfishLoadableExtension.java
@@ -14,7 +14,7 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.messaging.tck;
+package org.glassfish.signature.tck;
 
 import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;

--- a/glassfish-runner/signature/src/main/java/org/glassfish/signature/tck/GlassfishTestArchiveProcessor.java
+++ b/glassfish-runner/signature/src/main/java/org/glassfish/signature/tck/GlassfishTestArchiveProcessor.java
@@ -14,10 +14,11 @@
  * SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
  */
 
-package org.glassfish.messaging.tck;
+package org.glassfish.signature.tck;
 
 import java.net.URL;
 import java.util.logging.Logger;
+import java.io.File;
 
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.core.api.annotation.Observes;
@@ -26,6 +27,10 @@ import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 
 import tck.arquillian.porting.lib.spi.AbstractTestArchiveProcessor;
+
+import org.jboss.arquillian.container.test.spi.client.deployment.ApplicationArchiveProcessor;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.shrinkwrap.api.Archive;
 
 public class GlassfishTestArchiveProcessor extends AbstractTestArchiveProcessor {
 
@@ -45,8 +50,12 @@ public class GlassfishTestArchiveProcessor extends AbstractTestArchiveProcessor 
     }
 
     @Override
-    public void processWebArchive(WebArchive webArchive, Class<?> testClass, URL sunXmlURL) {
-        String name = webArchive.getName();
+    public void processWebArchive(WebArchive archive, Class<?> testClass, URL sunXmlURL) {
+        String name = archive.getName();
+        WebArchive webArchive = (WebArchive) archive;;
+        webArchive.addAsLibrary(new File("target/lib", "sigtest-maven-plugin.jar"), "sigtest-maven-plugin.jar");
+        webArchive.addAsLibrary(new File("target/lib", "signaturetest.jar"), "signaturetest.jar");
+
     }
 
     @Override
@@ -62,6 +71,10 @@ public class GlassfishTestArchiveProcessor extends AbstractTestArchiveProcessor 
     @Override
     public void processEarArchive(EnterpriseArchive earArchive, Class<?> testClass, URL sunXmlURL) {
         String name = earArchive.getName();
+        EnterpriseArchive ear = (EnterpriseArchive) earArchive;
+        ear.addAsLibrary(new File("target/lib", "sigtest-maven-plugin.jar"), "sigtest-maven-plugin.jar");
+        ear.addAsLibrary(new File("target/lib", "signaturetest.jar"), "signaturetest.jar");
+
     }
 
     @Override

--- a/glassfish-runner/signature/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/glassfish-runner/signature/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,1 +1,1 @@
-org.glassfish.messaging.tck.GlassfishLoadableExtension
+org.glassfish.signature.tck.GlassfishLoadableExtension

--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureAppClientTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureAppClientTest.java
@@ -34,7 +34,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -110,20 +109,10 @@ public class ClientSignatureAppClientTest extends JakartaEESigTest implements Se
             } else {
                 throw new IllegalStateException("missing " + signatureMapFile);
             }
-            // add jakarta.tck:sigtest-maven-plugin jar to the war
-            // Import Maven runtime dependencies
-            String profiles = System.getProperty("active.profiles", "");
-            String[] activeMavenProfiles = !profiles.isEmpty() ? profiles.split(",") : new String[]{};
-            File[] files = Maven.resolver()
-                    .loadPomFromFile("pom.xml", activeMavenProfiles)
-                    .resolve("jakarta.tck:sigtest-maven-plugin", "jakarta.tck:signaturetest")
-                    .withoutTransitivity()
-                    .asFile();
-
-            // add signature test artifacts
-            ear.addAsLibraries(files);
         }
         ear.addAsModule(archive);
+        archiveProcessor.processEarArchive(ear, ClientSignatureAppClientTest.class, appClientUrl);
+
         return ear;
     }
 

--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureEJBTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureEJBTest.java
@@ -33,7 +33,6 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -154,19 +153,6 @@ public class ClientSignatureEJBTest extends JakartaEESigTest implements Serializ
             }
 
         }
-
-
-        // add jakarta.tck:sigtest-maven-plugin jar to the war
-        // Import Maven runtime dependencies
-        String profiles = System.getProperty("active.profiles", "");
-        String[] activeMavenProfiles = !profiles.isEmpty() ? profiles.split(",") : new String[] {};
-        File[] files = Maven.resolver()
-                .loadPomFromFile("pom.xml", activeMavenProfiles)
-                .resolve("jakarta.tck:sigtest-maven-plugin", "jakarta.tck:signaturetest")
-                .withoutTransitivity()
-                .asFile();
-        // add signature test artifacts
-        signaturetest_servlet_vehicle_web.addAsLibraries(files);
 
         // Call the archive processor
         archiveProcessor.processWebArchive(signaturetest_servlet_vehicle_web, ClientSignatureEJBTest.class, warResURL);

--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureJspTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureJspTest.java
@@ -34,7 +34,6 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.ByteArrayAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -168,19 +167,6 @@ public class ClientSignatureJspTest extends JakartaEESigTest implements Serializ
             }
 
         }
-
-
-        // add jakarta.tck:sigtest-maven-plugin jar to the war
-        // Import Maven runtime dependencies
-        String profiles = System.getProperty("active.profiles", "");
-        String[] activeMavenProfiles = !profiles.isEmpty() ? profiles.split(",") : new String[] {};
-        File[] files = Maven.resolver()
-                .loadPomFromFile("pom.xml", activeMavenProfiles)
-                .resolve("jakarta.tck:sigtest-maven-plugin", "jakarta.tck:signaturetest")
-                .withoutTransitivity()
-                .asFile();
-        // add signature test artifacts
-        signaturetest_jsp_vehicle_web.addAsLibraries(files);
 
         // Call the archive processor
         archiveProcessor.processWebArchive(signaturetest_jsp_vehicle_web, ClientSignatureJspTest.class, warResURL);

--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureServletTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureServletTest.java
@@ -32,7 +32,6 @@ import org.jboss.arquillian.junit5.ArquillianExtension;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
-import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -154,19 +153,6 @@ public class ClientSignatureServletTest extends JakartaEESigTest implements Seri
             }
 
         }
-
-
-        // add jakarta.tck:sigtest-maven-plugin jar to the war
-        // Import Maven runtime dependencies
-        String profiles = System.getProperty("active.profiles", "");
-        String[] activeMavenProfiles = !profiles.isEmpty() ? profiles.split(",") : new String[] {};
-        File[] files = Maven.resolver()
-                .loadPomFromFile("pom.xml", activeMavenProfiles)
-                .resolve("jakarta.tck:sigtest-maven-plugin", "jakarta.tck:signaturetest")
-                .withoutTransitivity()
-                .asFile();
-        // add signature test artifacts
-        signaturetest_servlet_vehicle_web.addAsLibraries(files);
 
         // Call the archive processor
         archiveProcessor.processWebArchive(signaturetest_servlet_vehicle_web, ClientSignatureServletTest.class, warResURL);


### PR DESCRIPTION
**Describe the change**
- The usage of maven resolver api in the test sources is removed. 
- The required jars are added to the deployables via TestArchiveProcessor in runner.
- The tests are failing due to missing jakarta.data package as per latest status (tracked via https://github.com/jakartaee/platform-tck/issues/2260). 

**Additional context**
Due to the usage of maven resolver api in the tests, the properties specified in the runner pom.xml cannot be overriden via mvn command and the test will parse glassfish-runner/signature/pom.xml instead of platform_pom.xml. 
Similar PR for ejb tests : https://github.com/jakartaee/platform-tck/pull/2315


