### PR TITLE
Platform TCK challenge 2614: For persistence.core.criteriaapi.metamodelquery address missed classloader failure in Client2*.java deployment where we needed to remove the Status.class like we did for Client1* + other tests in same package

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2AppmanagedTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2AppmanagedTest.java
@@ -87,7 +87,6 @@ public class Client2AppmanagedTest extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class,
             ee.jakarta.tck.persistence.common.PMClientBase.class,
             ee.jakarta.tck.persistence.common.schema30.Util.class,
-            com.sun.ts.lib.harness.Status.class,
             com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
             com.sun.ts.tests.common.vehicle.appmanaged.AppManagedVehicleRunner.class,
             com.sun.ts.tests.common.vehicle.web.AltWebVehicleRunner.class,

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2AppmanagednotxTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2AppmanagednotxTest.java
@@ -78,7 +78,6 @@ public class Client2AppmanagednotxTest extends ee.jakarta.tck.persistence.core.c
             com.sun.ts.tests.common.vehicle.appmanagedNoTx.AppManagedNoTxVehicleRunner.class,
             com.sun.ts.tests.common.vehicle.web.AltWebVehicleRunner.class,
             ee.jakarta.tck.persistence.common.schema30.Util.class,
-            com.sun.ts.lib.harness.Status.class,
             com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
             com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper.class,
             EETest.class,

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2PmservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2PmservletTest.java
@@ -74,7 +74,6 @@ public class Client2PmservletTest extends ee.jakarta.tck.persistence.core.criter
             ee.jakarta.tck.persistence.common.PMClientBase.class,
             com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class,
             ee.jakarta.tck.persistence.common.schema30.Util.class,
-            com.sun.ts.lib.harness.Status.class,
             com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
             ee.jakarta.tck.persistence.core.criteriaapi.metamodelquery.Client2.class,
             com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper.class,

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2PuservletTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2PuservletTest.java
@@ -75,7 +75,6 @@ public class Client2PuservletTest extends ee.jakarta.tck.persistence.core.criter
             ee.jakarta.tck.persistence.common.PMClientBase.class,
             com.sun.ts.tests.common.vehicle.servlet.ServletVehicle.class,
             ee.jakarta.tck.persistence.common.schema30.Util.class,
-            com.sun.ts.lib.harness.Status.class,
             com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
             ee.jakarta.tck.persistence.core.criteriaapi.metamodelquery.Client2.class,
             com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper.class,

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateful3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateful3Test.java
@@ -77,7 +77,6 @@ public class Client2Stateful3Test extends ee.jakarta.tck.persistence.core.criter
             com.sun.ts.tests.common.vehicle.stateful3.Stateful3VehicleRunner.class,
             com.sun.ts.tests.common.vehicle.web.AltWebVehicleRunner.class,
             ee.jakarta.tck.persistence.common.schema30.Util.class,
-            com.sun.ts.lib.harness.Status.class,
             com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
             com.sun.ts.tests.common.vehicle.stateful3.Stateful3VehicleIF.class,
             com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper.class,

--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateless3Test.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/Client2Stateless3Test.java
@@ -86,7 +86,6 @@ public class Client2Stateless3Test extends ee.jakarta.tck.persistence.core.crite
             com.sun.ts.tests.common.vehicle.EmptyVehicleRunner.class,
             ee.jakarta.tck.persistence.common.PMClientBase.class,
             ee.jakarta.tck.persistence.common.schema30.Util.class,
-            com.sun.ts.lib.harness.Status.class,
             com.sun.ts.tests.common.vehicle.VehicleRunnable.class,
             com.sun.ts.tests.common.vehicle.ejb3share.UserTransactionWrapper.class,
             com.sun.ts.tests.common.vehicle.stateless3.Stateless3VehicleIF.class,


### PR DESCRIPTION

**Fixes Issue**
https://github.com/jakartaee/platform-tck/issues/2614


**Describe the change**
Remove Status.class from the ersistence.core.criteriaapi.metamodelquery.Client2* deployment classes which was missed by the https://github.com/jakartaee/platform-tck/pull/2616 change for the same challenge.

**Additional context**

```
java.lang.LinkageError: loader constraint violation: when resolving method 'com.sun.ts.lib.harness.Status com.sun.ts.lib.harness.RemoteStatus.toStatus()' the class loader 'deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar' @19aae096 of the current class, com/sun/ts/tests/common/vehicle/web/AltWebVehicleRunner, and the class loader 'deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear' @4d5c8d6e for the method's defining class, com/sun/ts/lib/harness/RemoteStatus, have different Class objects for the type com/sun/ts/lib/harness/Status used in the signature (com.sun.ts.tests.common.vehicle.web.AltWebVehicleRunner is in unnamed module of loader 'deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar' @19aae096, parent loader 'app'; com.sun.ts.lib.harness.RemoteStatus is in unnamed module of loader 'deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear' @4d5c8d6e, parent loader 'app')
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar//com.sun.ts.tests.common.vehicle.web.AltWebVehicleRunner.runWebVehicleTest(AltWebVehicleRunner.java:137)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar//com.sun.ts.tests.common.vehicle.web.AltWebVehicleRunner.run(AltWebVehicleRunner.java:84)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar//com.sun.ts.tests.common.vehicle.appmanaged.AppManagedVehicleRunner.run(AppManagedVehicleRunner.java:47)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar//com.sun.ts.tests.common.base.ServiceEETest.run(ServiceEETest.java:120)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar//com.sun.ts.tests.common.base.EETest.getPropsReady(EETest.java:445)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar//com.sun.ts.tests.common.base.ServiceEETest.run(ServiceEETest.java:221)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar//com.sun.ts.tests.common.base.EETest.run(EETest.java:259)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at deployment.jpa_core_criteriaapi_metamodelquery_vehicles.ear.jpa_core_criteriaapi_metamodelquery_vehicles_client.jar//com.sun.ts.tests.common.vehicle.VehicleClient.main(VehicleClient.java:37)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at java.base/java.lang.reflect.Method.invoke(Method.java:565)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at org.jboss.as.appclient@40.0.0.Beta1-SNAPSHOT//org.jboss.as.appclient.service.ApplicationClientStartService$1.run(ApplicationClientStartService.java:89)
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57)  at java.base/java.lang.Thread.run(Thread.java:1516)
2026-04-20 13:16:56,017 INFO  [stdout] (Thread-57) 04-20-2026 13:16:56:  TRACE: SLEPT FOR:  0
2026-04-20 13:16:56,017 ERROR [stderr] (Thread-57) STATUS:Failed.Vehicle runner failed.
```

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
