### PR TITLE
Fix CDI TCK runner

### DIFF
--- a/glassfish-runner/cdi-model-tck/pom.xml
+++ b/glassfish-runner/cdi-model-tck/pom.xml
@@ -19,7 +19,7 @@
         <cdi.tck-4-0.version>4.1.0</cdi.tck-4-0.version>
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0-M12</glassfish.version>
+        <glassfish.version>8.0.0-M15</glassfish.version>
         <maven.compiler.release>17</maven.compiler.release>
         <weld.version>6.0.3.Final</weld.version>
 
@@ -125,17 +125,10 @@
         <dependency>
             <groupId>ee.omnifish.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.2</version>
         </dependency>
-
     </dependencies>
 
-    <repositories>
-        <repository>
-            <id>jakarta-snapshots</id>
-            <url>https://jakarta.oss.sonatype.org/content/repositories/staging/</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/glassfish-runner/cdi-tck/cdi-tck-run/pom.xml
+++ b/glassfish-runner/cdi-tck/cdi-tck-run/pom.xml
@@ -38,8 +38,7 @@
         <cdi.tck-4-1.version>4.1.0</cdi.tck-4-1.version>
         <glassfish.root>${project.build.directory}</glassfish.root>
 
-        <!-- Note M6 still has some failures, future M7 passes all -->
-        <glassfish.version>8.0.0-M9</glassfish.version>
+        <glassfish.version>8.0.0-M15</glassfish.version>
 
         <!-- This matches the htmlunit version in TCK -->
         <htmlunit.version>2.50.0</htmlunit.version>
@@ -240,7 +239,7 @@
         <dependency>
             <groupId>org.glassfish.expressly</groupId>
             <artifactId>expressly</artifactId>
-            <version>6.0.0-M1</version>
+            <version>6.0.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -285,13 +284,14 @@
             <artifactId>shrinkwrap-descriptors-impl-javaee</artifactId>
             <scope>test</scope>
         </dependency>
+        
         <!--
             The Arquillian connector that starts GlassFish and deploys archives to it.
         -->
         <dependency>
-            <groupId>org.omnifaces.arquillian</groupId>
+            <groupId>ee.omnifish.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>1.7</version>
+            <version>2.1.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -306,6 +306,7 @@
                     <testCompilerArgument>-proc:none</testCompilerArgument>
                 </configuration>
             </plugin>
+
             <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <executions>
@@ -324,6 +325,7 @@
                     </execution>
                 </executions>
             </plugin>
+
             <plugin>
                 <artifactId>maven-dependency-plugin</artifactId>
                 <executions>
@@ -408,6 +410,7 @@
                 <version>3.3.0</version>
                 <configuration>
                     <argLine>-Xmx768m</argLine>
+                    
                     <!-- Surefire / TestNG Properties -->
                     <!-- The suite, the exclude and the test dependencies together determine which tests are being run -->
                     <suiteXmlFiles>
@@ -417,6 +420,7 @@
                     <dependenciesToScan>
                         <dependency>jakarta.enterprise:cdi-tck-core-impl</dependency>
                     </dependenciesToScan>
+                    
                     <properties>
                         <property>
                             <name>surefire.testng.verbose</name>
@@ -425,20 +429,26 @@
                     </properties>
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
+                    
                     <!-- System Properties -->
                     <systemPropertyVariables>
                         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
                         <glassfish.enableDerby>true</glassfish.enableDerby>
                         <glassfish.maxHeapSize>2048m</glassfish.maxHeapSize>
                         <glassfish.enableAssertions>:org.jboss.cdi.tck...</glassfish.enableAssertions>
-                        <glassfish.systemProperties>cdiTckExcludeDummy=true
-                            glassfish.servlet.loadAllOnStartup=true</glassfish.systemProperties>
-                        <glassfish.postBootCommands>create-jms-resource --restype jakarta.jms.Queue --property Name=queue_test queue_test
+                        <glassfish.systemProperties>
+                            cdiTckExcludeDummy=true
+                            glassfish.servlet.loadAllOnStartup=true
+                        </glassfish.systemProperties>
+                        <glassfish.postBootCommands>
+                            create-jms-resource --restype jakarta.jms.Queue --property Name=queue_test queue_test
                             create-jms-resource --restype jakarta.jms.Topic --property Name=topic_test topic_test
                             set configs.config.server-config.cdi-service.enable-implicit-cdi=true
-                            create-file-user --groups student --passwordfile ${project.build.directory}/test-classes/password.txt student
-                            create-file-user --groups printer --passwordfile ${project.build.directory}/test-classes/password.txt printer
-                            create-file-user --groups student:alarm --passwordfile ${project.build.directory}/test-classes/password.txt alarm</glassfish.postBootCommands>
+                            --passwordfile ${project.build.directory}/test-classes/password.txt create-file-user --groups student student
+                            --passwordfile ${project.build.directory}/test-classes/password.txt create-file-user --groups printer printer
+                            --passwordfile ${project.build.directory}/test-classes/password.txt create-file-user --groups student:alarm alarm
+                        </glassfish.postBootCommands>
+                        
                         <libPath>${project.build.outputDirectory}</libPath>
                         <org.jboss.cdi.tck.libraryDirectory>${project.build.directory}/dependency/lib</org.jboss.cdi.tck.libraryDirectory>
                         <debugMode>true</debugMode>
@@ -456,6 +466,7 @@
                         <id>run tck</id>
                         <goals>
                             <goal>integration-test</goal>
+                            <goal>verify</goal>
                         </goals>
                         <phase>integration-test</phase>
                     </execution>

--- a/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishBeansImpl.java
+++ b/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishBeansImpl.java
@@ -18,6 +18,7 @@ package org.jboss.weld.tck.glassfish;
 
 import java.io.IOException;
 import java.util.Arrays;
+
 import org.jboss.cdi.tck.spi.Beans;
 
 /**

--- a/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishContextualsImpl.java
+++ b/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishContextualsImpl.java
@@ -17,6 +17,7 @@ package org.jboss.weld.tck.glassfish;
 
 import jakarta.enterprise.context.spi.Context;
 import jakarta.enterprise.context.spi.CreationalContext;
+
 import org.jboss.cdi.tck.spi.Contextuals;
 
 public class GlassFishContextualsImpl implements Contextuals {

--- a/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishCreationalContextsImpl.java
+++ b/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishCreationalContextsImpl.java
@@ -16,6 +16,7 @@
 package org.jboss.weld.tck.glassfish;
 
 import jakarta.enterprise.context.spi.Contextual;
+
 import org.jboss.cdi.tck.spi.CreationalContexts;
 import org.jboss.weld.contexts.CreationalContextImpl;
 

--- a/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishDeploymentExceptionTransformer.java
+++ b/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishDeploymentExceptionTransformer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, 2023 Contributors to the Eclipse Foundation.
+ * Copyright (c) 2022, 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2013, 2020 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -17,13 +17,13 @@
 
 package org.jboss.weld.tck.glassfish;
 
-import java.util.List;
-
-import org.apache.commons.lang.exception.ExceptionUtils;
-import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
-
 import jakarta.enterprise.inject.spi.DefinitionException;
 import jakarta.enterprise.inject.spi.DeploymentException;
+
+import java.util.List;
+
+import org.apache.commons.lang3.exception.ExceptionUtils;
+import org.jboss.arquillian.container.spi.client.container.DeploymentExceptionTransformer;
 
 /**
  *
@@ -35,16 +35,18 @@ import jakarta.enterprise.inject.spi.DeploymentException;
 public class GlassFishDeploymentExceptionTransformer implements DeploymentExceptionTransformer {
 
     private static final String[] DEPLOYMENT_EXCEPTION_FRAGMENTS = new String[] {
-            "Only normal scopes can be passivating",
-            "org.jboss.weld.exceptions.DeploymentException",
-            "org.jboss.weld.exceptions.UnserializableDependencyException",
-            "org.jboss.weld.exceptions.InconsistentSpecializationException",
-            "CDI deployment failure:",
-            "org.jboss.weld.exceptions.NullableDependencyException" };
+        "Only normal scopes can be passivating",
+        "org.jboss.weld.exceptions.DeploymentException",
+        "org.jboss.weld.exceptions.UnserializableDependencyException",
+        "org.jboss.weld.exceptions.InconsistentSpecializationException",
+        "CDI deployment failure:",
+        "org.jboss.weld.exceptions.NullableDependencyException"
+    };
 
-    private static final String[] DEFINITION_EXCEPTION_FRAGMENTS = new String[]
-            { "CDI definition failure:",
-              "org.jboss.weld.exceptions.DefinitionException" };
+    private static final String[] DEFINITION_EXCEPTION_FRAGMENTS = new String[] {
+        "CDI definition failure:",
+        "org.jboss.weld.exceptions.DefinitionException"
+    };
 
     @Override
     public Throwable transform(Throwable throwable) {
@@ -53,11 +55,11 @@ public class GlassFishDeploymentExceptionTransformer implements DeploymentExcept
         // exception and sometimes AS7 exception itself
         @SuppressWarnings("unchecked")
         List<Throwable> throwableList = ExceptionUtils.getThrowableList(throwable);
-        if (throwableList.size() < 1)
+        if (throwableList.isEmpty()) {
             return throwable;
+        }
 
-        Throwable root = null;
-
+        final Throwable root;
         if (throwableList.size() == 1) {
             root = throwable;
         } else {
@@ -84,5 +86,4 @@ public class GlassFishDeploymentExceptionTransformer implements DeploymentExcept
         }
         return false;
     }
-
 }

--- a/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishExtension.java
+++ b/glassfish-runner/cdi-tck/cdi-tck-run/src/test/java/org/jboss/weld/tck/glassfish/GlassFishExtension.java
@@ -1,4 +1,5 @@
 /*
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation.
  * Copyright (c) 2013, 2018 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
@@ -26,13 +27,9 @@ import org.jboss.arquillian.core.spi.LoadableExtension;
  */
 public class GlassFishExtension implements LoadableExtension {
 
-    private static final String GLASSFISH_CLIENTUTILS_CLASS = "org.omnifaces.arquillian.container.glassfish.clientutils.GlassFishClientUtil";
-
     @Override
     public void register(ExtensionBuilder builder) {
-        if (Validate.classExists(GLASSFISH_CLIENTUTILS_CLASS)) {
-            builder.service(DeploymentExceptionTransformer.class, GlassFishDeploymentExceptionTransformer.class);
-        }
+        builder.service(DeploymentExceptionTransformer.class, GlassFishDeploymentExceptionTransformer.class);
     }
 
 }


### PR DESCRIPTION
The GlassFish TCK runner for CDI was silently failing, since the verify goal was not added to the failsafe plugin.

It failed because of a GF Arquillian container that was too old, and a misconfigured exception handler, and the setting of roles.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
