### PR TITLE
Switch to released TCK common 11.1.1-M1 (include pr#2470 to remove @Transactional from Persistence Vehicles)

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -43,7 +43,7 @@
     <!-- The Arquillian protocol artifacts -->
     <jakarta.tck.arquillian.version>11.1.2</jakarta.tck.arquillian.version>
     <!-- The released version of tools/common -->
-    <jakarta.tck.common.version>11.1.0</jakarta.tck.common.version>
+    <jakarta.tck.common.version>11.1.1-M1</jakarta.tck.common.version>
     <!-- The released version of tools/signaturetest -->
     <jakarta.tck.sigtest.version>11.1.0</jakarta.tck.sigtest.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <!-- The Arquillian protocol artifacts -->
         <jakarta.tck.arquillian.version>11.1.2</jakarta.tck.arquillian.version>
         <!-- The released version of tools/common -->
-        <jakarta.tck.common.version>11.1.0</jakarta.tck.common.version>
+        <jakarta.tck.common.version>11.1.1-M1</jakarta.tck.common.version>
         <!-- The released version of tools/signaturetest -->
         <jakarta.tck.sigtest.version>11.1.0</jakarta.tck.sigtest.version>
     </properties>


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2512

**Describe the change**
Switch to released TCK common 11.1.1-M1

**Additional context**
https://github.com/jakartaee/platform-tck/issues/2475 is the parent issue prepare for building snapshot of EE 11 Platform TCK

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
