### PR TITLE
[2548] Allow the Chrome driver to be overridden with a system property.

### DIFF
--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/selenium/ChromeDevtoolsDriver.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/selenium/ChromeDevtoolsDriver.java
@@ -519,10 +519,14 @@ public class ChromeDevtoolsDriver implements ExtendedWebDriver {
 
     public static ExtendedWebDriver stdInit() {
         Locale.setDefault(new Locale("en", "US"));
-        WebDriverManager.chromedriver().setup();
         initCDPVersionMessageFilter();
 
         ChromeOptions options = new ChromeOptions();
+
+        String chromedriverVersion = System.getProperty("chromedriver.version");
+        if (chromedriverVersion != null && !chromedriverVersion.isEmpty()) {
+            options.setBrowserVersion(chromedriverVersion);
+        }
 
         // we can turn on a visual browser by
         // adding chromedriver.headless = false to our properties


### PR DESCRIPTION
**Fixes Issue**
resolves #2548 

**Related Issue(s)**
N/A

**Describe the change**
This adds a system property, the same one used in the Jakarta Faces TCK, to explicitly set the version of the Chrome Driver to be used.

**Additional context**
This is the main branch version of the challenge for #2548 that was resolved in #2598.
