### PR TITLE
Address Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy failure for websocket-tck-platform-tests

### DIFF
--- a/tcks/apis/to-move/websocket-component-tck/docs/parent/pom.xml
+++ b/tcks/apis/to-move/websocket-component-tck/docs/parent/pom.xml
@@ -106,16 +106,6 @@
                 </plugin>
 
                 <plugin>
-                    <groupId>org.sonatype.plugins</groupId>
-                    <artifactId>nexus-staging-maven-plugin</artifactId>
-                    <version>1.6.13</version>
-                    <configuration>
-                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
-                        <!-- Skip based on the maven.deploy.skip property -->
-                        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>3.7.1</version>


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2518

**Describe the change**
Address Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy failure for websocket-tck-platform-tests


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
