### PR TITLE
Fix Jakarta Mail TCK Deployments

### DIFF
--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/fetchprofile/fetchprofileEJB_Test.java
@@ -49,7 +49,8 @@ public class fetchprofileEJB_Test extends fetchprofile_Test implements Serializa
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
-		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejbClient.addClass(com.sun.ts.tests.common.base.EETest.class);
 		ejbClient.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		ejbClient.addClasses(fetchprofileEJB_Test.class, fetchprofile_Test.class);
@@ -72,7 +73,8 @@ public class fetchprofileEJB_Test extends fetchprofile_Test implements Serializa
 				"MANIFEST.MF");
 
 		JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "fetchprofile_ejb_vehicle_ejb.jar");
-		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejb.addPackages(true, "com.sun.ts.lib.harness");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/getMessageContent/getMessageContentEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/getMessageContent/getMessageContentEJB_Test.java
@@ -45,7 +45,8 @@ public class getMessageContentEJB_Test extends getMessageContent_Test {
 	public static EnterpriseArchive createDeploymentEjb(@ArquillianResource TestArchiveProcessor archiveProcessor)
 			throws IOException {
 		JavaArchive ejbClient = ShrinkWrap.create(JavaArchive.class, "getMessageContent_ejb_vehicle_client.jar");
-		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
@@ -69,7 +70,8 @@ public class getMessageContentEJB_Test extends getMessageContent_Test {
 		archiveProcessor.processClientArchive(ejbClient, getMessageContentEJB_Test.class, resURL);
 
 		JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "getMessageContent_ejb_vehicle_ejb.jar");
-		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejb.addPackages(true, "com.sun.ts.lib.harness");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartAppClient_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartAppClient_Test.java
@@ -45,12 +45,13 @@ public class internetMimeMultipartAppClient_Test extends internetMimeMultipart_T
 			throws IOException {
 		JavaArchive archive = ShrinkWrap.create(JavaArchive.class,
 				"internetMimeMultipart_appclient_vehicle_client.jar");
-		archive.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
 		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
 		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
-		archive.addClasses(internetMimeMultipartAppClient_Test.class, internetMimeMultipart_Test.class);
+		archive.addClasses(internetMimeMultipartAppClient_Test.class, internetMimeMultipart_Test.class, NullOutputStream.class, MyMimeMultipart.class);
 		archive.addAsManifestResource(
 				new StringAsset("Main-Class: " + "com.sun.ts.tests.common.vehicle.VehicleClient" + "\n"),
 				"MANIFEST.MF");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartEJB_Test.java
@@ -43,13 +43,14 @@ public class internetMimeMultipartEJB_Test extends internetMimeMultipart_Test {
 	@Deployment(name = "ejb", testable = true)
 	public static EnterpriseArchive createDeploymentEjb(@ArquillianResource TestArchiveProcessor archiveProcessor) throws IOException {
 		JavaArchive ejbClient = ShrinkWrap.create(JavaArchive.class, "internetMimeMultipart_ejb_vehicle_client.jar");
-		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
 		ejbClient.addClass(com.sun.ts.tests.common.base.EETest.class);
 		ejbClient.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
-		ejbClient.addClasses(internetMimeMultipartEJB_Test.class, internetMimeMultipart_Test.class);
+		ejbClient.addClasses(internetMimeMultipartEJB_Test.class, internetMimeMultipart_Test.class, NullOutputStream.class, MyMimeMultipart.class);
 
 		URL resURL = internetMimeMultipartEJB_Test.class.getResource("/com/sun/ts/tests/common/vehicle/ejb/ejb_vehicle_client.xml");
 		if (resURL != null) {
@@ -67,13 +68,14 @@ public class internetMimeMultipartEJB_Test extends internetMimeMultipart_Test {
 
 
 		JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "internetMimeMultipart_ejb_vehicle_ejb.jar");
-		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejb.addPackages(true, "com.sun.ts.lib.harness");
 		ejb.addClass(com.sun.ts.tests.common.base.EETest.class);
 		ejb.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
-		ejb.addClasses(internetMimeMultipartEJB_Test.class, internetMimeMultipart_Test.class);
+		ejb.addClasses(internetMimeMultipartEJB_Test.class, internetMimeMultipart_Test.class, NullOutputStream.class, MyMimeMultipart.class);
 
 		
 		resURL = internetMimeMultipartEJB_Test.class.getResource(

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartJSP_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartJSP_Test.java
@@ -42,7 +42,8 @@ public class internetMimeMultipartJSP_Test extends internetMimeMultipart_Test {
 	@Deployment(name = "jsp", testable = true)
 	public static WebArchive createDeploymentJSP(@ArquillianResource TestArchiveProcessor archiveProcessor) throws IOException {
 		WebArchive archive = ShrinkWrap.create(WebArchive.class, "internetMimeMultipart_jsp_vehicle_web.war");
-		archive.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.jsp");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
@@ -58,7 +59,7 @@ public class internetMimeMultipartJSP_Test extends internetMimeMultipart_Test {
       archive.addAsWebResource(clientHtml, "/client.html");
     }
     
-		archive.addClasses(internetMimeMultipartJSP_Test.class, internetMimeMultipart_Test.class);
+		archive.addClasses(internetMimeMultipartJSP_Test.class, internetMimeMultipart_Test.class, NullOutputStream.class, MyMimeMultipart.class);
 		
 		// The jsp descriptor
         URL jspUrl = internetMimeMultipartJSP_Test.class.getResource("jsp_vehicle_client.xml");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartServlet_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetMimeMultipart/internetMimeMultipartServlet_Test.java
@@ -40,14 +40,15 @@ public class internetMimeMultipartServlet_Test extends internetMimeMultipart_Tes
 	@Deployment(name = "servlet", testable = true)
 	public static WebArchive createDeploymentServlet(@ArquillianResource TestArchiveProcessor archiveProcessor) throws IOException {
 		WebArchive archive = ShrinkWrap.create(WebArchive.class, "internetMimeMultipart_servlet_vehicle_web.war");
-		archive.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.servlet");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
 		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
 		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
 		archive.addPackages(false, "com.sun.ts.tests.javamail.ee.internetMimeMultipart");
-		archive.addClasses(internetMimeMultipartServlet_Test.class, internetMimeMultipart_Test.class);
+		archive.addClasses(internetMimeMultipartServlet_Test.class, internetMimeMultipart_Test.class, NullOutputStream.class, MyMimeMultipart.class);
 		
 		
 		// The servlet descriptor

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/internetaddress/internetaddressEJB_Test.java
@@ -51,7 +51,8 @@ public class internetaddressEJB_Test extends internetaddress_Test
 	public static EnterpriseArchive createDeploymentEjb(@ArquillianResource TestArchiveProcessor archiveProcessor)
 			throws IOException {
 		JavaArchive ejbClient = ShrinkWrap.create(JavaArchive.class, "internetaddress_ejb_vehicle_client.jar");
-		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
@@ -75,7 +76,8 @@ public class internetaddressEJB_Test extends internetaddress_Test
 		archiveProcessor.processClientArchive(ejbClient,  internetaddressEJB_Test.class, resURL);
 
 		JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "internetaddress_ejb_vehicle_ejb.jar");
-		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejb.addPackages(true, "com.sun.ts.lib.harness");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageAppClient_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageAppClient_Test.java
@@ -48,12 +48,13 @@ public class mimemessageAppClient_Test extends mimemessage_Test implements Seria
 	@Deployment(name = "appclient", testable = true)
 	public static EnterpriseArchive createDeploymentAppclient(@ArquillianResource TestArchiveProcessor archiveProcessor) throws IOException {
 		JavaArchive archive = ShrinkWrap.create(JavaArchive.class, "mimemessage_appclient_vehicle_client.jar");
-		archive.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
 		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
 		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
-		archive.addClasses(mimemessageAppClient_Test.class, mimemessage_Test.class);
+		archive.addClasses(mimemessageAppClient_Test.class, mimemessage_Test.class, MyMimeMessage.class, MyReplyMimeMessage.class);
 		
 		archive.addAsManifestResource(
 				new StringAsset("Main-Class: " + "com.sun.ts.tests.common.vehicle.VehicleClient" + "\n"),

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageEJB_Test.java
@@ -48,13 +48,14 @@ public class mimemessageEJB_Test extends mimemessage_Test implements Serializabl
 	@Deployment(name = "ejb", testable = true)
 	public static EnterpriseArchive createDeploymentEJB(@ArquillianResource TestArchiveProcessor archiveProcessor) throws IOException {
 		JavaArchive ejbClient = ShrinkWrap.create(JavaArchive.class, "mimemessage_ejb_vehicle_client.jar");
-		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
 		ejbClient.addClass(com.sun.ts.tests.common.base.EETest.class);
 		ejbClient.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
-		ejbClient.addClasses(mimemessageEJB_Test.class, mimemessage_Test.class);
+		ejbClient.addClasses(mimemessageEJB_Test.class, mimemessage_Test.class, MyMimeMessage.class, MyReplyMimeMessage.class);
 
 		URL resURL = mimemessageEJB_Test.class.getResource("/com/sun/ts/tests/common/vehicle/ejb/ejb_vehicle_client.xml");
 		if (resURL != null) {
@@ -72,13 +73,14 @@ public class mimemessageEJB_Test extends mimemessage_Test implements Serializabl
 
 
 		JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "mimemessage_ejb_vehicle_ejb.jar");
-		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejb.addPackages(true, "com.sun.ts.lib.harness");
 		ejb.addClass(com.sun.ts.tests.common.base.EETest.class);
 		ejb.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
-		ejb.addClasses(mimemessageEJB_Test.class, mimemessage_Test.class);
+		ejb.addClasses(mimemessageEJB_Test.class, mimemessage_Test.class, MyMimeMessage.class, MyReplyMimeMessage.class);
 
 		resURL = mimemessageEJB_Test.class.getResource(
 				"/com/sun/ts/tests/javamail/ee/mimemessage/mimemessage_ejb_vehicle_ejb.jar.sun-ejb-jar.xml");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageJSP_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageJSP_Test.java
@@ -48,13 +48,14 @@ public class mimemessageJSP_Test extends mimemessage_Test implements Serializabl
 	@Deployment(name = "jsp", testable = true)
 	public static WebArchive createDeploymentJSP(@ArquillianResource TestArchiveProcessor archiveProcessor) throws IOException {
 		WebArchive archive = ShrinkWrap.create(WebArchive.class, "mimemessage_jsp_vehicle_web.war");
-		archive.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.jsp");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
 		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
 		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
-		archive.addClasses(mimemessageJSP_Test.class, mimemessage_Test.class);
+		archive.addClasses(mimemessageJSP_Test.class, mimemessage_Test.class, MyMimeMessage.class, MyReplyMimeMessage.class);
     
 		URL jspVehicle = mimemessageJSP_Test.class.getResource("/com/sun/ts/tests/common/vehicle/jsp/contentRoot/jsp_vehicle.jsp");
 		if(jspVehicle != null) {

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageServlet_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/mimemessage/mimemessageServlet_Test.java
@@ -46,13 +46,14 @@ public class mimemessageServlet_Test extends mimemessage_Test implements Seriali
 	@Deployment(name = "servlet", testable = true)
 	public static WebArchive createDeploymentServlet(@ArquillianResource TestArchiveProcessor archiveProcessor) throws IOException {
 		WebArchive archive = ShrinkWrap.create(WebArchive.class, "mimemessage_servlet_vehicle_web.war");
-		archive.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		archive.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		archive.addPackages(false, "com.sun.ts.tests.common.vehicle.servlet");
 		archive.addPackages(true, "com.sun.ts.lib.harness");
 		archive.addClass(com.sun.ts.tests.common.base.EETest.class);
 		archive.addClass(com.sun.ts.tests.common.base.ServiceEETest.class);
-		archive.addClasses(mimemessageServlet_Test.class, mimemessage_Test.class);
+		archive.addClasses(mimemessageServlet_Test.class, mimemessage_Test.class, MyMimeMessage.class, MyReplyMimeMessage.class);
 		
 		// The servlet descriptor
         URL jspUrl = mimemessageServlet_Test.class.getResource("servlet_vehicle_web.xml");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/multipart/multipartEJB_Test.java
@@ -48,7 +48,8 @@ public class multipartEJB_Test extends multipart_Test implements Serializable {
 	@Deployment(name = "ejb", testable = true)
 	public static EnterpriseArchive createDeploymentEJB(@ArquillianResource TestArchiveProcessor archiveProcessor) throws IOException {
 		JavaArchive ejbClient = ShrinkWrap.create(JavaArchive.class, "multipart_ejb_vehicle_client.jar");
-		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
@@ -72,7 +73,8 @@ public class multipartEJB_Test extends multipart_Test implements Serializable {
 
 
 		JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "multipart_ejb_vehicle_ejb.jar");
-		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejb.addPackages(true, "com.sun.ts.lib.harness");

--- a/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendEJB_Test.java
+++ b/tcks/apis/javamail/src/main/java/com/sun/ts/tests/javamail/ee/transport/sendEJB_Test.java
@@ -48,7 +48,8 @@ public class sendEJB_Test extends send_Test implements Serializable {
 	@Deployment(name = "ejb", testable = true)
 	public static EnterpriseArchive createDeploymentEJB(@ArquillianResource TestArchiveProcessor archiveProcessor) throws IOException {
 		JavaArchive ejbClient = ShrinkWrap.create(JavaArchive.class, "send_ejb_vehicle_client.jar");
-		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejbClient.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejbClient.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejbClient.addPackages(true, "com.sun.ts.lib.harness");
@@ -71,7 +72,8 @@ public class sendEJB_Test extends send_Test implements Serializable {
 				"MANIFEST.MF");
 
 		JavaArchive ejb = ShrinkWrap.create(JavaArchive.class, "send_ejb_vehicle_ejb.jar");
-		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.common");
+		ejb.addPackages(true, "com.sun.ts.tests.javamail.ee.util");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle");
 		ejb.addPackages(false, "com.sun.ts.tests.common.vehicle.ejb");
 		ejb.addPackages(true, "com.sun.ts.lib.harness");


### PR DESCRIPTION
**Fixes Issue**
fixes #2640
fixes #2641 

**Describe the change**
This removes unneeded types from deployments and ensures the the `TestArchiveProcessor` is used in the EJB tests.

I did run these changes against the TCK in WildFly and it passed.
