### PR TITLE
Exclude 18 failing ee.jakarta.tck.persistence.ee.pluggability.contracts.jta.ClientAppmanagedTest tests

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/pluggability/contracts/jta/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/pluggability/contracts/jta/ClientAppmanagedTest.java
@@ -9,6 +9,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -23,6 +24,7 @@ import java.net.URL;
 @Tag("platform")
 @Tag("tck-appclient")
 
+@Disabled("https://github.com/jakartaee/platform-tck/issues/2338")
 public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.ee.pluggability.contracts.jta.Client {
     static final String VEHICLE_ARCHIVE = "jpa_ee_pluggability_contracts_jta_appmanaged_vehicle";
 


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2338

**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/2334

**Describe the change**
Add @org.junit.jupiter.api.Disabled to the ee.jakarta.tck.persistence.ee.pluggability.contracts.jta.ClientAppmanagedTest  class to disable the contained 18 tests.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
