### PR TITLE
11.0.x branch update to address Persistence TCK challenge https://github.com/jakartaee/persistence/issues/982

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1.java
+++ b/tcks/apis/persistence/persistence-inside-container/spec-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1.java
@@ -1920,7 +1920,7 @@ public class Client1 extends PMClientBase {
 
 		try {
 			logMsg( "Testing a parm of incorrect type");
-			getEntityManager().createQuery("select e from Employee e where e.firstName = ?1").setParameter(1, 1);
+			getEntityManager().createQuery("select e from Employee e where e.hireDate = ?1").setParameter(1, 1);
 			logErr( "IllegalArgumentException not thrown");
 		} catch (IllegalArgumentException iae) {
 			logTrace( "IllegalArgumentException Caught as Expected");
@@ -1945,7 +1945,7 @@ public class Client1 extends PMClientBase {
 		}
 		try {
 			logMsg( "Testing a parm of incorrect type");
-			getEntityManager().createQuery("select e from Employee e where e.firstName = ?1", Employee.class)
+			getEntityManager().createQuery("select e from Employee e where e.hireDate = ?1", Employee.class)
 					.setParameter(1, 1);
 			logErr( "IllegalArgumentException not thrown");
 		} catch (IllegalArgumentException iae) {
@@ -2982,7 +2982,7 @@ public class Client1 extends PMClientBase {
 
 			try {
 				query = getEntityManager()
-						.createQuery("select e from Employee e where e.firstName = ?1 and e.lastName = ?2")
+						.createQuery("select e from Employee e where e.firstName = ?1 and e.hireDate = ?2")
 						.setParameter(1, "Kate").setParameter(2, 10);
 			} catch (IllegalArgumentException iae) {
 				logTrace( "IllegalArgumentException Caught as Expected");


### PR DESCRIPTION


**Fixes Issue**
https://github.com/jakartaee/persistence/issues/982

**Describe the change**
The challenge is to `Exclude TCK tests that require `IllegalArgumentException` to be thrown for not well defined reason` however we will try a change before excluding these tests which is to update the mentioned tests to bind a more likely to throw `IllegalArgumentException` which is consistent with the change we made for the (staged) 3.2.1 TCK.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
