### PR TITLE
remove ejb30 + ejb32 from release process

### DIFF
--- a/release/artifact-install.pom
+++ b/release/artifact-install.pom
@@ -120,36 +120,6 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>install-ejb30</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                        <configuration>
-                            <groupId>jakarta.tck</groupId>
-                            <artifactId>ejb30</artifactId>
-                            <version>${project.version}</version>
-                            <packaging>jar</packaging>
-                            <file>ejb30-${project.version}.jar</file>
-                            <generatePom>false</generatePom>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>install-ejb32</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                        <configuration>
-                            <groupId>jakarta.tck</groupId>
-                            <artifactId>ejb32</artifactId>
-                            <version>${project.version}</version>
-                            <packaging>jar</packaging>
-                            <file>ejb32-${project.version}.jar</file>
-                            <generatePom>false</generatePom>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>install-el-platform-tck</id>
                         <phase>package</phase>
                         <goals>

--- a/release/src/main/assembly/assembly.xml
+++ b/release/src/main/assembly/assembly.xml
@@ -124,8 +124,6 @@
                 <include>${project.groupId}:common</include>
                 <include>${project.groupId}:cdi-tck-ee-impl</include>
                 <include>${project.groupId}:connector</include>
-                <include>${project.groupId}:ejb30</include>
-                <include>${project.groupId}:ejb32</include>
                 <include>${project.groupId}:el-platform-tck</include>
                 <include>${project.groupId}:integration</include>
                 <include>${project.groupId}:javaee-tck</include>


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2478 

**Describe the change**
Address failure in https://ci.eclipse.org/jakartaee-tck/job/12/job/stage-release-artifacts/job/TCKDistRelease/5/

```
Failed to execute goal org.apache.maven.plugins:maven-install-plugin:3.1.3:install-file (install-ejb30) on project platform-tck-artifacts: The specified file '/home/jenkins/agent/workspace/12/stage-release-artifacts/TCKDistRelease/release/target/jakartaeetck/artifacts/ejb30-12.0.0-SNAPSHOT.jar' does not exist -> [Help 1]
````

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
