### PR TITLE
mail : probable fixes for missing resource files in javatests , part 4

### DIFF
--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileJSP_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileJSP_Test.java
@@ -49,6 +49,9 @@ public class fetchprofileJSP_Test extends fetchprofile_Test implements Serializa
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.jsp");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
+
 
 		URL jspVehicle = fetchprofileJSP_Test.class.getResource
 			("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileServlet_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileServlet_Test.java
@@ -47,6 +47,8 @@ public class fetchprofileServlet_Test extends fetchprofile_Test implements Seria
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.servlet");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(fetchprofileServlet_Test.class, fetchprofile_Test.class);
 		
 	       // The servlet descriptor

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/getMessageContent/getMessageContentJSP_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/getMessageContent/getMessageContentJSP_Test.java
@@ -48,6 +48,8 @@ public class getMessageContentJSP_Test extends getMessageContent_Test {
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.jsp");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 
     URL jspVehicle = getMessageContentJSP_Test.class.getResource
                 ("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/getMessageContent/getMessageContentServlet_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/getMessageContent/getMessageContentServlet_Test.java
@@ -47,6 +47,8 @@ public class getMessageContentServlet_Test extends getMessageContent_Test {
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.servlet");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(getMessageContentServlet_Test.class, getMessageContent_Test.class);
 		
 		// The servlet descriptor

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartJSP_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartJSP_Test.java
@@ -46,14 +46,14 @@ public class internetMimeMultipartJSP_Test extends internetMimeMultipart_Test {
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.jsp");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 
-		URL jspVehicle = internetMimeMultipartJSP_Test.class.getResource
-                ("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
+		URL jspVehicle = internetMimeMultipartJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
     if(jspVehicle != null) {
       archive.addAsWebResource(jspVehicle, "/jsp_vehicle.jsp");
     }
-    URL clientHtml = internetMimeMultipartJSP_Test.class.getResource
-                ("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
+    URL clientHtml = internetMimeMultipartJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
     if(clientHtml != null) {
       archive.addAsWebResource(clientHtml, "/client.html");
     }

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartServlet_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartServlet_Test.java
@@ -44,6 +44,8 @@ public class internetMimeMultipartServlet_Test extends internetMimeMultipart_Tes
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.servlet");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addPackages(false, "com.sun.ts.tests.javamail.ee.internetMimeMultipart");
 		archive.addClasses(internetMimeMultipartServlet_Test.class, internetMimeMultipart_Test.class);
 		

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressJSP_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressJSP_Test.java
@@ -54,21 +54,26 @@ public class internetaddressJSP_Test extends internetaddress_Test
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.jsp");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(internetaddressJSP_Test.class, internetaddress_Test.class);
-		InputStream jspVehicle = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
-        archive.add(new ByteArrayAsset(jspVehicle), "jsp_vehicle.jsp");
-        InputStream clientHtml = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
-        archive.add(new ByteArrayAsset(clientHtml), "client.html");
+
+		URL jspVehicle = internetaddressJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
+		if(jspVehicle != null) {
+			archive.addAsWebResource(jspVehicle, "/jsp_vehicle.jsp");
+		}
+		URL clientHtml = internetaddressJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
+		if(clientHtml != null) {
+			archive.addAsWebResource(clientHtml, "/client.html");
+		}
         
 		// The jsp descriptor
-        URL jspUrl = getMessageContentJSP_Test.class.getResource("jsp_vehicle_client.xml");
+        URL jspUrl = internetaddressJSP_Test.class.getResource("jsp_vehicle_client.xml");
         if(jspUrl != null) {
         	archive.addAsWebInfResource(jspUrl, "web.xml");
         }
         // The sun jsp descriptor
-        URL sunJSPUrl = getMessageContentJSP_Test.class.getResource("internetaddress_jsp_vehicle_web.war.sun-web.xml");
+        URL sunJSPUrl = internetaddressJSP_Test.class.getResource("internetaddress_jsp_vehicle_web.war.sun-web.xml");
         if(sunJSPUrl != null) {
         	archive.addAsWebInfResource(sunJSPUrl, "sun-web.xml");
         }

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressServlet_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressServlet_Test.java
@@ -51,7 +51,9 @@ public class internetaddressServlet_Test extends internetaddress_Test
 		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.servlet");
-				archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(internetaddressServlet_Test.class, internetaddress_Test.class);
 		
 		// The Servlet descriptor

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageJSP_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageJSP_Test.java
@@ -51,14 +51,19 @@ public class mimemessageJSP_Test extends mimemessage_Test implements Serializabl
 		archive.addPackages(true, "com.sun.ts.tests.javamail.ee");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.jsp");
-				archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(mimemessageJSP_Test.class, mimemessage_Test.class);
-		InputStream jspVehicle = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
-        archive.add(new ByteArrayAsset(jspVehicle), "jsp_vehicle.jsp");
-        InputStream clientHtml = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
-        archive.add(new ByteArrayAsset(clientHtml), "client.html");
+    
+		URL jspVehicle = mimemessageJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
+		if(jspVehicle != null) {
+			archive.addAsWebResource(jspVehicle, "/jsp_vehicle.jsp");
+		}
+		URL clientHtml = mimemessageJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
+		if(clientHtml != null) {
+			archive.addAsWebResource(clientHtml, "/client.html");
+		}
 
 		// The jsp descriptor
         URL jspUrl = mimemessageJSP_Test.class.getResource("jsp_vehicle_web.xml");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageServlet_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageServlet_Test.java
@@ -50,6 +50,8 @@ public class mimemessageServlet_Test extends mimemessage_Test implements Seriali
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.servlet");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(mimemessageServlet_Test.class, mimemessage_Test.class);
 		
 		// The servlet descriptor

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartJSP_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartJSP_Test.java
@@ -52,15 +52,15 @@ public class multipartJSP_Test extends multipart_Test implements Serializable {
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.jsp");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(multipartJSP_Test.class, multipart_Test.class);
 
-    URL jspVehicle = multipartJSP_Test.class.getResource
-                ("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
+    URL jspVehicle = multipartJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
     if(jspVehicle != null) {
       archive.addAsWebResource(jspVehicle, "/jsp_vehicle.jsp");
     }
-    URL clientHtml = multipartJSP_Test.class.getResource
-                ("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
+    URL clientHtml = multipartJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
     if(clientHtml != null) {
       archive.addAsWebResource(clientHtml, "/client.html");
     }

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartServlet_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartServlet_Test.java
@@ -50,6 +50,8 @@ public class multipartServlet_Test extends multipart_Test implements Serializabl
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.servlet");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(multipartServlet_Test.class, multipart_Test.class);
 		
 		// The servlet descriptor

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendJSP_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendJSP_Test.java
@@ -52,13 +52,18 @@ public class sendJSP_Test extends send_Test implements Serializable {
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.jsp");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(sendJSP_Test.class, send_Test.class);
-		InputStream jspVehicle = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
-        archive.add(new ByteArrayAsset(jspVehicle), "jsp_vehicle.jsp");
-        InputStream clientHtml = Thread.currentThread().getContextClassLoader()
-                .getResourceAsStream("com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
-        archive.add(new ByteArrayAsset(clientHtml), "client.html");
+    
+		URL jspVehicle = sendJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
+		if(jspVehicle != null) {
+			archive.addAsWebResource(jspVehicle, "/jsp_vehicle.jsp");
+		}
+		URL clientHtml = sendJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/client.html");
+		if(clientHtml != null) {
+			archive.addAsWebResource(clientHtml, "/client.html");
+		}
         
 		// The jsp descriptor
         URL jspUrl = sendJSP_Test.class.getResource("jsp_vehicle_web.xml");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendServlet_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendServlet_Test.java
@@ -50,6 +50,8 @@ public class sendServlet_Test extends send_Test implements Serializable {
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.servlet");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
+		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
+		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addClasses(sendServlet_Test.class, send_Test.class);
 		
 		// The jsp descriptor


### PR DESCRIPTION
**Related Issue(s)**
Continuation to PRs:
https://github.com/jakartaee/platform-tck/pull/2347
https://github.com/jakartaee/platform-tck/pull/2348
https://github.com/jakartaee/platform-tck/pull/2349

**Describe the change**
- add missing ServiceEETest/EETest classes to the javatest archives

