### PR TITLE
Remove fragile debug code from ejb30.assembly.initorder.appclientejb.Client

### DIFF
--- a/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/assembly/initorder/appclientejb/Client.java
+++ b/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/assembly/initorder/appclientejb/Client.java
@@ -80,39 +80,6 @@ public class Client extends EETest {
    * default app-name.
    */
   public void appName() {
-
-    TestUtil.logTrace("appName(), java:app entries:");
-    try {
-      InitialContext c = new InitialContext();
-      NamingEnumeration<Binding> bindings = c.listBindings("java:app");
-      while (bindings.hasMore()) {
-        Binding b = bindings.next();
-        String name = b.getName();
-        Object obj = b.getObject();
-        TestUtil.logTrace("java:app/%s entry: %s(%s)".formatted(name, obj, b.getClassName()));
-        if(obj instanceof Context) {
-          Context ctx = (Context) obj;
-          TestUtil.logTrace("+ Context(%s) bindings: ".formatted(ctx.getNameInNamespace()));
-            NamingEnumeration<Binding> ctxBindings = ctx.listBindings("");
-            while (ctxBindings.hasMore()) {
-              Binding b2 = ctxBindings.next();
-              String name2 = b2.getName();
-              Object obj2 = b2.getObject();
-              TestUtil.logTrace("++ %s entry: %s(%s)".formatted(name2, obj2, b2.getClassName()));
-            }
-        }
-      }
-      NamingEnumeration<NameClassPair> listings = c.list("java:app");
-        while (listings.hasMore()) {
-            NameClassPair ncp = listings.next();
-            String name = ncp.getName();
-            String className = ncp.getClassName();
-            TestUtil.logTrace("java:app/%s list: %s".formatted(name, className));
-        }
-    } catch (NamingException e) {
-      TestUtil.logMsg("java:app listBindings failed", e);
-    }
-
     String expected = "renamed2";
     String lookup = "java:app/AppName";
     String actual = (String) ServiceLocator.lookupNoTry(lookup);


### PR DESCRIPTION
**Fixes Issue**
Addresses TCK challenge https://github.com/jakartaee/platform-tck/issues/2454

**Describe the change**
Removes debug code that was not present in the EE 10 TCK and has added fragility to test executions, causing failures on some vendor implementations.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
