### PR TITLE
issue 2673 - Remove recent added extra copy of Stateful3IF.class that causes java.lang.ClassCastException

### DIFF
--- a/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/ejb/exclude/ClientTest.java
+++ b/tcks/apis/persistence/persistence-inside-container/platform-tests/src/main/java/ee/jakarta/tck/persistence/ee/packaging/ejb/exclude/ClientTest.java
@@ -76,7 +76,7 @@ public class ClientTest extends ee.jakarta.tck.persistence.ee.packaging.ejb.excl
 
             // non-vehicle appclientproxy invoker war
             WebArchive appclientproxy = ShrinkWrap.create(WebArchive.class, "appclientproxy.war");
-            appclientproxy.addClasses(Client.class, ClientServletTarget.class, ServletNoVehicle.class, Stateful3IF.class, Stateful3Bean.class);
+            appclientproxy.addClasses(Client.class, ClientServletTarget.class, ServletNoVehicle.class, Stateful3Bean.class);
             appclientproxy.addAsWebInfResource(new StringAsset(""), "beans.xml");
 
         // Ear


### PR DESCRIPTION


**Fixes Issue**
#2673 

**Describe the change**
https://github.com/jakartaee/platform-tck/commit/dca311ea43d95dcb4b05c72f55884edf0c9044a3#diff-07b7cc70ce03cc743dd32e5034061cc41c7561ebd343368a28165be6798d8950R79 added an extra copy of the Stateful3IF class which causes ClassCastException so this pull updates the change merged last week.  This change is specifically to make this updated test portable to different EE 11 implementations.

**Additional context**
Add any other context about the problem here.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
