### PR TITLE
Skip invalid JMS property names from harness properties

### DIFF
--- a/tools/common/src/main/java/com/sun/ts/tests/jms/common/JmsUtil.java
+++ b/tools/common/src/main/java/com/sun/ts/tests/jms/common/JmsUtil.java
@@ -135,7 +135,8 @@ public final class JmsUtil {
             while (e.hasMoreElements()) {
                 key = (String) e.nextElement();
                 TestUtil.logTrace("addProps: " + key);
-                if ((key.indexOf(notValid) == -1) && (key.indexOf("***") == -1) && !(key.startsWith("JMS"))) {
+                if ((key.indexOf("-") == -1) && (key.indexOf(notValid) == -1) && (key.indexOf("***") == -1)
+                        && !(key.startsWith("JMS"))) {
                     TestUtil.logTrace("addProps: add property " + key);
                     msg.setStringProperty(key, TestUtil.getProperty(p, key));
                 }


### PR DESCRIPTION
**Fixes Issue**
#2652 - for main branch (PR #2663 fixes the issue for branch 11.0.x)

**Describe the change**
Change the message filtering logic to filter out characters that are not valid Java identifier characters, as required by §3.8.1.1 of the Messaging 3.1 specification

**Additional context**
WebLogic Server passes the failing tests from #2652 with this fix.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
