### PR TITLE
Move Authentication (jaspic) from KEYWORD_WEB_FULL_OPTIONAL_TECHS to KEYWORD_WEB as Authentication is required for Web Profile

### DIFF
--- a/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/JakartaEESigTest.java
+++ b/tcks/profiles/platform/signaturevalidation/src/main/java/com/sun/ts/tests/signaturetest/JakartaEESigTest.java
@@ -74,12 +74,12 @@ public class JakartaEESigTest extends SigTestEE {
       + " cdi data beanval persistence connector"
       + " jacc jaspic jsonp jta el servlet jsf jaxrs websocket batch concurrency jsonb securityapi";
 
-  public static final String KEYWORD_WEB = "caj ejb persistence el jsf jsonp jsp servlet jta jaxrs cdi data beanval interceptors websocket concurrency jsonb securityapi";
+  public static final String KEYWORD_WEB = "caj ejb persistence el jaspic jsf jsonp jsp servlet jta jaxrs cdi data beanval interceptors websocket concurrency jsonb securityapi";
 
   public static final ArrayList<String> KEYWORD_JAVAEE_FULL_OPTIONAL_TECHS = new ArrayList<String>();
 
   public static final ArrayList<String> KEYWORD_WEB_FULL_OPTIONAL_TECHS = new ArrayList<String>(
-      Arrays.asList("batch", "connector", "jms", "javamail", "jacc", "jaspic"));
+      Arrays.asList("batch", "connector", "jms", "javamail", "jacc"));
 
   enum Containers {
     ejb, servlet, jsp, appclient 

--- a/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java
+++ b/tools/signaturetest/src/main/java/com/sun/ts/tests/signaturetest/javaee/JavaEESigTest.java
@@ -75,12 +75,12 @@ public class JavaEESigTest extends SigTestEE {
             + " cdi di beanval persistence jaxb saaj jaxws connector"
             + " jacc jaspic jsonp jta el servlet jsf jaxrs websocket batch concurrency jsonb securityapi";
 
-    public static final String KEYWORD_WEB = "caj ejb persistence el jsf jsonp jsp servlet jta jaxrs cdi di beanval interceptors websocket concurrency jsonb securityapi";
+    public static final String KEYWORD_WEB = "caj ejb persistence el jaspic jsf jsonp jsp servlet jta jaxrs cdi di beanval interceptors websocket concurrency jsonb securityapi";
 
     public static final ArrayList<String> KEYWORD_JAVAEE_FULL_OPTIONAL_TECHS = new ArrayList<String>();
 
     public static final ArrayList<String> KEYWORD_WEB_FULL_OPTIONAL_TECHS = new ArrayList<String>(
-            Arrays.asList("batch", "connector", "jaxws", "jaxb", "jms", "javamail", "jacc", "jaspic", "wsmd"));
+            Arrays.asList("batch", "connector", "jaxws", "jaxb", "jms", "javamail", "jacc", "wsmd"));
 
     public enum Containers {
         ejb, servlet, jsp, appclient


### PR DESCRIPTION
This is the main branch change for https://github.com/jakartaee/platform-tck/issues/2394
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2394

**Describe the change**
Update Signature testing to require Authentication SPEC API.

**Additional context**
Backport to EE 11 once verified as the correct fix.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
