### PR TITLE
release TCK common 11.1.1-M1

### DIFF
--- a/release/pom.xml
+++ b/release/pom.xml
@@ -416,6 +416,16 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
+                    <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/tools/common/pom.xml
+++ b/tools/common/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>jakarta.tck</groupId>
     <artifactId>common</artifactId>
-    <version>11.1.1-SNAPSHOT</version>
+    <version>11.1.1-M1</version>
     <packaging>jar</packaging>
 
     <name>TCK Tools Common</name>
@@ -201,7 +201,16 @@
                     </execution>
                 </executions>
             </plugin>
-
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <publishingServerId>central</publishingServerId>
+                    <autoPublish>true</autoPublish>
+                    <waitUntil>published</waitUntil>
+                    <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2505

**Describe the change**
Switch to use jakarta.tck:common:11.1.1 which needs to be released as an after step if the release of TCK Common 11.1.1-M1 is successful.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
