### PR TITLE
Update to address TCK challenge https://github.com/jakartaee/platform-tck/issues/2673

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/appclient/annotation/ClientTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/appclient/annotation/ClientTest.java
@@ -53,7 +53,6 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.appclien
             ee.jakarta.tck.persistence.ee.packaging.appclient.annotation.Coffee.class,
             ee.jakarta.tck.persistence.ee.packaging.appclient.annotation.Client.class,
             EETest.class,
-            com.sun.ts.lib.util.TestUtil.class,
             SetupException.class,
             com.sun.ts.lib.harness.Status.class
             );

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/appclient/descriptor/ClientTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/appclient/descriptor/ClientTest.java
@@ -53,7 +53,6 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.appclien
             ee.jakarta.tck.persistence.ee.packaging.appclient.descriptor.Coffee.class,
             Fault.class,
             EETest.class,
-            com.sun.ts.lib.util.TestUtil.class,
             com.sun.ts.lib.harness.Status.class,
             ee.jakarta.tck.persistence.ee.packaging.appclient.descriptor.Client.class,
             SetupException.class

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/ejb/exclude/ClientTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/ejb/exclude/ClientTest.java
@@ -60,7 +60,6 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.ejb.excl
             JavaArchive jpa_ee_packaging_ejb_exclude_ejb = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_ejb_exclude_ejb.jar");
             // The class files
             jpa_ee_packaging_ejb_exclude_ejb.addClasses(
-                ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.Stateful3IF.class,
                 ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.A.class,
                 ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.Stateful3Bean.class,
                 ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.B.class
@@ -76,11 +75,14 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.ejb.excl
 
             // non-vehicle appclientproxy invoker war
             WebArchive appclientproxy = ShrinkWrap.create(WebArchive.class, "appclientproxy.war");
-            appclientproxy.addClasses(Client.class, ClientServletTarget.class, ServletNoVehicle.class, Stateful3IF.class);
+            appclientproxy.addClasses(Client.class, ClientServletTarget.class, ServletNoVehicle.class);
             appclientproxy.addAsWebInfResource(new StringAsset(""), "beans.xml");
 
         // Ear
             EnterpriseArchive jpa_ee_packaging_ejb_exclude_ear = ShrinkWrap.create(EnterpriseArchive.class, "jpa_ee_packaging_ejb_exclude.ear");
+
+            JavaArchive libClasses = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_ejb_exclude_libclasses.jar");
+            libClasses.addClass(ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.Stateful3IF.class);
 
             // Any libraries added to the ear
 
@@ -88,6 +90,7 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.ejb.excl
             jpa_ee_packaging_ejb_exclude_ear.addAsModule(jpa_ee_packaging_ejb_exclude_ejb);
             jpa_ee_packaging_ejb_exclude_ear.addAsModule(jpa_ee_packaging_ejb_exclude_client);
             jpa_ee_packaging_ejb_exclude_ear.addAsModule(appclientproxy);
+            jpa_ee_packaging_ejb_exclude_ear.addAsLibrary(libClasses);
 
             // The application.xml descriptor
             URL earResURL = null;

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/ejb/exclude/ClientTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/ejb/exclude/ClientTest.java
@@ -60,6 +60,7 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.ejb.excl
             JavaArchive jpa_ee_packaging_ejb_exclude_ejb = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_ejb_exclude_ejb.jar");
             // The class files
             jpa_ee_packaging_ejb_exclude_ejb.addClasses(
+                ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.Stateful3IF.class,
                 ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.A.class,
                 ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.Stateful3Bean.class,
                 ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.B.class
@@ -75,14 +76,11 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.ejb.excl
 
             // non-vehicle appclientproxy invoker war
             WebArchive appclientproxy = ShrinkWrap.create(WebArchive.class, "appclientproxy.war");
-            appclientproxy.addClasses(Client.class, ClientServletTarget.class, ServletNoVehicle.class);
+            appclientproxy.addClasses(Client.class, ClientServletTarget.class, ServletNoVehicle.class, Stateful3IF.class, Stateful3Bean.class);
             appclientproxy.addAsWebInfResource(new StringAsset(""), "beans.xml");
 
         // Ear
             EnterpriseArchive jpa_ee_packaging_ejb_exclude_ear = ShrinkWrap.create(EnterpriseArchive.class, "jpa_ee_packaging_ejb_exclude.ear");
-
-            JavaArchive libClasses = ShrinkWrap.create(JavaArchive.class, "jpa_ee_packaging_ejb_exclude_libclasses.jar");
-            libClasses.addClass(ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.Stateful3IF.class);
 
             // Any libraries added to the ear
 
@@ -90,7 +88,6 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.ejb.excl
             jpa_ee_packaging_ejb_exclude_ear.addAsModule(jpa_ee_packaging_ejb_exclude_ejb);
             jpa_ee_packaging_ejb_exclude_ear.addAsModule(jpa_ee_packaging_ejb_exclude_client);
             jpa_ee_packaging_ejb_exclude_ear.addAsModule(appclientproxy);
-            jpa_ee_packaging_ejb_exclude_ear.addAsLibrary(libClasses);
 
             // The application.xml descriptor
             URL earResURL = null;


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2673

**Related Issue(s)**
https://github.com/jakartaee/platform-tck/issues/2614

**Describe the change**
- Remove duplicate com.sun.ts.lib.util.TestUtil.class from tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/appclient/descriptor/ClientTest.java as that class will already be in jpa_ee_packaging_appclient_descriptor.ear/lib/arquillian-protocol-lib.jar
- Remove duplicate com.sun.ts.util.TestUtil.class from tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/appclient/annotation/ClientTest.java as that class will already be in jpa_ee_packaging_appclient_descriptor.ear/lib/arquillian-protocol-lib.jar
- Remove duplicate ee.jakarta.tck.persistence.ee.packaging.ejb.exclude.Stateful3IF.class from jpa_ee_packaging_ejb_exclude_ejb.jar + appclientproxy.war in tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/ejb/exclude/ClientTest.java and instead add that (Stateful3IF) class in newly added ear/lib/jpa_ee_packaging_ejb_exclude_libclasses.jar.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
