### PR TITLE
Add Missing Client Class to EJB Jar

### DIFF
--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/getstatus/UserGetStatusClientEjbTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/getstatus/UserGetStatusClientEjbTest.java
@@ -93,7 +93,7 @@ public class UserGetStatusClientEjbTest extends com.sun.ts.tests.jta.ee.usertran
                 EETest.class, Fault.class,
                 SetupException.class, ServiceEETest.class,
                 com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.common.vehicle.VehicleClient.class,
-                UserGetStatusClientEjbTest.class);
+                com.sun.ts.tests.jta.ee.usertransaction.getstatus.UserGetStatusClient.class, UserGetStatusClientEjbTest.class);
         // The ejb-jar.xml descriptor
         URL ejbResURL = UserGetStatusClientEjbTest.class.getClassLoader().getResource(packagePath + "/ejb_vehicle_ejb.xml");
         if (ejbResURL != null) {


### PR DESCRIPTION
Follow-on problem discovered after fix for https://github.com/jakartaee/platform-tck/pull/2409 tested. Now that the test is running in an EJB on the server, that application needs access to all of the client classes.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
