### PR TITLE
switch to use jakarta.tck:common:11.1.1-M2

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -43,7 +43,7 @@
     <!-- The Arquillian protocol artifacts -->
     <jakarta.tck.arquillian.version>11.1.2</jakarta.tck.arquillian.version>
     <!-- The released version of tools/common -->
-    <jakarta.tck.common.version>11.1.1-M1</jakarta.tck.common.version>
+    <jakarta.tck.common.version>11.1.1-M2</jakarta.tck.common.version>
     <!-- The released version of tools/signaturetest -->
     <jakarta.tck.sigtest.version>11.1.0</jakarta.tck.sigtest.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <!-- The Arquillian protocol artifacts -->
         <jakarta.tck.arquillian.version>11.1.2</jakarta.tck.arquillian.version>
         <!-- The released version of tools/common -->
-        <jakarta.tck.common.version>11.1.1-M1</jakarta.tck.common.version>
+        <jakarta.tck.common.version>11.1.1-M2</jakarta.tck.common.version>
         <!-- The released version of tools/signaturetest -->
         <jakarta.tck.sigtest.version>11.1.0</jakarta.tck.sigtest.version>
     </properties>


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2588

**Related Issue(s)**
Working towards https://github.com/jakartaee/platform-tck/issues/2505

**Describe the change**
- Correct conditions checked for in WebVehicleRunner when producing test failure message
- Fix EJB wrappers for AppClient Tests 

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
