### PR TITLE
address Platform issues/2593 TCK challenge 

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientAppmanagedTest.java
@@ -13,6 +13,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -235,6 +236,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
         @Test
         @Override
         @TargetVehicle("appmanaged")
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2593")
         public void elementCollectionTest() throws java.lang.Exception {
             super.elementCollectionTest();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientPmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientPmservletTest.java
@@ -12,6 +12,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -181,6 +182,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.annotat
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2593")
         public void elementCollectionTest() throws java.lang.Exception {
             super.elementCollectionTest();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateful3Test.java
@@ -13,6 +13,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -235,6 +236,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
         @Test
         @Override
         @TargetVehicle("stateful3")
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2593")
         public void elementCollectionTest() throws java.lang.Exception {
             super.elementCollectionTest();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeyenumerated/ClientStateless3Test.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -242,6 +243,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
         @Test
         @Override
         @TargetVehicle("stateless3")
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2593")
         public void elementCollectionTest() throws java.lang.Exception {
             super.elementCollectionTest();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientAppmanagedTest.java
@@ -13,6 +13,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -223,6 +224,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.annota
         @Test
         @Override
         @TargetVehicle("appmanaged")
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2593")
         public void elementCollectionTest() throws java.lang.Exception {
             super.elementCollectionTest();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientPmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientPmservletTest.java
@@ -12,6 +12,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -170,6 +171,7 @@ public class ClientPmservletTest extends ee.jakarta.tck.persistence.core.annotat
         @Test
         @Override
         @TargetVehicle("pmservlet")
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2593")
         public void elementCollectionTest() throws java.lang.Exception {
             super.elementCollectionTest();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateful3Test.java
@@ -13,6 +13,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -223,6 +224,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.annotat
         @Test
         @Override
         @TargetVehicle("stateful3")
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2593")
         public void elementCollectionTest() throws java.lang.Exception {
             super.elementCollectionTest();
         }

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/annotations/mapkeytemporal/ClientStateless3Test.java
@@ -14,6 +14,7 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -230,6 +231,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.annota
         @Test
         @Override
         @TargetVehicle("stateless3")
+        @Disabled("https://github.com/jakartaee/platform-tck/issues/2593")
         public void elementCollectionTest() throws java.lang.Exception {
             super.elementCollectionTest();
         }


### PR DESCRIPTION
for ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.ClientPmservletTest.elementCollectionTest, ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.ClientPmservletTest.elementCollectionTest, ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.ClientAppmanagedTest.elementCollectionTest , ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.ClientAppmanagedTest.elementCollectionTest , ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.ClientStateful3Test.elementCollectionTest , ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.ClientStateful3Test.elementCollectionTest , ee.jakarta.tck.persistence.core.annotations.mapkeyenumerated.ClientStateless3Test.elementCollectionTest, ee.jakarta.tck.persistence.core.annotations.mapkeytemporal.ClientStateless3Test.elementCollectionTest

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2593

**Describe the change**
Address TCK challenge https://github.com/jakartaee/platform-tck/issues/2593 by excluding Persistence tests that were previously excluded for earlier Jakarta EE 8-10 releases.  

**Additional context**
The tests haven't been updated as of yet.  

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
