### PR TITLE
(11.0.x) Platform TCK challenge 2614: adjust persistence.core.query.apitest subset of changes to deploy more correctly with regard to portable application class layout

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1AppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1AppmanagednotxTest.java
@@ -156,7 +156,7 @@ public class Client1AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client1.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1PmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1PmservletTest.java
@@ -116,7 +116,7 @@ public class Client1PmservletTest extends ee.jakarta.tck.persistence.core.query.
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client1.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1PuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1PuservletTest.java
@@ -116,7 +116,7 @@ public class Client1PuservletTest extends ee.jakarta.tck.persistence.core.query.
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client1.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client1Stateless3Test.java
@@ -151,7 +151,7 @@ public class Client1Stateless3Test extends ee.jakarta.tck.persistence.core.query
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client1.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2AppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2AppmanagednotxTest.java
@@ -143,7 +143,7 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client2.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2PmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2PmservletTest.java
@@ -116,7 +116,7 @@ public class Client2PmservletTest extends ee.jakarta.tck.persistence.core.query.
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client2.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2PuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2PuservletTest.java
@@ -116,7 +116,7 @@ public class Client2PuservletTest extends ee.jakarta.tck.persistence.core.query.
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client2.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client2Stateless3Test.java
@@ -156,7 +156,7 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.query
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client2.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3AppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3AppmanagednotxTest.java
@@ -145,7 +145,7 @@ public class Client3AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client3.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3PmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3PmservletTest.java
@@ -116,7 +116,7 @@ public class Client3PmservletTest extends ee.jakarta.tck.persistence.core.query.
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client3.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3PuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3PuservletTest.java
@@ -116,7 +116,7 @@ public class Client3PuservletTest extends ee.jakarta.tck.persistence.core.query.
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client3.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client3Stateless3Test.java
@@ -145,7 +145,7 @@ public class Client3Stateless3Test extends ee.jakarta.tck.persistence.core.query
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client3.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4AppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4AppmanagednotxTest.java
@@ -145,7 +145,7 @@ public class Client4AppmanagednotxTest extends ee.jakarta.tck.persistence.core.q
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client4.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4PmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4PmservletTest.java
@@ -116,7 +116,7 @@ public class Client4PmservletTest extends ee.jakarta.tck.persistence.core.query.
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client4.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4PuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4PuservletTest.java
@@ -116,7 +116,7 @@ public class Client4PuservletTest extends ee.jakarta.tck.persistence.core.query.
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client4.class.getResource("persistence.xml");
             if(parURL != null) {

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/query/apitests/Client4Stateless3Test.java
@@ -145,7 +145,7 @@ public class Client4Stateless3Test extends ee.jakarta.tck.persistence.core.query
                 ee.jakarta.tck.persistence.core.query.apitests.Department.class,
                 ee.jakarta.tck.persistence.core.query.apitests.DataTypes2.class,
                 ee.jakarta.tck.persistence.core.query.apitests.Insurance.class
-            ).addClasses(ee.jakarta.tck.persistence.common.schema30.Util.getSchema30classes());
+            );
             // The persistence.xml descriptor
             URL parURL = Client4.class.getResource("persistence.xml");
             if(parURL != null) {


### PR DESCRIPTION
Update for  https://github.com/jakartaee/platform-tck/issues/2614 for (more correctly)  updating the relevant test deployments to only contain the (needed) entity classes in the ear/lib (same as Jakarta EE 8/9/10 Platform TCK).

Describe the change

This is for addressing the EE 11 TCK challenge https://github.com/jakartaee/platform-tck/issues/2614

Fixes Issue

https://github.com/jakartaee/platform-tck/issues/2614

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
