### PR TITLE
Reapply "exclude jakarta.tck:smoke-tests from being deployed to sonatype"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -318,6 +318,12 @@
                     <publishingServerId>central</publishingServerId>
                     <autoPublish>true</autoPublish>
                     <waitUntil>published</waitUntil>
+                    <exclusions>
+                        <exclusion>
+                            <groupId>jakarta.tck</groupId>
+                            <artifactId>smoke-tests</artifactId>
+                        </exclusion>
+                    </exclusions>
                     <centralSnapshotsUrl>https://central.sonatype.com/repository/maven-snapshots/</centralSnapshotsUrl>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Try excluding the smoke tests in both the tool/smoke/pom.xml + the root project pom.xml which is the parent pom for tool/smoke/pom.xml

This reverts commit 76f7518994f2682406ecd751816ff520f38b63a7.

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2523


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
