### PR TITLE
Skip build of the Persistence 3.2 standalone TCK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,9 @@
         <module>tcks/apis/messaging/messaging-outside-container</module>
         <module>tcks/apis/pages</module>
         <module>tcks/apis/persistence/persistence-inside-container</module>
-        <module>tcks/apis/persistence/persistence-outside-container</module>
+        <!-- skip deploy of the standalone Persistence 3.2 TCK https://github.com/jakartaee/platform-tck/issues/2514   
+           <module>tcks/apis/persistence/persistence-outside-container</module>
+        -->
         <module>tcks/apis/rest</module>
         <module>tcks/apis/tags</module>
         <module>tcks/apis/tags/docs</module>


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2514 

**Describe the change**
Skip build of the Persistence 3.2 standalone TCK so we can deploy the EE 11 Platform TCK.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
