### PR TITLE
platform-tck/issues/2679 EE 10/11 Platform TCK Jakarta Enterprise Beans test logic that assemble HTTP requests should use CRLF instead of OS platform specific "line.separator"

### DIFF
--- a/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java
+++ b/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java
@@ -23,12 +23,12 @@ package com.sun.ts.tests.ejb30.misc.jndi.earwar;
 import java.io.PrintWriter;
 
 import com.sun.ts.lib.harness.Status;
-import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.servlet.common.client.AbstractUrlClient;
 
 public class Client extends AbstractUrlClient {
+  private static final String HTTP_CRLF = "\r\n";
   public static final String APP_MODULE_NAME_HEADER = "appName: misc_jndi_earwar"
-      + TestUtil.NEW_LINE + "moduleName: misc_jndi_earwar_web";
+      + HTTP_CRLF + "moduleName: misc_jndi_earwar_web";
 
   public static final String CONTEXT_ROOT = "/misc_jndi_earwar_web";
 

--- a/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java
+++ b/tcks/apis/enterprise-beans/ejb30/src/main/java/com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java
@@ -23,12 +23,12 @@ package com.sun.ts.tests.ejb30.misc.jndi.earwarjar;
 import java.io.PrintWriter;
 
 import com.sun.ts.lib.harness.Status;
-import com.sun.ts.lib.util.TestUtil;
 import com.sun.ts.tests.servlet.common.client.AbstractUrlClient;
 
 public class Client extends AbstractUrlClient {
+  private static final String HTTP_CRLF = "\r\n";
   public static final String APP_MODULE_NAME_HEADER = "appName: misc_jndi_earwarjar"
-      + TestUtil.NEW_LINE + "moduleName: misc_jndi_earwarjar_ejb";
+      + HTTP_CRLF + "moduleName: misc_jndi_earwarjar_ejb";
 
   public static final String CONTEXT_ROOT = "/misc_jndi_earwarjar_web";
 


### PR DESCRIPTION
**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2679

**Describe the change**
[The problem is that com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#L30](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#L30) is operating system specific due to use of System.getProperty("line.separator", "\n"). We are running TCK testing on Linux where the line.separator is LF (line feed only) but well formed HTTP requests should use CRLF (carriage return + line feed) as specified in https://datatracker.ietf.org/doc/html/rfc9112#name-message-format + https://datatracker.ietf.org/doc/html/rfc7230#section-3 + https://datatracker.ietf.org/doc/html/rfc2234#section-2.2. Implementations may of been lenient in the past about allowing other sequences but implementations should be able parse HTTP requests by only checking for CRLF.

It seems very likely that this use of System.getProperty("line.separator", "\n") in the mentioned Enterprise Beans TCK tests was accidental as the test assertions do not mention testing the operating system "line.separator" property.

For reference [src/com/sun/ts/lib/util/TestUtil.java#L58](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/lib/util/TestUtil.java#L58) contains the actual code that obtains the line.separator OS property which is correct for logging but not for actual TCK test logic.

List of failing tests to be updated or excluded:

[com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#appJNDI](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#L88)
[com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#appJNDI2](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#L100)
[com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#appNameModuleName](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#L132)
[com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#globalJNDI](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/tests/ejb30/misc/jndi/earwar/Client.java#L65)
[com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java#appJNDI](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java#L88)
[com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java#appJNDI2](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java#L100)
[com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java#globalJNDI](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java#L65)
[com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java#globalJNDI2](https://github.com/jakartaee/platform-tck/blob/febd0176d513a2b4d9b13354bf69b6d6c03d79a3/src/com/sun/ts/tests/ejb30/misc/jndi/earwarjar/Client.java#L77)

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
