### PR TITLE
Fix for Challenge 2411

### DIFF
--- a/tcks/apis/jsonb/src/main/java/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ClientEjbTest.java
+++ b/tcks/apis/jsonb/src/main/java/com/sun/ts/tests/jsonb/pluggability/jsonbprovidertests/ClientEjbTest.java
@@ -114,7 +114,7 @@ public class ClientEjbTest extends Client {
         if (resURL != null) {
             jsonbprovidertests_ejb_vehicle_client.addAsManifestResource(resURL, "application-client.xml");
         }
-        jsonbprovidertests_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"),
+        jsonbprovidertests_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"),
                 "MANIFEST.MF");
 
         resURL = ClientEjbTest.class.getClassLoader().getResource(packagePath + "/ejb_vehicle_client.jar.sun-application-client.xml");
@@ -156,21 +156,21 @@ public class ClientEjbTest extends Client {
     }
     @Override
     @Test
-    @TargetVehicle("appclient")
+    @TargetVehicle("ejb")
     public void jsonbProviderTest1() throws Exception {
         super.jsonbProviderTest1();
     }
 
     @Override
     @Test
-    @TargetVehicle("appclient")
+    @TargetVehicle("ejb")
     public void jsonbProviderTest2() throws Exception {
         super.jsonbProviderTest2();
     }
 
     @Override
     @Test
-    @TargetVehicle("appclient")
+    @TargetVehicle("ejb")
     public void jsonbProviderTest3() throws Exception {
         super.jsonbProviderTest3();
     }

--- a/tcks/apis/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchEjbTest.java
+++ b/tcks/apis/jsonp/src/main/java/com/sun/ts/tests/jsonp/api/patchtests/PatchEjbTest.java
@@ -124,7 +124,7 @@ public class PatchEjbTest extends ServiceEETest {
     if(resURL != null) {
       patchtests_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
     }
-    patchtests_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + PatchEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+    patchtests_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"), "MANIFEST.MF");
 
 
     JavaArchive patchtests_ejb_vehicle_ejb = ShrinkWrap.create(JavaArchive.class, "patchtests_ejb_vehicle_ejb.jar");

--- a/tcks/apis/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientEjbTest.java
+++ b/tcks/apis/jsonp/src/main/java/com/sun/ts/tests/jsonp/pluggability/jsonprovidertests/ClientEjbTest.java
@@ -117,7 +117,7 @@ public class ClientEjbTest extends Client {
     if(resURL != null) {
       jsonprovidertests_ejb_vehicle_client.addAsManifestResource(resURL, "application-client.xml");
     }
-    jsonprovidertests_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + Client.class.getName() + "\n"), "MANIFEST.MF");
+    jsonprovidertests_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"), "MANIFEST.MF");
     resURL = ClientEjbTest.class.getClassLoader().getResource(packagePath+"/ejb_vehicle_client.jar.sun-application-client.xml");
     if(resURL != null) {
       jsonprovidertests_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
@@ -177,95 +177,95 @@ public class ClientEjbTest extends Client {
   /* Tests */
 
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest1() throws Exception {
     super.jsonProviderTest1();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest2() throws Exception {
     super.jsonProviderTest2();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest3() throws Exception {
     super.jsonProviderTest3();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest4() throws Exception {
     super.jsonProviderTest4();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest5() throws Exception {
     super.jsonProviderTest5();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest6() throws Exception {
     super.jsonProviderTest6();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest7() throws Exception {
     super.jsonProviderTest7();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest8() throws Exception {
     super.jsonProviderTest8();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest9() throws Exception {
     super.jsonProviderTest9();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest10() throws Exception {
     super.jsonProviderTest10();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest11() throws Exception {
     super.jsonProviderTest11();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest12() throws Exception {
     super.jsonProviderTest12();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest13() throws Exception {
     super.jsonProviderTest13();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest14() throws Exception {
     super.jsonProviderTest14();
   }
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest15() throws Exception {
     super.jsonProviderTest15();
   }
 
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest16() throws Exception {
     super.jsonProviderTest16();
   }
 
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest17() throws Exception {
     super.jsonProviderTest17();
   }
 
   @Test
-  @TargetVehicle("appclient")
+  @TargetVehicle("ejb")
   public void jsonProviderTest18() throws Exception {
     super.jsonProviderTest18();
   }

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/begin/UserBeginClientEjbTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/begin/UserBeginClientEjbTest.java
@@ -78,7 +78,7 @@ public class UserBeginClientEjbTest extends com.sun.ts.tests.jta.ee.usertransact
         if (resURL != null) {
             begin_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
         }
-        begin_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + UserBeginClientEjbTest.class.getName() + "\n"),
+        begin_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"),
                 "MANIFEST.MF");
         archiveProcessor.processClientArchive(begin_ejb_vehicle_client, UserBeginClientEjbTest.class, resURL);
 

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/commit/UserCommitClientEjbTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/commit/UserCommitClientEjbTest.java
@@ -80,7 +80,7 @@ public class UserCommitClientEjbTest extends com.sun.ts.tests.jta.ee.usertransac
         if (resURL != null) {
             commit_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
         }
-        commit_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: " + UserCommitClientEjbTest.class.getName() + "\n"),
+        commit_ejb_vehicle_client.addAsManifestResource(new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"),
                 "MANIFEST.MF");
         archiveProcessor.processClientArchive(commit_ejb_vehicle_client, UserCommitClientEjbTest.class, resURL);
 

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/getstatus/UserGetStatusClientEjbTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/getstatus/UserGetStatusClientEjbTest.java
@@ -79,7 +79,7 @@ public class UserGetStatusClientEjbTest extends com.sun.ts.tests.jta.ee.usertran
             getstatus_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
         }
         getstatus_ejb_vehicle_client
-                .addAsManifestResource(new StringAsset("Main-Class: " + UserGetStatusClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+                .addAsManifestResource(new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"), "MANIFEST.MF");
         archiveProcessor.processClientArchive(getstatus_ejb_vehicle_client, UserGetStatusClientEjbTest.class, resURL);
 
         JavaArchive getstatus_ejb_vehicle_ejb = ShrinkWrap.create(JavaArchive.class, "getstatus_ejb_vehicle_ejb.jar");
@@ -93,7 +93,7 @@ public class UserGetStatusClientEjbTest extends com.sun.ts.tests.jta.ee.usertran
                 EETest.class, Fault.class,
                 SetupException.class, ServiceEETest.class,
                 com.sun.ts.tests.jta.ee.common.TransactionStatus.class, com.sun.ts.tests.common.vehicle.VehicleClient.class,
-                UserGetStatusClientEjbTest.class);
+                com.sun.ts.tests.jta.ee.usertransaction.getstatus.UserGetStatusClient.class, UserGetStatusClientEjbTest.class);
         // The ejb-jar.xml descriptor
         URL ejbResURL = UserGetStatusClientEjbTest.class.getClassLoader().getResource(packagePath + "/ejb_vehicle_ejb.xml");
         if (ejbResURL != null) {

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/rollback/UserRollbackClientEjbTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/rollback/UserRollbackClientEjbTest.java
@@ -81,7 +81,7 @@ public class UserRollbackClientEjbTest extends com.sun.ts.tests.jta.ee.usertrans
             rollback_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
         }
         rollback_ejb_vehicle_client
-                .addAsManifestResource(new StringAsset("Main-Class: " + UserRollbackClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+                .addAsManifestResource(new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"), "MANIFEST.MF");
         archiveProcessor.processClientArchive(rollback_ejb_vehicle_client, UserRollbackClientEjbTest.class, resURL);
 
         // Ejb

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setrollbackonly/UserSetRollbackOnlyClientEjbTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/setrollbackonly/UserSetRollbackOnlyClientEjbTest.java
@@ -79,7 +79,7 @@ public class UserSetRollbackOnlyClientEjbTest extends com.sun.ts.tests.jta.ee.us
             setrollbackonly_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
         }
         setrollbackonly_ejb_vehicle_client.addAsManifestResource(
-                new StringAsset("Main-Class: " + UserSetRollbackOnlyClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+                new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"), "MANIFEST.MF");
         archiveProcessor.processClientArchive(setrollbackonly_ejb_vehicle_client, UserSetRollbackOnlyClientEjbTest.class, resURL);
 
         JavaArchive setrollbackonly_ejb_vehicle_ejb = ShrinkWrap.create(JavaArchive.class, "setrollbackonly_ejb_vehicle_ejb.jar");

--- a/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/settransactiontimeout/UserSetTransactionTimeoutClientEjbTest.java
+++ b/tcks/apis/transactions/src/main/java/com/sun/ts/tests/jta/ee/usertransaction/settransactiontimeout/UserSetTransactionTimeoutClientEjbTest.java
@@ -81,7 +81,7 @@ public class UserSetTransactionTimeoutClientEjbTest
             settransactiontimeout_ejb_vehicle_client.addAsManifestResource(resURL, "sun-application-client.xml");
         }
         settransactiontimeout_ejb_vehicle_client.addAsManifestResource(
-                new StringAsset("Main-Class: " + UserSetTransactionTimeoutClientEjbTest.class.getName() + "\n"), "MANIFEST.MF");
+                new StringAsset("Main-Class: com.sun.ts.tests.common.vehicle.VehicleClient\n"), "MANIFEST.MF");
         archiveProcessor.processClientArchive(settransactiontimeout_ejb_vehicle_client, UserSetTransactionTimeoutClientEjbTest.class,
                 resURL);
 


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2411

**Describe the change**
Some tests in the EE 11+ TCK are intended to be run as EJB vehicle tests, but are actually running purely in the appclient instead. This makes changes (primarily to the client jar Main-Class) to ensure that these tests run in an EJB instead as designed. Also includes a fix to add a missing client class to a test application.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
