### PR TITLE
Exclude tcks/apis/persistence/persistence-outside-container/docs/parent from release

### DIFF
--- a/tcks/apis/persistence/persistence-outside-container/docs/parent/pom.xml
+++ b/tcks/apis/persistence/persistence-outside-container/docs/parent/pom.xml
@@ -114,6 +114,16 @@
                 </plugin>
                 
                 <plugin>
+                    <groupId>org.sonatype.plugins</groupId>
+                    <artifactId>nexus-staging-maven-plugin</artifactId>
+                    <version>1.7.0</version>
+                    <configuration>
+                        <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        <!-- Skip based on the maven.deploy.skip property -->
+                        <skipNexusStagingDeployMojo>true</skipNexusStagingDeployMojo>
+                    </configuration>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
                     <version>3.7.1</version>


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2478

**Describe the change**
Address ` Eclipse Foundation Technology Compatibility Kit User's Guide Parent for Jakarta Persistence for Jakarta EE, Release 3.2 3.2.1 3.2.1 FAILURE` from https://ci.eclipse.org/jakartaee-platform/job/JakartaEE-TCK/job/12/job/stage-release-artifacts/job/TCKDistRelease/7/ run.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
