### PR TITLE
Fix deployment failure by excluding tags-tck from release

### DIFF
--- a/release/artifact-install.pom
+++ b/release/artifact-install.pom
@@ -346,6 +346,8 @@
                             <generatePom>false</generatePom>
                         </configuration>
                     </execution>
+
+                    <!-- remove Tags TCK from the EE 12 release since it moved to the Jakarta Tags repository.
                     <execution>
                         <id>install-tags-tck</id>
                         <phase>package</phase>
@@ -361,6 +363,7 @@
                             <generatePom>false</generatePom>
                         </configuration>
                     </execution>
+                    -->
 
                     <execution>
                         <id>install-signaturetest</id>


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2562

**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/2478

**Describe the change**
Do not try to release the tags-tck to avoid failure:

> Failed to execute goal org.apache.maven.plugins:maven-install-plugin:3.1.3:install-file (install-tags-tck) on project platform-tck-artifacts: The specified file '/home/jenkins/agent/workspace/JakartaEE-TCK/12/stage-release-artifacts/TCKDistRelease/release/target/jakartaeetck/artifacts/tags-tck-12.0.0-SNAPSHOT.jar' does not exist -


**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
