### PR TITLE
TCK Challenge: com.sun.ts.tests.assembly.classpath tests are invalid -- no longer testing intended function

### DIFF
--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/classpath/appclient/Client.java
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/classpath/appclient/Client.java
@@ -44,6 +44,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,6 +54,7 @@ import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 @Tag("platform")
 @Tag("tck-appclient")
 @ExtendWith(ArquillianExtension.class)
+@Disabled("https://github.com/jakartaee/platform-tck/issues/2493")
 public class Client extends EETest {
 
   private TSNamingContext nctx = null;

--- a/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/classpath/ejb/Client.java
+++ b/tcks/profiles/platform/assembly/src/main/java/com/sun/ts/tests/assembly/classpath/ejb/Client.java
@@ -38,6 +38,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -47,6 +48,7 @@ import tck.arquillian.porting.lib.spi.TestArchiveProcessor;
 @Tag("platform")
 @Tag("tck-appclient")
 @ExtendWith(ArquillianExtension.class)
+@Disabled("https://github.com/jakartaee/platform-tck/issues/2493")
 public class Client extends EETest {
 
   /** JNDI Name we use to lookup the bean */


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2493

**Describe the change**
Exclude mentioned tests for EE 11

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
