### PR TITLE
Address TCK challenge 2497 by excluding ee.jakarta.tck.persistence.core.metamodelapi.identifiabletype.Client*#getDeclaredSingularAttributes()

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientAppmanagedTest.java
@@ -13,6 +13,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -510,6 +511,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.metamo
             super.getDeclaredSingularAttributeStringIllegalArgumentException();
         }
 
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2497")
         @Test
         @Override
         @TargetVehicle("appmanaged")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientAppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientAppmanagednotxTest.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -516,6 +517,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.me
             super.getDeclaredSingularAttributeStringIllegalArgumentException();
         }
 
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2497")
         @Test
         @Override
         @TargetVehicle("appmanagedNoTx")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientPmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientPmservletTest.java
@@ -12,6 +12,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -460,6 +461,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.metamod
             super.getDeclaredSingularAttributeStringIllegalArgumentException();
         }
 
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2497")
         @Test
         @Override
         @TargetVehicle("pmservlet")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientPuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientPuservletTest.java
@@ -12,6 +12,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -460,6 +461,7 @@ public class ClientPuservletTest extends ee.jakarta.tck.persistence.core.metamod
             super.getDeclaredSingularAttributeStringIllegalArgumentException();
         }
 
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2497")
         @Test
         @Override
         @TargetVehicle("puservlet")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientStateful3Test.java
@@ -13,6 +13,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -510,6 +511,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.metamod
             super.getDeclaredSingularAttributeStringIllegalArgumentException();
         }
 
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2497")
         @Test
         @Override
         @TargetVehicle("stateful3")

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientStateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/metamodelapi/identifiabletype/ClientStateless3Test.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -517,6 +518,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.metamo
             super.getDeclaredSingularAttributeStringIllegalArgumentException();
         }
 
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2497")
         @Test
         @Override
         @TargetVehicle("stateless3")


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2497

**Related Issue(s)**
These tests were excluded from Jakarta EE 8-10.  

**Describe the change**
Exclude the getDeclaredSingularAttributes method as it was excluded in previous releases.

**Additional context**
The test failure is addressed for EE 12.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
