### PR TITLE
[jakartaee/persistence#714] TCK should not try declare generator with  same name multiple times

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/DataTypes2.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/DataTypes2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity
@@ -57,7 +56,6 @@ public class DataTypes2 implements java.io.Serializable {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQGENERATOR")
-	@SequenceGenerator(name = "SEQGENERATOR", allocationSize = 1, initialValue = 10)
 	@Column(name = "ID")
 	public int getId() {
 		return id;

--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/DataTypes4.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/DataTypes4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity
@@ -44,7 +43,6 @@ public class DataTypes4 implements java.io.Serializable {
 	}
 
 	@Id
-	@SequenceGenerator(name = "SEQGENERATOR", allocationSize = 1, initialValue = 10)
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQGENERATOR")
 	@Column(name = "ID")
 	public int getId() {

--- a/tcks/apis/persistence/persistence-outside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/DataTypes2.java
+++ b/tcks/apis/persistence/persistence-outside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/DataTypes2.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,7 +21,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity
@@ -57,7 +56,6 @@ public class DataTypes2 implements java.io.Serializable {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQGENERATOR")
-	@SequenceGenerator(name = "SEQGENERATOR", allocationSize = 1, initialValue = 10)
 	@Column(name = "ID")
 	public int getId() {
 		return id;

--- a/tcks/apis/persistence/persistence-outside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/DataTypes4.java
+++ b/tcks/apis/persistence/persistence-outside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/types/generator/DataTypes4.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,6 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.SequenceGenerator;
 import jakarta.persistence.Table;
 
 @Entity
@@ -44,7 +43,6 @@ public class DataTypes4 implements java.io.Serializable {
 	}
 
 	@Id
-	@SequenceGenerator(name = "SEQGENERATOR", allocationSize = 1, initialValue = 10)
 	@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "SEQGENERATOR")
 	@Column(name = "ID")
 	public int getId() {


### PR DESCRIPTION
**Fixes Issue**
TCK challenge https://github.com/jakartaee/persistence/issues/714 is accepted and this change should work for Hibernate ORM and other implementations.

**Describe the change**
TCK should not try declare generator with same name multiple times

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
