### PR TITLE
Address Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy failure for websocket-tck-platform-tests

### DIFF
--- a/tcks/apis/websocket/pom.xml
+++ b/tcks/apis/websocket/pom.xml
@@ -25,14 +25,16 @@
         <relativePath/>
     </parent>
 
+    <groupId>jakarta.tck</groupId>
     <artifactId>websocket-tck-platform-tests</artifactId>
-    <packaging>jar</packaging>
-    <name>Jakarta Websocket TCK Platform Tests</name>
     <version>11.0.2-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>Jakarta Websocket TCK Platform Tests</name>
+    <description>Jakarta WebSocket Platform TCK Tests</description>
 
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
-        <jakarta.tck.version>11.0.2-SNAPSHOT</jakarta.tck.version>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2518

**Describe the change**
The `tcks/apis/websocket/pom.xml` parent was set to an already released artifact (`tcks/apis/to-move/websocket-component-tck/pom.xml`) that used the old 1.x org.eclipse.ee4j:project.  

As a result, we got the `Failed to execute goal org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy failure for websocket-tck-platform-tests` failure.

The fix is to merge the needed parts of tcks/apis/to-move/websocket-component-tck/pom.xml that we need to build `tcks/apis/websocket/pom.xml`.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
