### PR TITLE
[2653] Do not use the java.version system property when attempting to…

### DIFF
--- a/tcks/apis/tags/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
+++ b/tcks/apis/tags/src/main/java/com/sun/ts/tests/jstl/common/client/AbstractUrlClient.java
@@ -229,18 +229,7 @@ public class AbstractUrlClient extends BaseUrlClient {
   }
 
   public boolean isJavaVersion20OrGreater() {
-    boolean isJavaVersion20OrGreater = false;
-
-    String version = System.getProperty("java.version");
-    int majorVersionDot = version.indexOf(".");
-
-    version = version.substring(0, majorVersionDot);
-
-    if (Integer.parseInt(version) >= 20) {
-        isJavaVersion20OrGreater = true;
-    }
-
-    return isJavaVersion20OrGreater;
+    return Runtime.version().feature() >= 20;
   }
 
 }


### PR DESCRIPTION
… determine the Java version. Instead use the Runtime.version() in the Jakarta Tags TCK.

**Fixes Issue**
fixes #2653 

**Describe the change**
Uses the `Runtime.vesion()` to determine the JVM version rather than the `java.version` system property.
