### PR TITLE
Cleanup JDBC Tests - Wrong Vehicles, App Packaging

### DIFF
--- a/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/callStmt/callStmt1/callStmtClient1AppClient.java
+++ b/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/callStmt/callStmt1/callStmtClient1AppClient.java
@@ -50,7 +50,6 @@ import tck.arquillian.protocol.common.TargetVehicle;
 @Tag("tck-appclient")
 
 public class callStmtClient1AppClient extends callStmtClient1 implements Serializable {
-
 	@TargetsContainer("tck-appclient")
 	@OverProtocol("appclient")
 	@Deployment(name = "appclient", testable = true)
@@ -63,7 +62,7 @@ public class callStmtClient1AppClient extends callStmtClient1 implements Seriali
 		archive.addClasses(callStmtClient1.class, ServiceEETest.class, EETest.class);
 		// The appclient-client descriptor
 		URL appClientUrl = callStmtClient1AppClient.class
-				.getResource("/com/sun/ts/tests/jdbc/ee/callStmt1/appclient_vehicle_client.xml");
+				.getResource("/com/sun/ts/tests/jdbc/ee/callStmt/callStmt1/appclient_vehicle_client.xml");
 		if (appClientUrl != null) {
 			archive.addAsManifestResource(appClientUrl, "application-client.xml");
 		}

--- a/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/callStmt/callStmt1/callStmtClient1EJB.java
+++ b/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/callStmt/callStmt1/callStmtClient1EJB.java
@@ -373,7 +373,7 @@ public class callStmtClient1EJB extends callStmtClient1 implements Serializable 
 	 * method to retrieve the null value. Check if it returns null
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetInt03() throws Exception {
 		super.testGetInt03();
 	}
@@ -393,7 +393,7 @@ public class callStmtClient1EJB extends callStmtClient1 implements Serializable 
 	 * equal.
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetBoolean01() throws Exception {
 		super.testGetBoolean01();
 	}
@@ -413,7 +413,7 @@ public class callStmtClient1EJB extends callStmtClient1 implements Serializable 
 	 * equal.
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetBoolean02() throws Exception {
 		super.testGetBoolean02();
 	}
@@ -432,7 +432,7 @@ public class callStmtClient1EJB extends callStmtClient1 implements Serializable 
 	 * returned by the getLong(int parameterIndex). Both the values should be equal.
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetLong01() throws Exception {
 		super.testGetLong01();
 	}
@@ -451,7 +451,7 @@ public class callStmtClient1EJB extends callStmtClient1 implements Serializable 
 	 * returned by the getLong(int parameterIndex) Both the values should be equal.
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetLong02() throws Exception {
 		super.testGetLong02();
 	}
@@ -469,7 +469,7 @@ public class callStmtClient1EJB extends callStmtClient1 implements Serializable 
 	 * it returns null
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetLong03() throws Exception {
 		super.testGetLong03();
 	}

--- a/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/callStmt/callStmt10/callStmtClient10AppClient.java
+++ b/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/callStmt/callStmt10/callStmtClient10AppClient.java
@@ -68,7 +68,7 @@ public class callStmtClient10AppClient extends callStmtClient10 implements Seria
 
 		// The appclient-client descriptor
 		URL appClientUrl = callStmtClient10AppClient.class
-				.getResource("/com/sun/ts/tests/jdbc/ee/callStmt10/appclient_vehicle_client.xml");
+				.getResource("/com/sun/ts/tests/jdbc/ee/callStmt/callStmt10/appclient_vehicle_client.xml");
 		if (appClientUrl != null) {
 			archive.addAsManifestResource(appClientUrl, "application-client.xml");
 		}

--- a/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/dbMeta/dbMeta12/dbMetaClient12EJB.java
+++ b/tcks/profiles/platform/jdbc/src/main/java/com/sun/ts/tests/jdbc/ee/dbMeta/dbMeta12/dbMetaClient12EJB.java
@@ -123,7 +123,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 * 
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetSQLStateType() throws Exception {
 		super.testGetSQLStateType();
 	}
@@ -140,7 +140,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 * 
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetDatabaseMinorVersion() throws Exception {
 		super.testGetDatabaseMinorVersion();
 	}
@@ -158,7 +158,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 * 
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetDatabaseMajorVersion() throws Exception {
 		super.testGetDatabaseMajorVersion();
 	}
@@ -175,7 +175,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 * 
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetJDBCMinorVersion() throws Exception {
 		super.testGetJDBCMinorVersion();
 	}
@@ -192,7 +192,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 * 
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetJDBCMajorVersion() throws Exception {
 		super.testGetJDBCMajorVersion();
 	}
@@ -209,7 +209,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 *
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testSupportsSavepoints() throws Exception {
 		super.testSupportsSavepoints();
 	}
@@ -226,7 +226,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 *
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testSupportsNamedParameters() throws Exception {
 		super.testSupportsNamedParameters();
 	}
@@ -243,7 +243,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 *
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testSupportsMultipleOpenResults() throws Exception {
 		super.testSupportsMultipleOpenResults();
 	}
@@ -260,7 +260,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 *
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testSupportsGetGeneratedKeys() throws Exception {
 		super.testSupportsGetGeneratedKeys();
 	}
@@ -277,7 +277,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 *
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testSupportsResultSetHoldability01() throws Exception {
 		super.testSupportsResultSetHoldability01();
 	}
@@ -294,7 +294,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 *
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testSupportsResultSetHoldability02() throws Exception {
 		super.testSupportsResultSetHoldability02();
 	}
@@ -311,7 +311,7 @@ public class dbMetaClient12EJB extends dbMetaClient12 implements Serializable {
 	 *
 	 */
 	@Test
-	@TargetVehicle("appclient")
+	@TargetVehicle("ejb")
 	public void testGetResultSetHoldability() throws Exception {
 		super.testGetResultSetHoldability();
 	}


### PR DESCRIPTION
The callstmt app packaging issues can cause failures, since it results in a client module that lacks a ref to the test datasource.
The EJB vehicle updates are corrections to ensure that the proper test method is actually being used. On Open Liberty, having the wrong vehicle in the callstmt1 test causes failures, since it falls back on a client module that isn't packaged properly.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
