### PR TITLE
Remove check for Jakarta Data in Application Client signature test

### DIFF
--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureAppClientTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/ClientSignatureAppClientTest.java
@@ -77,7 +77,6 @@ public class ClientSignatureAppClientTest extends JakartaEESigTest implements Se
         String[] signatureMapFiles = {
                 "jakarta.annotation.sig",
                 "jakarta.batch.sig",
-                "jakarta.data.sig",
                 "jakarta.ejb.sig",
                 "jakarta.el.sig",
                 "jakarta.enterprise.concurrent.sig",


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2340

**Describe the change**
As per https://jakarta.ee/specifications/platform/11/jakarta-platform-spec-11.0-m5#a2339, remove the validation of Jakarta Data Spec API in Application Client signature validation


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
