### PR TITLE
Allow bindings to be added to appclient jars

### DIFF
--- a/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/resref/casesens/Client.java
+++ b/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/resref/casesens/Client.java
@@ -87,6 +87,8 @@ public class Client extends EETest {
 				new StringAsset("Main-Class: " + "com.sun.ts.tests.appclient.deploy.resref.casesens.Client" + "\n"),
 				"MANIFEST.MF");
 
+                archiveProcessor.processClientArchive(ejbClient, Client.class, appClientUrl);
+
 		EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "appclient_dep_resref_casesens.ear");
 		ear.addAsModule(ejbClient);
 		return ear;

--- a/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/resref/scope/Client.java
+++ b/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/resref/scope/Client.java
@@ -82,6 +82,8 @@ public class Client extends EETest {
                 new StringAsset("Main-Class: " + Client.class.getName() + "\n"),
                 "MANIFEST.MF");
 
+        archiveProcessor.processClientArchive(ejbClient1, Client.class, appClientUrl);
+
         JavaArchive ejbClient2 = ShrinkWrap.create(JavaArchive.class, "appclient_dep_resref_scope_client.jar");
         ejbClient2.addClasses(Client.class, EETest.class, Fault.class, SetupException.class, QueueCode.class);
 
@@ -93,6 +95,8 @@ public class Client extends EETest {
         ejbClient2.addAsManifestResource(
                 new StringAsset("Main-Class: " + Client.class.getName() + "\n"),
                 "MANIFEST.MF");
+
+        archiveProcessor.processClientArchive(ejbClient2, Client.class, resURL);
 
         EnterpriseArchive ear = ShrinkWrap.create(EnterpriseArchive.class, "appclient_dep_resref_scope.ear");
         ear.addAsModule(ejbClient1);

--- a/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/resref/single/Client.java
+++ b/tcks/profiles/platform/appclient/src/main/java/com/sun/ts/tests/appclient/deploy/resref/single/Client.java
@@ -96,6 +96,9 @@ public class Client extends EETest {
 		ejbClient.addAsManifestResource(
 				new StringAsset("Main-Class: " + "com.sun.ts.tests.appclient.deploy.resref.single.Client" + "\n"),
 				"MANIFEST.MF");
+
+                archiveProcessor.processClientArchive(ejbClient, Client.class, appClientUrl);
+
 		WebArchive webArchive = ShrinkWrap.create(WebArchive.class, "appclient_dep_resref_single_jsp_web.war");
 		InputStream testJSP = Thread.currentThread().getContextClassLoader()
 				.getResourceAsStream("com/sun/ts/tests/appclient/deploy/resref/single/contentRoot/test.jsp");


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2490

**Describe the change**
Adds missing processClientArchive calls to the appclient resref tests to allow implementations to add vendor-specific binding files to the applications.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
