### PR TITLE
Add Missing Class to persistence.ee.packaging.ejb.resource_local war module

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/ejb/resource_local/ClientTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/ejb/resource_local/ClientTest.java
@@ -99,7 +99,7 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.ejb.reso
 
             // non-vehicle appclientproxy invoker war
             WebArchive appclientproxy = ShrinkWrap.create(WebArchive.class, "appclientproxy.war");
-            appclientproxy.addClasses(Client.class, EETest.class, StatelessServletTarget.class, ServletNoVehicle.class);
+            appclientproxy.addClasses(Client.class, EETest.class, SetupException.class, StatelessServletTarget.class, ServletNoVehicle.class);
             appclientproxy.addAsWebInfResource(new StringAsset(""), "beans.xml");
 
         // Ear


### PR DESCRIPTION
**Fixes Issue**
TCK Challenge: https://github.com/jakartaee/platform-tck/issues/2472

**Describe the change**
Adds missing framework to test's war module, resolving NoClassDefFoundError seen on some implementations.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
