### PR TITLE
Install the whiteboxes for EJB, as the Eclipse mirror failed

### DIFF
--- a/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-install/pom.xml
+++ b/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-install/pom.xml
@@ -109,6 +109,36 @@
                             <packaging>jar</packaging>
                         </configuration>
                     </execution>
+                    
+                    <execution>
+                        <id>install-whitebox-tx</id>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <file>${project.build.directory}/jakartaeetck/artifacts/whitebox-tx-${tck.test.enterprise-beans.version}.rar</file>
+                            <groupId>jakarta.tck</groupId>
+                            <artifactId>whitebox-tx</artifactId>
+                            <version>${tck.test.enterprise-beans.version}</version>
+                            <packaging>rar</packaging>
+                        </configuration>
+                    </execution>
+                    
+                    <execution>
+                        <id>install-whitebox</id>
+                        <goals>
+                            <goal>install-file</goal>
+                        </goals>
+                        <phase>process-resources</phase>
+                        <configuration>
+                            <file>${project.build.directory}/jakartaeetck/artifacts/whitebox-${tck.test.enterprise-beans.version}.jar</file>
+                            <groupId>jakarta.tck</groupId>
+                            <artifactId>whitebox</artifactId>
+                            <version>${tck.test.enterprise-beans.version}</version>
+                            <packaging>jar</packaging>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
 


### PR DESCRIPTION
Should fix

```
[ERROR] Failed to execute goal on project enterprise-beans-tck-run: Could not resolve dependencies for project jakarta.tck:enterprise-beans-tck-run:jar:11.0.1
[ERROR] dependency: jakarta.tck:whitebox-tx:rar:11.0.1 (compile)
[ERROR] 	Could not find artifact jakarta.tck:whitebox-tx:rar:11.0.1 in sonatype-nexus-staging (https://jakarta.oss.sonatype.org/content/repositories/staging/)
[ERROR] 	Could not find artifact jakarta.tck:whitebox-tx:rar:11.0.1 in eclipse.maven.central.mirror (https://repo.eclipse.org/content/repositories/maven_central/)
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/DependencyResolutionException
```

Reason: The Eclipse Mirror is corrupted for the Whitebox, containing only a few files of the whole set: https://repo.eclipse.org/content/repositories/maven_central/jakarta/tck/whitebox-tx/11.0.1/

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
