### PR TITLE
Correct conditions checked for in WebVehicleRunner when producing test failure message for 11.0.x branch

### DIFF
--- a/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/web/WebVehicleRunner.java
+++ b/tools/common/src/main/java/com/sun/ts/tests/common/vehicle/web/WebVehicleRunner.java
@@ -94,9 +94,9 @@ public class WebVehicleRunner implements VehicleRunnable {
 
         if (sServletStatus.isPassed() && sJspStatus.isPassed()) {
             sTestStatus = Status.passed("Test passed in a servlet and in a jsp");
-        } else if (sServletStatus.isFailed() && sServletStatus.isFailed()) {
+        } else if (sServletStatus.isFailed() && sJspStatus.isFailed()) {
             sTestStatus = Status.failed("Test failed in a servlet and in a jsp");
-        } else if (sJspStatus.isFailed()) {
+        } else if (sServletStatus.isFailed()) {
             sTestStatus = Status.failed("Test passed in a jsp but failed in a servlet");
         } else {
             sTestStatus = Status.failed("Test passed in a servlet but failed in a jsp");


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2572

Currently the error message may be incorrect for example:

>     [INFO] Running ee.jakarta.tck.persistence.core.entityManager2.Client2PuservletTest
>     [INFO] Tests run: 3, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 1.570 s -- in ee.jakarta.tck.persistence.core.entityManager2.Client2PuservletTest
>     [INFO] Running ee.jakarta.tck.persistence.core.entityManager2.Client2Stateless3Test
>     [ERROR] Tests run: 3, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 41.63 s <<< FAILURE! -- in ee.jakarta.tck.persistence.core.entityManager2.Client2Stateless3Test
>     [ERROR] ee.jakarta.tck.persistence.core.entityManager2.Client2Stateless3Test.lockTransactionRequiredException2Test -- Time elapsed: 13.17 s <<< ERROR!
>     java.lang.Exception: Test failed in a servlet and in a jsp
>     at tck.arquillian.protocol.appclient.AppClientMethodExecutor.invoke(AppClientMethodExecutor.java:178)
>     at org.jboss.arquillian.container.test.impl.execution.RemoteTestExecuter.execute(RemoteTestExecuter.java:102)
>     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
>     at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:85)
>     at org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:102)
>     at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:89)
>     at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:133)
>     at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:105)
>     at org.jboss.arquillian.core.impl.EventImpl.fire(EventImpl.java:61)
>     at org.jboss.arquillian.container.test.impl.execution.ClientTestExecuter.execute(ClientTestExecuter.java:51)
>     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
>     at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:85)
>     at org.jboss.arquillian.core.impl.EventContextImpl.invokeObservers(EventContextImpl.java:102)
>     at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:89)
>     at org.jboss.arquillian.container.test.impl.client.ContainerEventController.createContext(ContainerEventController.java:127)
>     at org.jboss.arquillian.container.test.impl.client.ContainerEventController.createTestContext(ContainerEventController.java:117)
>     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
>     at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:85)
>     at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:94)
>     at org.jboss.arquillian.test.impl.TestContextHandler.createTestContext(TestContextHandler.java:115)
>     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
>     at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:85)
>     at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:94)
>     at org.jboss.arquillian.test.impl.TestContextHandler.createClassContext(TestContextHandler.java:82)
>     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
>     at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:85)
>     at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:94)
>     at org.jboss.arquillian.test.impl.TestContextHandler.createSuiteContext(TestContextHandler.java:68)
>     at java.base/java.lang.reflect.Method.invoke(Method.java:565)
>     at org.jboss.arquillian.core.impl.ObserverImpl.invoke(ObserverImpl.java:85)
>     at org.jboss.arquillian.core.impl.EventContextImpl.proceed(EventContextImpl.java:94)
>     at org.jboss.arquillian.core.impl.ManagerImpl.fire(ManagerImpl.java:133)
>     at org.jboss.arquillian.test.impl.EventTestRunnerAdaptor.test(EventTestRunnerAdaptor.java:138)
>     at org.jboss.arquillian.junit5.ArquillianExtension.interceptInvocation(ArquillianExtension.java:265)
>     at org.jboss.arquillian.junit5.ArquillianExtension.interceptTestMethod(ArquillianExtension.java:167)
>     at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
>     at java.base/java.util.ArrayList.forEach(ArrayList.java:1604)
> 
>     [ERROR] ee.jakarta.tck.persistence.core.entityManager2.Client2Stateless3Test.lockTransactionRequiredExceptionTest -- Time elapsed: 13.08 s <<< ERROR!
>     java.lang.Exception: Test failed in a servlet and in a jsp
>     at tck.arquillian.protocol.appclient.AppClientMethodExecutor.invoke(AppClientMethodExecutor.java:178)
>     at org.jboss.arquillian.container.test.impl.execution.RemoteTestExecuter.execute(RemoteTestExecuter.java:102)
> 

**Describe the change**
Update the logic to produce a correct error message.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
