### PR TITLE
Revert "Defend against intermittent EJB failures" committed and merged in #2396 without correct process

### DIFF
--- a/src/com/sun/ts/tests/ejb30/common/lite/EJBLiteClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/lite/EJBLiteClientBase.java
@@ -22,8 +22,6 @@ package com.sun.ts.tests.ejb30.common.lite;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -377,9 +375,6 @@ public class EJBLiteClientBase extends ServiceEETest
 
   protected void appendReason(Object... oo) {
     for (Object o : oo) {
-      if (o instanceof Collection<?>) {
-        o = new ArrayList<>((Collection<?>) o); // Copy to prevent ConcurrentModificationException
-      }
       getReasonBuffer().append(o).append(System.getProperty("line.separator"));
     }
   }

--- a/src/com/sun/ts/tests/ejb30/common/lite/EJBLiteJsfClientBase.java
+++ b/src/com/sun/ts/tests/ejb30/common/lite/EJBLiteJsfClientBase.java
@@ -19,8 +19,6 @@ package com.sun.ts.tests.ejb30.common.lite;
 import java.io.File;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
@@ -381,9 +379,6 @@ public class EJBLiteJsfClientBase extends ServiceEETest
 
   protected void appendReason(Object... oo) {
     for (Object o : oo) {
-      if (o instanceof Collection<?>) {
-        o = new ArrayList<>((Collection<?>) o); // Copy to prevent ConcurrentModificationException
-      }
       getReasonBuffer().append(o).append(System.getProperty("line.separator"));
     }
   }

--- a/src/com/sun/ts/tests/ejb30/timer/common/TimerUtil.java
+++ b/src/com/sun/ts/tests/ejb30/timer/common/TimerUtil.java
@@ -271,7 +271,7 @@ public final class TimerUtil {
 
   public static Timer createSecondLaterTimer(TimerService timerService,
       TimerConfig timerConfig) {
-    return createSecondLaterTimer(timerService, timerConfig, 2);
+    return createSecondLaterTimer(timerService, timerConfig, 1);
   }
 
   public static Timer createSecondLaterTimer(TimerService timerService,
@@ -284,7 +284,7 @@ public final class TimerUtil {
 
   public static Timer createSecondLaterTimer(TimerService timerService,
       TimerInfo info) {
-    return createSecondLaterTimer(timerService, info, 2);
+    return createSecondLaterTimer(timerService, info, 1);
   }
 
   public static Timer createSecondLaterTimer(TimerService timerService,


### PR DESCRIPTION
This reverts commit 657b66c4e30dc8388e26e9335cc8252c16f93f12 as requested by @scottmarlow 

Breaks #2322 in TCK10 executed against GlassFish 7.1 on JDK17.

I am kindly asking to postpone this revert as much as possible before releasing 10.0.7 to avoid redundant noise, and to resolve my mistake by late approval instead.

