### PR TITLE
mail: add ServiceEETest, EETest classes to client

### DIFF
--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileAppClient_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileAppClient_Test.java
@@ -51,7 +51,8 @@ public class fetchprofileAppClient_Test extends fetchprofile_Test implements Ser
 		appclientArchive.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
 		appclientArchive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		appclientArchive.addPackages(true, "com.sun.ts.lib.harness");
-		appclientArchive.addClasses(fetchprofile_Test.class);
+		appclientArchive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		appclientArchive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		// The appclient-client descriptor
 		URL appClientUrl = fetchprofileAppClient_Test.class
 				.getResource("/com/sun/ts/tests/javamail/ee/fetchprofile/appclient_vehicle_client.xml");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileEJB_Test.java
@@ -50,6 +50,8 @@ public class fetchprofileEJB_Test extends fetchprofile_Test implements Serializa
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
 		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejbClient.addClass(com.sun.ts.tests.common.base.EETest.class);
+		ejbClient.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		ejbClient.addClasses(fetchprofileEJB_Test.class, fetchprofile_Test.class);
 
 		URL resURL = fetchprofileEJB_Test.class

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/getMessageContent/getMessageContentAppClient_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/getMessageContent/getMessageContentAppClient_Test.java
@@ -47,6 +47,9 @@ public class getMessageContentAppClient_Test extends getMessageContent_Test {
 		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+    archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
+
 		archive.addClasses(getMessageContentAppClient_Test.class, getMessageContent_Test.class);
 		
         // The appclient-client descriptor

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartAppClient_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartAppClient_Test.java
@@ -48,6 +48,8 @@ public class internetMimeMultipartAppClient_Test extends internetMimeMultipart_T
 		archive.addPackages(true, "com.sun.ts.tests.javamail.ee");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(internetMimeMultipartAppClient_Test.class, internetMimeMultipart_Test.class);
 		archive.addAsManifestResource(
 				new StringAsset("Main-Class: " + "com.sun.ts.tests.common.vehicle.VehicleClient" + "\n"),

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartEJB_Test.java
@@ -47,6 +47,8 @@ public class internetMimeMultipartEJB_Test extends internetMimeMultipart_Test {
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
+		ejbClient.addClass(com.sun.ts.tests.common.base.EETest.class);
+		ejbClient.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		ejbClient.addClasses(internetMimeMultipartEJB_Test.class, internetMimeMultipart_Test.class);
 
 		URL resURL = internetMimeMultipartEJB_Test.class.getResource("/com/sun/ts/tests/common/vehicle/ejb/ejb_vehicle_client.xml");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressAppClient_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressAppClient_Test.java
@@ -52,6 +52,8 @@ public class internetaddressAppClient_Test extends internetaddress_Test
 		archive.addPackages(false, "com.sun.ts.tests.javamail.ee.common");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(internetaddressAppClient_Test.class, internetaddress_Test.class);
 		
 		archive.addAsManifestResource(

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressEJB_Test.java
@@ -55,6 +55,8 @@ public class internetaddressEJB_Test extends internetaddress_Test
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
+		ejbClient.addClass(com.sun.ts.tests.common.base.EETest.class);
+		ejbClient.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		ejbClient.addClasses(internetaddressEJB_Test.class, internetaddress_Test.class);
 
 		URL resURL = internetaddressEJB_Test.class

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageAppClient_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageAppClient_Test.java
@@ -51,6 +51,8 @@ public class mimemessageAppClient_Test extends mimemessage_Test implements Seria
 		archive.addPackages(true, "com.sun.ts.tests.javamail.ee");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(mimemessageAppClient_Test.class, mimemessage_Test.class);
 		
 		archive.addAsManifestResource(

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageEJB_Test.java
@@ -52,6 +52,8 @@ public class mimemessageEJB_Test extends mimemessage_Test implements Serializabl
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
+		ejbClient.addClass(com.sun.ts.tests.common.base.EETest.class);
+		ejbClient.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		ejbClient.addClasses(mimemessageEJB_Test.class, mimemessage_Test.class);
 
 		URL resURL = mimemessageEJB_Test.class.getResource("/com/sun/ts/tests/common/vehicle/ejb/ejb_vehicle_client.xml");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartAppClient_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartAppClient_Test.java
@@ -52,6 +52,8 @@ public class multipartAppClient_Test extends multipart_Test implements Serializa
 		archive.addPackages(false, "com.sun.ts.tests.javamail.ee.common");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(multipartAppClient_Test.class, multipart_Test.class);
 		
 		archive.addAsManifestResource(

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartEJB_Test.java
@@ -52,6 +52,8 @@ public class multipartEJB_Test extends multipart_Test implements Serializable {
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
+		ejbClient.addClass(com.sun.ts.tests.common.base.EETest.class);
+		ejbClient.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		ejbClient.addClasses(multipartEJB_Test.class, multipart_Test.class);
 
 		URL resURL = multipartEJB_Test.class.getResource("/com/sun/ts/tests/common/vehicle/ejb/ejb_vehicle_client.xml");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendAppClient_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendAppClient_Test.java
@@ -52,6 +52,8 @@ public class sendAppClient_Test extends send_Test implements Serializable {
 		archive.addPackages(false, "com.sun.ts.tests.javamail.ee.common");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(sendAppClient_Test.class, send_Test.class);
 		
 		archive.addAsManifestResource(

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendEJB_Test.java
@@ -52,6 +52,8 @@ public class sendEJB_Test extends send_Test implements Serializable {
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
+		ejbClient.addClass(com.sun.ts.tests.common.base.EETest.class);
+		ejbClient.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		ejbClient.addClasses(sendEJB_Test.class, send_Test.class);
 
 		URL resURL = sendEJB_Test.class.getResource("/com/sun/ts/tests/common/vehicle/ejb/ejb_vehicle_client.xml");


### PR DESCRIPTION
- Possible fix to NoclassdefFoundError in mail tck 
