### PR TITLE
Platform TCK challenge 2614: For persistence.core.criteriaapi.From  address IllegalArgumentException: IllegalArgumentException: object is not an instance of declaring class

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1AppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1AppmanagedTest.java
@@ -88,7 +88,7 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client1.class,
             Client1AppmanagedTest.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(resURL != null) {
@@ -127,7 +127,7 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -146,43 +146,7 @@ public class Client1AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client1.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1AppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1AppmanagednotxTest.java
@@ -99,7 +99,7 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client1.class,
             Client1AppmanagednotxTest.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {
@@ -138,7 +138,7 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
                 com.sun.ts.tests.common.vehicle.appmanagedNoTx.AppManagedNoTxVehicleBean.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -157,43 +157,7 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client1.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1Stateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1Stateful3Test.java
@@ -87,7 +87,7 @@ public class Client1Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.From.Client1.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(resURL != null) {
@@ -126,7 +126,7 @@ public class Client1Stateful3Test extends ee.jakarta.tck.persistence.core.criter
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -145,43 +145,7 @@ public class Client1Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client1.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client1Stateless3Test.java
@@ -94,7 +94,7 @@ public class Client1Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.From.Client1.class,
             Client1Stateless3Test.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {
@@ -133,7 +133,7 @@ public class Client1Stateless3Test extends ee.jakarta.tck.persistence.core.crite
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client1.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -152,43 +152,7 @@ public class Client1Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client1.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2AppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2AppmanagedTest.java
@@ -99,7 +99,7 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.From.Client2.class,
             Client2AppmanagedTest.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(resURL != null) {
@@ -138,7 +138,7 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -157,43 +157,7 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client2.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2AppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2AppmanagednotxTest.java
@@ -88,7 +88,7 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client2.class,
             Client2AppmanagednotxTest.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {
@@ -127,7 +127,7 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
                 com.sun.ts.tests.common.vehicle.appmanagedNoTx.AppManagedNoTxVehicleBean.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -146,43 +146,7 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client2.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2Stateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2Stateful3Test.java
@@ -88,7 +88,7 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client2.class,
             Client2Stateful3Test.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(resURL != null) {
@@ -127,7 +127,7 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -146,43 +146,7 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client2.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client2Stateless3Test.java
@@ -99,7 +99,7 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client2.class,
             Client2Stateless3Test.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {
@@ -138,7 +138,7 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client2.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -157,43 +157,7 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client2.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3AppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3AppmanagedTest.java
@@ -89,7 +89,7 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client3.class,
             Client3AppmanagedTest.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(resURL != null) {
@@ -128,7 +128,7 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -147,43 +147,7 @@ public class Client3AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client3.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3AppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3AppmanagednotxTest.java
@@ -88,8 +88,8 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client3.class,
-            Client3AppmanagednotxTest.class)
-            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            Client3AppmanagednotxTest.class
+            );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {
@@ -128,7 +128,7 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
                 com.sun.ts.tests.common.vehicle.appmanagedNoTx.AppManagedNoTxVehicleBean.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -147,43 +147,7 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client3.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3Stateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3Stateful3Test.java
@@ -88,7 +88,7 @@ public class Client3Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.From.Client3.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(resURL != null) {
@@ -127,7 +127,7 @@ public class Client3Stateful3Test extends ee.jakarta.tck.persistence.core.criter
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -146,43 +146,7 @@ public class Client3Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client3.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client3Stateless3Test.java
@@ -88,8 +88,8 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client3.class,
-            Client3Stateless3Test.class)
-            .addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            Client3Stateless3Test.class
+            );
             // The application-client.xml descriptor
             URL resURL = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {
@@ -128,7 +128,7 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client3.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -147,43 +147,7 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client3.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4AppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4AppmanagedTest.java
@@ -88,7 +88,7 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client4.class,
             Client4AppmanagedTest.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(resURL != null) {
@@ -127,7 +127,7 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -146,43 +146,7 @@ public class Client4AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client4.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4AppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4AppmanagednotxTest.java
@@ -88,7 +88,7 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client4.class,
             Client4AppmanagednotxTest.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {
@@ -127,7 +127,7 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
                 com.sun.ts.tests.common.vehicle.appmanagedNoTx.AppManagedNoTxVehicleBean.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -146,43 +146,7 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client4.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4Stateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4Stateful3Test.java
@@ -88,7 +88,7 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client4.class,
             Client4Stateful3Test.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(resURL != null) {
@@ -127,7 +127,7 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.criter
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -146,43 +146,7 @@ public class Client4Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client4.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/From/Client4Stateless3Test.java
@@ -88,7 +88,7 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client4.class,
             Client4Stateless3Test.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {
@@ -127,7 +127,7 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.crite
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client4.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -146,43 +146,7 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriaapi_From = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriaapi_From.jar");
             // The class files
-            jpa_core_criteriaapi_From.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriaapi_From.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client4.class.getResource("persistence.xml");
             if(parURL != null) {


### PR DESCRIPTION
Fixes Issue
https://github.com/jakartaee/platform-tck/issues/2614 by updating the relevant test deployments to only contain the entity classes in the ear/lib (same as Jakarta EE 8/9/10 Platform TCK).

Describe the change
This is for addressing the EE 11 TCK challenge https://github.com/jakartaee/platform-tck/issues/2614

Fixes Issue
https://github.com/jakartaee/platform-tck/issues/2614

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
