### PR TITLE
Exclude persistencedocfromdeploy

### DIFF
--- a/tcks/apis/persistence/persistence-outside-container/docs/parent/pom.xml
+++ b/tcks/apis/persistence/persistence-outside-container/docs/parent/pom.xml
@@ -215,6 +215,15 @@
         </pluginManagement>
         
         <plugins>
+            <!-- do not publish this artifact to Maven repositories -->
+            <plugin>
+                <groupId>org.sonatype.central</groupId>
+                <artifactId>central-publishing-maven-plugin</artifactId>
+                <configuration>
+                    <skipPublishing>true</skipPublishing>
+                </configuration>
+            </plugin>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
**Fixes Issue**
revert previous incorrect change for https://github.com/jakartaee/platform-tck/issues/2478

**Describe the change**
Address ` Eclipse Foundation Technology Compatibility Kit User's Guide Parent for Jakarta Persistence for Jakarta EE, Release 3.2 3.2.1 3.2.1 FAILURE` from https://ci.eclipse.org/jakartaee-platform/job/JakartaEE-TCK/job/12/job/stage-release-artifacts/job/TCKDistRelease/7/ run.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
