### PR TITLE
Skip deploy of the Persistence 3.2 standalone TCK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,6 +320,10 @@
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
                     <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
+                    <excludeArtifacts>
+                        <!-- skip deploy of the standalone Persistence 3.2 TCK https://github.com/jakartaee/platform-tck/issues/2514  --> 
+                        <exclude>jakarta.tck:persistence-tck</exclude>
+                    </excludeArtifacts>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2514

**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/2475

**Describe the change**
When deploying the Platform TCK via https://ci.eclipse.org/jakartaee-tck/job/11/job/stage-artifacts/job/TCKDistRelease/ do not deploy the Standalone Persistence 3.2 TCK


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
