### PR TITLE
Fix ibanno transaction support annotation

### DIFF
--- a/tcks/apis/connector-whitebox/ibanno/src/main/java/com/sun/ts/tests/common/connector/whitebox/ibanno/IBAnnotatedResourceAdapterImpl.java
+++ b/tcks/apis/connector-whitebox/ibanno/src/main/java/com/sun/ts/tests/common/connector/whitebox/ibanno/IBAnnotatedResourceAdapterImpl.java
@@ -49,7 +49,7 @@ import jakarta.resource.spi.work.WorkManager;
  *
  */
 
-@Connector(description = "CTS Test Resource Adapter with No DD", displayName = "whitebox-anno_no_md.rar", vendorName = "Java Software", eisType = "TS EIS", version = "1.6", licenseDescription = "CTS License Required", licenseRequired = true, authMechanisms = @AuthenticationMechanism(credentialInterface = AuthenticationMechanism.CredentialInterface.PasswordCredential, authMechanism = "BasicPassword", description = "Basic Password Authentication"), reauthenticationSupport = false, securityPermissions = @SecurityPermission(), transactionSupport = TransactionSupport.TransactionSupportLevel.XATransaction, requiredWorkContexts = {
+@Connector(description = "CTS Test Resource Adapter with No DD", displayName = "whitebox-anno_no_md.rar", vendorName = "Java Software", eisType = "TS EIS", version = "1.6", licenseDescription = "CTS License Required", licenseRequired = true, authMechanisms = @AuthenticationMechanism(credentialInterface = AuthenticationMechanism.CredentialInterface.PasswordCredential, authMechanism = "BasicPassword", description = "Basic Password Authentication"), reauthenticationSupport = false, securityPermissions = @SecurityPermission(), transactionSupport = TransactionSupport.TransactionSupportLevel.LocalTransaction, requiredWorkContexts = {
         TransactionContext.class })
 public class IBAnnotatedResourceAdapterImpl implements ResourceAdapter, java.io.Serializable {
 


### PR DESCRIPTION
**Fixes Issue**
#2657 in 11.0.x (PR #2658 fixes this in main)

**Describe the change**
Changed the IBAnnotatedResourceAdapterImpl class to declare local transaction support instead of XA transaction support, which aligns with the rest of the adapter implementation. 

**Additional context**
Proven to fix the ibanno adapter deployment issue in WebLogic related to trying to create the connection pool but getXAResource() is throwing an exception.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
