### PR TITLE
Update to address TCK challenge https://github.com/jakartaee/platform-tck/issues/2671 for ee.jakarta.tck.persistence.ee.propagation.cm.extended.ClientTest#test6

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/propagation/cm/extended/Stateful3Bean.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/propagation/cm/extended/Stateful3Bean.java
@@ -92,6 +92,7 @@ public class Stateful3Bean implements Stateful3IF {
 	public void removeTestData() {
 		TestUtil.logTrace( "removeTestData");
 		try {
+			entityManager.clear();
 			entityManager.createNativeQuery("DELETE FROM BEJB_1X1_BI_BTOB").executeUpdate();
 			entityManager.createNativeQuery("DELETE FROM AEJB_1X1_BI_BTOB").executeUpdate();
 		} catch (Exception e) {


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2671

**Describe the change**
Update the test cleanup method to clear the extended persistence context state to ensure changes from previous test do not impact the next test.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
