### PR TITLE
Exclude deploying of component TCK doc artifacts for connector/tags/messaging/transactions/el doc artifacts to avoid already deployed failure

### DIFF
--- a/tcks/apis/connector/docs/pom.xml
+++ b/tcks/apis/connector/docs/pom.xml
@@ -33,13 +33,21 @@
     <name>connector tck</name>
     <description>Connector docs</description>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <modules>
         <module>parent</module>
         <module>userguide</module>
     </modules>
 
+    <build>
+        <plugins>
+            <!-- do not publish this artifact to Maven repositories -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/tcks/apis/expression-language/expression-language-inside-container/docs/userguide/pom.xml
+++ b/tcks/apis/expression-language/expression-language-inside-container/docs/userguide/pom.xml
@@ -196,6 +196,15 @@
                     </execution>
                 </executions>
             </plugin>
+            <!-- do not publish this artifact to Maven repositories -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+    
 	    </plugins>
 
         <pluginManagement>

--- a/tcks/apis/messaging/messaging-inside-container/docs/pom.xml
+++ b/tcks/apis/messaging/messaging-inside-container/docs/pom.xml
@@ -33,13 +33,22 @@
     <name>messaging tck</name>
     <description>Messaging docs</description>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <modules>
         <module>parent</module>
         <module>userguide</module>
     </modules>
+
+     <build>
+        <plugins>
+            <!-- do not publish this artifact to Maven repositories -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/tcks/apis/tags/docs/pom.xml
+++ b/tcks/apis/tags/docs/pom.xml
@@ -33,13 +33,22 @@
     <name>tags tck</name>
     <description>tags docs</description>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <modules>
         <module>parent</module>
         <module>userguide</module>
     </modules>
+
+    <build>
+        <plugins>
+            <!-- do not publish this artifact to Maven repositories -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/tcks/apis/transactions/docs/pom.xml
+++ b/tcks/apis/transactions/docs/pom.xml
@@ -33,13 +33,22 @@
     <name>transaction tck</name>
     <description>Transaction docs</description>
 
-    <properties>
-        <maven.deploy.skip>true</maven.deploy.skip>
-    </properties>
-
     <modules>
         <module>parent</module>
         <module>userguide</module>
     </modules>
+
+     <build>
+        <plugins>
+            <!-- do not publish this artifact to Maven repositories -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2529 

**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/2475

**Describe the change**
Exclude deploying of component TCK doc artifacts for connector/tags/messaging/transactions/el doc artifacts to avoid already deployed failure

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
