### PR TITLE
Inline the smoke-tests parent pom and instead use org.eclipse.ee4j as parent and hope Maven doesn't try to deploy the smoke-tests

### DIFF
--- a/tools/smoke/pom.xml
+++ b/tools/smoke/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2021  Contributors to the Eclipse Foundation
+    Copyright (c) 2021, 2025  Contributors to the Eclipse Foundation
     All rights reserved.
 
     This program and the accompanying materials are made available under the
@@ -20,14 +20,15 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>jakarta.tck</groupId>
+        <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>11.0.2-SNAPSHOT</version>
-        <relativePath>../../pom.xml</relativePath>
+        <version>2.0.0-M1</version>
     </parent>
 
+    <groupId>jakarta.tck</groupId>
     <artifactId>smoke-tests</artifactId>
     <packaging>jar</packaging>
+    <version>11.0.2-SNAPSHOT</version>
 
     <name>Smoke Tests</name>
     <description>Basic Smoke Tests</description>
@@ -37,6 +38,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>17</maven.compiler.release>
+
+        <jakarta.jakartaee-bom.version>11.0.0</jakarta.jakartaee-bom.version>
     </properties>
 
     <dependencyManagement>
@@ -48,6 +51,13 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+            <dependency>
+                <groupId>jakarta.tck</groupId>
+                <artifactId>artifacts-bom</artifactId>
+                <version>${project.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+             </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -56,9 +66,11 @@
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
         </dependency>
+
+       <!-- Junit5 -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter-engine</artifactId>
+            <artifactId>junit-jupiter</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -72,6 +84,11 @@
                 <configuration>
                     <skipPublishing>true</skipPublishing>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.5.3</version>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION


**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2523

**Describe the change**
Inline the smoke-tests parent pom and instead use org.eclipse.ee4j as parent

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
