### PR TITLE
https://github.com/jakartaee/platform-tck/issues/2523 exclude jakarta.tck:smoke-tests from being deployed to sonatype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,12 @@
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>jakarta.tck</groupId>
+                            <artifactId>smoke-tests</artifactId>
+                        </exclusion>
+                    </exclusions>
                     <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
                 </configuration>
             </plugin>


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2523

**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/2523

**Describe the change**
Exclude jakarta.tck:smoke-tests (tools/smoke) from being deployed to sonatype

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
