### PR TITLE
Setting 8gb mem not needed for CDI TCK

### DIFF
--- a/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-run/pom.xml
@@ -392,7 +392,6 @@
                             <systemPropertyVariables>
                                 <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
                                 <glassfish.enableDerby>true</glassfish.enableDerby>
-                                <glassfish.maxHeapSize>8192m</glassfish.maxHeapSize>
                                 <glassfish.enableAssertions>:org.jboss.cdi.tck...</glassfish.enableAssertions>
                                 <glassfish.systemProperties>
                                     cdiTckExcludeDummy=true


### PR DESCRIPTION


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
