### PR TITLE
Address Platform TCK challenge for lockTransactionRequiredException tests in ee.jakarta.tck.persistence.core.entityManager2

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/entityManager2/Client2.java
@@ -92,6 +92,8 @@ public class Client2 extends PMClientBase {
 	 * 
 	 * @assertion_ids: PERSISTENCE:JAVADOC:491; PERSISTENCE:JAVADOC:492;
 	 * PERSISTENCE:JAVADOC:498; PERSISTENCE:JAVADOC:499
+	 * IllegalArgumentException may also be thrown by lock method as per
+	 * jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/entitymanager#lock(java.lang.Object,jakarta.persistence.LockModeType)
 	 * 
 	 * @test_Strategy: Call EntityManager.lock() method
 	 */
@@ -111,6 +113,9 @@ public class Client2 extends PMClientBase {
 		} catch (TransactionRequiredException e) {
 			logTrace( "TransactionRequiredException Caught as Expected.");
 			pass1 = true;
+		} catch (IllegalArgumentException e) {
+			logTrace( "IllegalArgumentException caught which can also be thrown from lock call.");
+			pass1 = true;
 		} catch (Exception e) {
 			logErr( "Unexpected exception occurred", e);
 		}
@@ -122,6 +127,9 @@ public class Client2 extends PMClientBase {
 			logErr( "TransactionRequiredException not thrown");
 		} catch (TransactionRequiredException e) {
 			logTrace( "TransactionRequiredException Caught as Expected.");
+			pass2 = true;
+		} catch (IllegalArgumentException e) {
+			logTrace( "IllegalArgumentException caught which can also be thrown from lock call.");
 			pass2 = true;
 		} catch (Exception e) {
 			logErr( "Unexpected exception occurred", e);
@@ -200,6 +208,8 @@ public class Client2 extends PMClientBase {
 	 * @testName: lockTransactionRequiredException2Test
 	 * 
 	 * @assertion_ids: PERSISTENCE:SPEC:1313;
+	 * IllegalArgumentException may also be thrown by lock method as per
+	 * jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/entitymanager#lock(java.lang.Object,jakarta.persistence.LockModeType)
 	 *
 	 * @test_Strategy: Call EntityManager.lock() method without a transaction
 	 */
@@ -217,6 +227,9 @@ public class Client2 extends PMClientBase {
 			logErr( "TransactionRequiredException not thrown");
 		} catch (TransactionRequiredException tre) {
 			logTrace( "TransactionRequiredException Caught as Expected.");
+			pass1 = true;
+		} catch (IllegalArgumentException e) {
+			logTrace( "IllegalArgumentException caught which can also be thrown from lock call.");
 			pass1 = true;
 		} catch (Exception e) {
 			logErr( "Unexpected exception occurred", e);
@@ -241,6 +254,9 @@ public class Client2 extends PMClientBase {
 			logErr( "TransactionRequiredException not thrown");
 		} catch (TransactionRequiredException tre) {
 			logTrace( "TransactionRequiredException Caught as Expected.");
+			pass2 = true;
+		} catch (IllegalArgumentException e) {
+			logTrace( "IllegalArgumentException caught which can also be thrown from lock call.");
 			pass2 = true;
 		} catch (Exception e) {
 			logErr( "Unexpected exception occurred", e);


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2580

**Related Issue(s)**
https://github.com/jakartaee/persistence/issues/754

**Describe the change**
This change fixes the test problem by also treating IllegalArgumentException thrown by the EntityManager.lock call as passing the tests.  Quoting from https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/entitymanager#lock(java.lang.Object,jakarta.persistence.LockModeType,java.util.Map)

> Throws:
>     [IllegalArgumentException](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/IllegalArgumentException.html) - if the instance is not an entity or is a detached entity
>     [TransactionRequiredException](https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/transactionrequiredexception) - if there is no transaction or if invoked on an entity manager which has not been joined to the current transaction
>     [EntityNotFoundException](https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/entitynotfoundexception) - if the entity does not exist in the database when pessimistic locking is performed
>     [OptimisticLockException](https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/optimisticlockexception) - if the optimistic version check fails
>     [PessimisticLockException](https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/pessimisticlockexception) - if pessimistic locking fails and the transaction is rolled back
>     [LockTimeoutException](https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/locktimeoutexception) - if pessimistic locking fails and only the statement is rolled back
>     [PersistenceException](https://jakarta.ee/specifications/persistence/3.2/apidocs/jakarta.persistence/jakarta/persistence/persistenceexception) - if an unsupported lock call is made
> Since:
>     2.0
> 

In EE 11 Platform TCK testing it is perfectly reasonable to use a Persistence Provider that does throw 
IllegalArgumentException when the instance is not an entity or is a detached entity which are expected conditions in the current test.  

**Additional context**

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
