### PR TITLE
Skip build of the Persistence 3.2 standalone TCK by moving to profile persistence-outside-container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,10 +319,6 @@
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
                     <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
-                    <excludeArtifacts>
-                        <!-- skip deploy of the standalone Persistence 3.2 TCK https://github.com/jakartaee/platform-tck/issues/2514  --> 
-                        <exclude>jakarta.tck:persistence-tck</exclude>
-                    </excludeArtifacts>
                 </configuration>
             </plugin>
 


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2514 

**Describe the change**
Skip build of the Persistence 3.2 standalone TCK by moving to profile persistence-outside-container.

`mvn clean install -Ppersistence-outside-container` will build the Platform TCK with the standalone Persistence TCK.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
