### PR TITLE
Platform TCK challenge 2614: For persistence.core.criteriaapi.CriteriaUpdate 

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientAppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientAppmanagedTest.java
@@ -86,7 +86,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.criter
             SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(resURL != null) {
@@ -125,7 +125,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.criter
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanaged/appmanaged_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -144,43 +144,7 @@ public class ClientAppmanagedTest extends ee.jakarta.tck.persistence.core.criter
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriapia_CriteriaUpdate = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriapia_CriteriaUpdate.jar");
             // The class files
-            jpa_core_criteriapia_CriteriaUpdate.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriapia_CriteriaUpdate.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientAppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientAppmanagednotxTest.java
@@ -93,7 +93,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.cr
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.CriteriaUpdate.Client.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(resURL != null) {
@@ -132,7 +132,7 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.cr
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
                 com.sun.ts.tests.common.vehicle.appmanagedNoTx.AppManagedNoTxVehicleBean.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client.class.getResource("/com/sun/ts/tests/common/vehicle/appmanagedNoTx/appmanagedNoTx_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -151,43 +151,8 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.cr
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriapia_CriteriaUpdate = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriapia_CriteriaUpdate.jar");
             // The class files
-            jpa_core_criteriapia_CriteriaUpdate.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriapia_CriteriaUpdate.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientStateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientStateful3Test.java
@@ -88,7 +88,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.criteri
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             Client.class,
             ClientStateful3Test.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(resURL != null) {
@@ -127,7 +127,7 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.criteri
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateful3/stateful3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -146,43 +146,8 @@ public class ClientStateful3Test extends ee.jakarta.tck.persistence.core.criteri
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriapia_CriteriaUpdate = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriapia_CriteriaUpdate.jar");
             // The class files
-            jpa_core_criteriapia_CriteriaUpdate.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriapia_CriteriaUpdate.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientStateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/ClientStateless3Test.java
@@ -95,7 +95,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ee.jakarta.tck.persistence.core.criteriaapi.CriteriaUpdate.Client.class,
             ClientStateless3Test.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The application-client.xml descriptor
             URL resURL = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(resURL != null) {
@@ -134,7 +134,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.criter
                 SetupException.class,
                 com.sun.ts.tests.common.vehicle.VehicleClient.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The ejb-jar.xml descriptor
             URL ejbResURL1 = Client.class.getResource("/com/sun/ts/tests/common/vehicle/stateless3/stateless3_vehicle_client.xml");
             if(ejbResURL1 != null) {
@@ -153,43 +153,7 @@ public class ClientStateless3Test extends ee.jakarta.tck.persistence.core.criter
             // the jar with the correct archive name
             JavaArchive jpa_core_criteriapia_CriteriaUpdate = ShrinkWrap.create(JavaArchive.class, "jpa_core_criteriapia_CriteriaUpdate.jar");
             // The class files
-            jpa_core_criteriapia_CriteriaUpdate.addClasses(
-                ee.jakarta.tck.persistence.common.schema30.Department.class,
-                ee.jakarta.tck.persistence.common.schema30.Address_.class,
-                ee.jakarta.tck.persistence.common.schema30.Department_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard.class,
-                ee.jakarta.tck.persistence.common.schema30.Info.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem_.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer_.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim_.class,
-                ee.jakarta.tck.persistence.common.schema30.Order_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife_.class,
-                ee.jakarta.tck.persistence.common.schema30.ShelfLife.class,
-                ee.jakarta.tck.persistence.common.schema30.Phone_.class,
-                ee.jakarta.tck.persistence.common.schema30.Address.class,
-                ee.jakarta.tck.persistence.common.schema30.Info_.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Country_.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias_.class,
-                ee.jakarta.tck.persistence.common.schema30.Trim.class,
-                ee.jakarta.tck.persistence.common.schema30.HardwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.CreditCard_.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct.class,
-                ee.jakarta.tck.persistence.common.schema30.Product.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse.class,
-                ee.jakarta.tck.persistence.common.schema30.SoftwareProduct_.class,
-                ee.jakarta.tck.persistence.common.schema30.Spouse_.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItem.class,
-                ee.jakarta.tck.persistence.common.schema30.Employee.class,
-                ee.jakarta.tck.persistence.common.schema30.Product_.class,
-                ee.jakarta.tck.persistence.common.schema30.Customer.class,
-                ee.jakarta.tck.persistence.common.schema30.Alias.class,
-                ee.jakarta.tck.persistence.common.schema30.Order.class,
-                ee.jakarta.tck.persistence.common.schema30.LineItemException.class,
-                ee.jakarta.tck.persistence.common.schema30.Country.class
-            );
+            jpa_core_criteriapia_CriteriaUpdate.addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
             // The persistence.xml descriptor
             URL parURL = Client.class.getResource("persistence.xml");
             if(parURL != null) {


### PR DESCRIPTION
Fixes Issue
https://github.com/jakartaee/platform-tck/issues/2614 by updating the relevant test deployments to only contain the entity classes in the ear/lib (same as Jakarta EE 8/9/10 Platform TCK).

Describe the change
This is for addressing the EE 11 TCK challenge https://github.com/jakartaee/platform-tck/issues/2614

Fixes Issue
https://github.com/jakartaee/platform-tck/issues/2614

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
