### PR TITLE
Remove @Transactional from Persistence Vehicles

### DIFF
--- a/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/appmanaged/AppManagedVehicleBean.java
+++ b/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/appmanaged/AppManagedVehicleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -28,14 +28,13 @@ import com.sun.ts.tests.common.vehicle.ejb3share.EJB3ShareBaseBean;
 import com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper;
 
 import jakarta.annotation.Resource;
+import jakarta.ejb.Remove;
 import jakarta.ejb.SessionContext;
 import jakarta.ejb.Stateful;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.PersistenceUnit;
-import jakarta.transaction.Transaction;
-import jakarta.transaction.Transactional;
 
 @Stateful(name = "AppManagedVehicleBean")
 public class AppManagedVehicleBean extends EJB3ShareBaseBean
@@ -52,7 +51,7 @@ public class AppManagedVehicleBean extends EJB3ShareBaseBean
     private EntityManagerFactory emf;
 
     // ================== business methods ====================================
-    @Transactional(Transactional.TxType.REQUIRED)
+    @Remove
     public RemoteStatus runTest(String[] args, Properties props) {
         props.put("persistence.unit.name", "CTS-EM");
         try {

--- a/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/stateful3/Stateful3VehicleBean.java
+++ b/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/stateful3/Stateful3VehicleBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -37,8 +37,6 @@ import jakarta.persistence.EntityManagerFactory;
 import jakarta.persistence.EntityTransaction;
 import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.PersistenceUnit;
-import jakarta.transaction.Transaction;
-import jakarta.transaction.Transactional;
 
 @Stateful(name = "Stateful3VehicleBean")
 public class Stateful3VehicleBean extends EJB3ShareBaseBean
@@ -69,7 +67,6 @@ public class Stateful3VehicleBean extends EJB3ShareBaseBean
 
     // ================== business methods ====================================
     @Remove
-    @Transactional(Transactional.TxType.REQUIRED)
     public RemoteStatus runTest(String[] args, Properties props) {
         RemoteStatus retValue;
         props.put("persistence.unit.name", "CTS-EM");


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2469

**Describe the change**
Remove `@Transactional` from two Vehicle EJBs because it violates the EJB spec.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
