### PR TITLE
Comment out tags modules and refernces

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021  Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2025  Contributors to the Eclipse Foundation
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -140,11 +140,11 @@
         <artifactId>rest-platform-tck</artifactId>
         <version>${project.version}</version>
       </dependency>
-      <dependency>
+      <!-- <dependency>
         <groupId>jakarta.tck</groupId>
         <artifactId>tags-tck</artifactId>
         <version>${project.version}</version>
-      </dependency>
+      </dependency> -->
       <dependency>
         <groupId>jakarta.tck</groupId>
         <artifactId>websocket-tck-platform-tests</artifactId>

--- a/glassfish-runner/pom.xml
+++ b/glassfish-runner/pom.xml
@@ -62,7 +62,7 @@
         <module>rest-platform-extra-tck</module>
         <module>rest-tck</module>
         <module>servlet-tck</module>
-        <module>tags-tck</module>
+        <!-- <module>tags-tck</module> -->
         <module>transactions-tck</module>
         <module>validation-tck</module>
         <module>websocket-platform-extra-tck</module>

--- a/pom.xml
+++ b/pom.xml
@@ -57,8 +57,8 @@
         <module>tcks/apis/persistence/persistence-inside-container</module>
         <module>tcks/apis/persistence/persistence-outside-container</module>
         <module>tcks/apis/rest</module>
-        <module>tcks/apis/tags</module>
-        <module>tcks/apis/tags/docs</module>
+        <!-- <module>tcks/apis/tags</module>
+        <module>tcks/apis/tags/docs</module> -->
         <module>tcks/apis/transactions</module>
         <module>tcks/apis/transactions/docs</module>
         <module>tcks/apis/websocket</module>

--- a/release/pom.xml
+++ b/release/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021  Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2025  Contributors to the Eclipse Foundation
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -204,7 +204,7 @@
             <version>${project.version}</version>
             <classifier>sources</classifier>
         </dependency>
-        <dependency>
+        <!-- <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>tags-tck</artifactId>
         </dependency>
@@ -213,7 +213,7 @@
             <artifactId>tags-tck</artifactId>
             <version>${project.version}</version>
             <classifier>sources</classifier>
-        </dependency>
+        </dependency> -->
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>signaturetest</artifactId>


### PR DESCRIPTION
**Fixes Issue**
N/A (or TODO)

**Related Issue(s)**
Related https://github.com/jakartaee/platform-tck/issues/2500

**Describe the change**
Scott discussed ignore Tags in the Platform TCK, and I looked over the poms. I think what i have ought to be enough though. Scott mentioned the poms in the docs directory, but I commented the modules out instead.  I didn't remove the text as the tags source still reside here.

**Additional context**
I'm encountering build errors? Is it just me? I would like to be able to check my work, if possible. 
```
[ERROR]   The project jakarta.tck:websocket-tck-platform-tests:12.0.0-SNAPSHOT (/Users/volosied/opensource/platform-tck/tcks/apis/websocket/pom.xml) has 4 errors
[ERROR]     'dependencies.dependency.version' for jakarta.tck:websocket-tck-common:jar is missing. @ line 34, column 21
[ERROR]     'dependencies.dependency.version' for jakarta.inject:jakarta.inject-api:jar is missing. @ line 38, column 21
[ERROR]     'dependencies.dependency.version' for jakarta.enterprise:jakarta.enterprise.cdi-api:jar is missing. @ line 42, column 21
[ERROR]     'dependencies.dependency.version' for jakarta.servlet:jakarta.servlet-api:jar is missing. @ line 46, column 21
[ERROR] 
```

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
