### PR TITLE
Cleanup Spurious Setup Failures in Mail Tests

### DIFF
--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipart_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipart_Test.java
@@ -36,7 +36,6 @@ import jakarta.mail.Folder;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Session;
-import jakarta.mail.Store;
 import jakarta.mail.internet.MimeBodyPart;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
@@ -50,12 +49,6 @@ public class internetMimeMultipart_Test extends ServiceEETest {
   private int errors = 0; // number of unit test errors
 
   private MailTestUtil mailTestUtil;
-
-  private Folder folder;
-
-  private Message[] msgs;
-
-  private Store store;
 
   private Status status;
 
@@ -74,8 +67,7 @@ public class internetMimeMultipart_Test extends ServiceEETest {
    * smtp.port; imap.port;
    */
   public void setup(String[] args, Properties props) throws Exception {
-    try {
-
+      try {
     	  String protocol = TestUtil.getProperty("javamail.protocol");
           String host = TestUtil.getProperty("javamail.server");
           String user = TestUtil.getProperty("javamail.username");
@@ -91,26 +83,14 @@ public class internetMimeMultipart_Test extends ServiceEETest {
           int imapPort = Integer.parseInt(imapPortStr);
           TestUtil.logTrace("IMAP Port = " + imapPort);
 
-      mailTestUtil = new MailTestUtil();
-      store = mailTestUtil.connect2host(protocol, host, imapPort, user,
-          password);
-      session = mailTestUtil.getSession();
-
-      // Get a Folder object
-      Folder root = mailTestUtil.getRootFolder(store);
-      folder = root.getFolder(mailbox);
-
-      if (folder == null) {
-        throw new Exception("Invalid folder object!");
+          mailTestUtil = new MailTestUtil();
+          session = mailTestUtil.createSession(host, smtpPortStr, user, password);
+      } catch (Exception e) {
+          e.printStackTrace();
+          logErr("Exception : " + e.getMessage());
+          logErr("Setup Failed!");
+          TestUtil.printStackTrace(e);
       }
-      folder.open(Folder.READ_ONLY);
-
-    } catch (Exception e) {
-    e.printStackTrace();
-      logErr("Exception : " + e.getMessage());
-      logErr("Setup Failed!");
-      TestUtil.printStackTrace(e);
-    }
   }
 
   /*

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessage_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessage_Test.java
@@ -34,12 +34,10 @@ import com.sun.ts.tests.javamail.ee.common.MailTestUtil;
 
 import jakarta.mail.Address;
 import jakarta.mail.Flags;
-import jakarta.mail.Folder;
 import jakarta.mail.Message;
 import jakarta.mail.MessagingException;
 import jakarta.mail.Multipart;
 import jakarta.mail.Session;
-import jakarta.mail.Store;
 import jakarta.mail.internet.InternetAddress;
 import jakarta.mail.internet.MimeMessage;
 import jakarta.mail.internet.MimeMultipart;
@@ -57,12 +55,6 @@ public class mimemessage_Test extends ServiceEETest implements Serializable {
   private transient MailTestUtil mailTestUtil;
 
   private transient Session session;
-
-  private Folder folder;
-
-  private Message[] msgs;
-
-  private Store store;
 
   private transient Status status;
 
@@ -90,8 +82,7 @@ public class mimemessage_Test extends ServiceEETest implements Serializable {
    * imap.port;
    */
   public void setup(String[] args, Properties props) throws Exception {
-    try {
-
+      try {
     	  mailTo = props.getProperty("mailuser1");
     	  String protocol = TestUtil.getProperty("javamail.protocol");
           String host = TestUtil.getProperty("javamail.server");
@@ -108,29 +99,13 @@ public class mimemessage_Test extends ServiceEETest implements Serializable {
           int imapPort = Integer.parseInt(imapPortStr);
           TestUtil.logTrace("IMAP Port = " + imapPort);
 
-      MailTestUtil mailTestUtil = new MailTestUtil();
-
-      store = mailTestUtil.connect2host(protocol, host, imapPort, user,
-          password);
-      session = mailTestUtil.getSession();
-
-      // Get a Folder object
-      Folder root = mailTestUtil.getRootFolder(store);
-      folder = root.getFolder(mailbox);
-
-      if (folder == null) {
-        throw new Exception("Invalid folder object!");
+          mailTestUtil = new MailTestUtil();
+          session = mailTestUtil.createSession(host, smtpPortStr, user, password);
+      } catch (Exception e) {
+          logErr("Exception : " + e.getMessage());
+          logErr("Setup Failed!");
+          TestUtil.printStackTrace(e);
       }
-      folder.open(Folder.READ_ONLY);
-
-      // Get all the messages
-      msgs = folder.getMessages();
-
-    } catch (Exception e) {
-      logErr("Exception : " + e.getMessage());
-      logErr("Setup Failed!");
-      TestUtil.printStackTrace(e);
-    }
   }
 
   /*
@@ -562,9 +537,6 @@ public class mimemessage_Test extends ServiceEETest implements Serializable {
   public void cleanup() throws Exception {
     try {
       logMsg("Cleanup ;");
-      if (store != null) {
-        store = null;
-      }
       if (session != null) {
         session = null;
       }


### PR DESCRIPTION
Both of these tests throw setup failures doing things that aren't necessary for their respective tests. These failures don't actually cause any failures, but can serve as one heck of a red herring.

ex.
```
08-21-2025 00:49:24:  SVR-ERROR: Exception : test1 not found
08-21-2025 00:49:24:  SVR-ERROR: Setup Failed!
08-21-2025 00:49:24:  SVR-ERROR: jakarta.mail.FolderNotFoundException: test1 not found
	at org.eclipse.angus.mail.imap.IMAPFolder.checkExists(IMAPFolder.java:448)
	at org.eclipse.angus.mail.imap.IMAPFolder.open(IMAPFolder.java:1061)
	at org.eclipse.angus.mail.imap.IMAPFolder.open(IMAPFolder.java:994)
	at com.sun.ts.tests.javamail.ee.internetMimeMultipart.internetMimeMultipart_Test.setup(internetMimeMultipart_Test.java:106)
    ...
```

This PR removes the unnecessary steps from each test, eliminating the ugly error.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
