### PR TITLE
Update com.sun.ts.tests.jstl.compat.onedotzero.JSTLClientIT Tags tests to use https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd

### DIFF
--- a/tcks/apis/tags/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/jstl_1_0_compat_web.xml
+++ b/tcks/apis/tags/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/jstl_1_0_compat_web.xml
@@ -18,10 +18,10 @@
 
 -->
 
-<web-app version="6.1"
+<web-app version="5.0"
          xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
     <context-param>
         <param-name>JSTL_TAB1_ROWS</param-name>
         <param-value>10</param-value>

--- a/tcks/apis/tags/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/jstl_1_0_compat_web.xml
+++ b/tcks/apis/tags/src/main/java/com/sun/ts/tests/jstl/compat/onedotzero/jstl_1_0_compat_web.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE web-app
-     PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-    "http://java.sun.com/dtd/web-app_2_3.dtd">
 
 <!--
 
@@ -21,7 +18,10 @@
 
 -->
 
-<web-app>
+<web-app version="6.1"
+         xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
     <context-param>
         <param-name>JSTL_TAB1_ROWS</param-name>
         <param-value>10</param-value>

--- a/tcks/apis/tags/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/jstl_1_0_compat_web.xml
+++ b/tcks/apis/tags/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/jstl_1_0_compat_web.xml
@@ -18,10 +18,10 @@
 
 -->
 
-<web-app version="6.1"
+<web-app version="5.0"
          xmlns="https://jakarta.ee/xml/ns/jakartaee"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd">
     <context-param>
         <param-name>JSTL_TAB1_ROWS</param-name>
         <param-value>10</param-value>

--- a/tcks/apis/tags/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/jstl_1_0_compat_web.xml
+++ b/tcks/apis/tags/src/main/resources/com/sun/ts/tests/jstl/compat/onedotzero/jstl_1_0_compat_web.xml
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE web-app
-     PUBLIC "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
-    "http://java.sun.com/dtd/web-app_2_3.dtd">
 
 <!--
 
@@ -21,7 +18,10 @@
 
 -->
 
-<web-app>
+<web-app version="6.1"
+         xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd">
     <context-param>
         <param-name>JSTL_TAB1_ROWS</param-name>
         <param-value>10</param-value>


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2667

**Related Issue(s)**
Replaces pr https://github.com/jakartaee/platform-tck/pull/2680

**Describe the change**
Since the EE 11 Platform TCK only uses `https://jakarta.ee/xml/ns/jakartaee/web-app_5_0.xsd` but not the https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd we will use web-app_5_0.xsd.  

Note that the EE 12 Platform TCK will at  use https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd but could use https://jakarta.ee/xml/ns/jakartaee/web-app_6_2.xsd.


CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
