### PR TITLE
Do not build Standalone TCKs for Messaging + Persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,10 +52,10 @@
         <module>tcks/apis/jsonp</module>
         <module>tcks/apis/messaging/messaging-inside-container</module>
         <module>tcks/apis/messaging/messaging-inside-container/docs</module>
-        <module>tcks/apis/messaging/messaging-outside-container</module>
+        <!-- <module>tcks/apis/messaging/messaging-outside-container</module> -->
         <module>tcks/apis/pages</module>
         <module>tcks/apis/persistence/persistence-inside-container</module>
-        <module>tcks/apis/persistence/persistence-outside-container</module>
+        <!-- <module>tcks/apis/persistence/persistence-outside-container</module>  -->
         <module>tcks/apis/rest</module>
         <!-- <module>tcks/apis/tags</module>
         <module>tcks/apis/tags/docs</module> -->

--- a/release/src/main/assembly/assembly.xml
+++ b/release/src/main/assembly/assembly.xml
@@ -43,7 +43,7 @@
             <source>../tcks/profiles/platform/docs/userguide/platform/target/generated-docs/Jakarta-Platform-TCK-Users-Guide.pdf</source>
         </file>
         <!--  https://github.com/jakartaee/platform-tck/issues/2043 only include the Platform TCK user guide in the release.  
-              The below TCK user guides are not using when testing EE 11 compatibility.
+              The below TCK user guides are not being released for EE 12.
         <file>
             <outputDirectory>guides</outputDirectory>
             <source>../tcks/apis/transactions/docs/userguide/target/generated-docs/Jakarta-Transactions-TCK-Users-Guide.pdf</source>


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2553 Update EE 12 root pom + release assembly to not include component (standalone) TCKs that are being moved to separate TCK repositories or not being released

**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/2478 Prepare for building snapshot of EE 12 Platform TCK

**Describe the change**
Update to root pom to not include building of the Persistence/Messaging component TCK

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
