### PR TITLE
Fix:#2578 : Add null check before flushing objectOutputStream in flushStream method

### DIFF
--- a/tools/common/src/main/java/com/sun/ts/lib/util/TestUtil.java
+++ b/tools/common/src/main/java/com/sun/ts/lib/util/TestUtil.java
@@ -302,7 +302,9 @@ public final class TestUtil {
     public static void flushStream() {
         synchronized (socketMutex) {
             try {
-                objectOutputStream.flush();
+                if (objectOutputStream != null) {
+                    objectOutputStream.flush();
+                }
             } catch (Throwable t) {
                 // Ignore
                 // System.out.println("EXCEPTION WHILE FLUSHING");


### PR DESCRIPTION
**Fixes Issue**
Fixes : #2578

**Describe the change**
During local TCK testing, the issue was caused by code throwing a NullPointerException because the field had not been initialized. Adding a null check resolves the problem.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
