### PR TITLE
Platform TCK challenge 2614: For persistence/core/EntityGraph address IllegalArgumentException: Not an entity: ee.jakarta.tck.persistence.core.EntityGraph.Employee3

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/EntityGraph/ClientAppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/EntityGraph/ClientAppmanagednotxTest.java
@@ -97,8 +97,6 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.En
             SetupException.class,
             com.sun.ts.tests.common.vehicle.VehicleClient.class,
             ee.jakarta.tck.persistence.core.EntityGraph.Client.class,
-            ee.jakarta.tck.persistence.core.EntityGraph.Employee3.class,
-            ee.jakarta.tck.persistence.core.EntityGraph.Department.class,
             com.sun.ts.tests.common.vehicle.ejb3share.NoopTransactionWrapper.class,
             ClientAppmanagednotxTest.class
             );
@@ -132,8 +130,6 @@ public class ClientAppmanagednotxTest extends ee.jakarta.tck.persistence.core.En
                 com.sun.ts.tests.common.vehicle.ejb3share.UseEntityManagerFactory.class,
                 ee.jakarta.tck.persistence.common.PMClientBase.class,
                 ee.jakarta.tck.persistence.core.EntityGraph.Client.class,
-                ee.jakarta.tck.persistence.core.EntityGraph.Employee3.class,
-                ee.jakarta.tck.persistence.core.EntityGraph.Department.class,
                 com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
                 com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper.class,
                 EETest.class,


### PR DESCRIPTION
Fixes Issue
https://github.com/jakartaee/platform-tck/issues/2614 by updating the relevant test deployments to only contain the entity classes in the ear/lib (same as Jakarta EE 8/9/10 Platform TCK).

Describe the change
This is for addressing the EE 11 TCK challenge https://github.com/jakartaee/platform-tck/issues/2614

Fixes Issue
https://github.com/jakartaee/platform-tck/issues/2614

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
