### PR TITLE
Migrate CDI EE TCK assertions to CDI TCK 5.0.0.Alpha5 API

### DIFF
--- a/tcks/apis/cdi-ee-tck/tck/pom.xml
+++ b/tcks/apis/cdi-ee-tck/tck/pom.xml
@@ -38,9 +38,9 @@
     <dependencies>
         <!-- Jakarta EE dependencies -->
         <dependency>
-            <groupId>jakarta.enterprise</groupId>
-            <artifactId>cdi-tck-core-impl</artifactId>
-            <version>4.1.0</version>
+            <groupId>jakarta.cdi</groupId>
+            <artifactId>jakarta.cdi-tck-core-impl</artifactId>
+            <version>5.0.0.Alpha5</version>
         </dependency>
 
         <dependency>

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/SessionBeanTypesTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/definition/bean/types/enterprise/SessionBeanTypesTest.java
@@ -18,7 +18,7 @@ package org.jboss.cdi.tck.tests.definition.bean.types.enterprise;
 
 import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.SESSION_BEAN_TYPES;
-import static org.jboss.cdi.tck.util.Assert.assertTypeSetMatches;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -58,7 +58,7 @@ public class SessionBeanTypesTest extends AbstractTest {
         assertNotNull(vultureBean);
         // Object, Bird<Integer>, Vulture
         assertEquals(vultureBean.getTypes().size(), 3);
-        assertTypeSetMatches(vultureBean.getTypes(), Object.class, Vulture.class, new TypeLiteral<Bird<Integer>>() {
+        assertTypesMatch(vultureBean.getTypes(), Object.class, Vulture.class, new TypeLiteral<Bird<Integer>>() {
         }.getType());
 
         // Generic class inheritance with two interfaces
@@ -68,7 +68,7 @@ public class SessionBeanTypesTest extends AbstractTest {
         assertNotNull(tigerBean);
         // Object, Animal<String>, Mammal<String>
         assertEquals(tigerBean.getTypes().size(), 3);
-        assertTypeSetMatches(tigerBean.getTypes(), Object.class, new TypeLiteral<Animal<String>>() {
+        assertTypesMatch(tigerBean.getTypes(), Object.class, new TypeLiteral<Animal<String>>() {
         }.getType(), mammalLiteral.getType());
 
         // session bean with both local business interface and no-interface view
@@ -76,7 +76,7 @@ public class SessionBeanTypesTest extends AbstractTest {
         assertNotNull(creatureBean);
         // Object, LegendaryCreature, LegendaryLocal, Creature
         assertEquals(creatureBean.getTypes().size(), 4);
-        assertTypeSetMatches(creatureBean.getTypes(), Object.class, LegendaryCreature.class, LegendaryLocal.class,
+        assertTypesMatch(creatureBean.getTypes(), Object.class, LegendaryCreature.class, LegendaryLocal.class,
                 Creature.class);
     }
 
@@ -89,7 +89,7 @@ public class SessionBeanTypesTest extends AbstractTest {
         assertNotNull(creatureBean);
         // Object, LegendaryCreature, LegendaryLocal, Creature
         assertEquals(creatureBean.getTypes().size(), 4);
-        assertTypeSetMatches(creatureBean.getTypes(), Object.class, LegendaryCreature.class, LegendaryLocal.class,
+        assertTypesMatch(creatureBean.getTypes(), Object.class, LegendaryCreature.class, LegendaryLocal.class,
                 Creature.class);
     }
 
@@ -102,7 +102,7 @@ public class SessionBeanTypesTest extends AbstractTest {
         assertNotNull(loginBean);
         // MockLoginActionBean, LoginActionBean, Object
         assertEquals(loginBean.getTypes().size(), 3);
-        assertTypeSetMatches(loginBean.getTypes(), Object.class, LoginActionBean.class, MockLoginActionBean.class);
+        assertTypesMatch(loginBean.getTypes(), Object.class, LoginActionBean.class, MockLoginActionBean.class);
     }
     
     @Test(groups = INTEGRATION)
@@ -111,6 +111,6 @@ public class SessionBeanTypesTest extends AbstractTest {
         Bean<Cobra> cobraBean = getUniqueBean(Cobra.class);
         assertNotNull(cobraBean);
         assertEquals(cobraBean.getTypes().size(), 3);
-        assertTypeSetMatches(cobraBean.getTypes(), Object.class, Cobra.class, Snake.class);
+        assertTypesMatch(cobraBean.getTypes(), Object.class, Cobra.class, Snake.class);
     }
 }

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/EnterpriseQualifierDefinitionTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/definition/qualifier/enterprise/EnterpriseQualifierDefinitionTest.java
@@ -26,6 +26,7 @@ import jakarta.enterprise.inject.spi.Bean;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -46,7 +47,7 @@ public class EnterpriseQualifierDefinitionTest extends AbstractTest {
     public void testQualifierDeclaredInheritedIsInherited() throws Exception {
         Set<? extends Annotation> qualifiers = getBeans(BorderCollieLocal.class, new HairyQualifier(false)).iterator().next()
                 .getQualifiers();
-        assert annotationSetMatches(qualifiers, Any.class, Hairy.class);
+        Assert.assertAnnotationsMatch(qualifiers, Any.class, Hairy.class);
     }
 
     @Test(groups = INTEGRATION)
@@ -60,7 +61,7 @@ public class EnterpriseQualifierDefinitionTest extends AbstractTest {
     public void testQualifierDeclaredInheritedIsIndirectlyInherited() {
         Set<? extends Annotation> qualifiers = getBeans(EnglishBorderCollieLocal.class, new HairyQualifier(false)).iterator()
                 .next().getQualifiers();
-        assert annotationSetMatches(qualifiers, Any.class, Hairy.class);
+        Assert.assertAnnotationsMatch(qualifiers, Any.class, Hairy.class);
     }
 
     @Test(groups = INTEGRATION)

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/CreateBeanAttributesTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/extensions/beanManager/beanAttributes/ejb/CreateBeanAttributesTest.java
@@ -27,6 +27,7 @@ import jakarta.enterprise.inject.spi.BeanAttributes;
 import jakarta.inject.Named;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.full.extensions.beanManager.beanAttributes.Animal;
 import org.jboss.cdi.tck.tests.full.extensions.beanManager.beanAttributes.Fish;
@@ -76,9 +77,9 @@ public class CreateBeanAttributesTest extends AbstractTest {
         AnnotatedType<Lake> type = getCurrentManager().createAnnotatedType(Lake.class);
         BeanAttributes<Lake> attributes = getCurrentManager().createBeanAttributes(type);
 
-        assertTrue(typeSetMatches(attributes.getTypes(), LakeLocal.class, WaterBody.class, Landmark.class, Object.class));
-        assertTrue(typeSetMatches(attributes.getStereotypes(), TundraStereotype.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), Natural.class, Any.class));
+        Assert.assertTypesMatch(attributes.getTypes(), LakeLocal.class, WaterBody.class, Landmark.class, Object.class);
+        Assert.assertTypesMatch(attributes.getStereotypes(), TundraStereotype.class);
+        Assert.assertAnnotationsMatch(attributes.getQualifiers(), Natural.class, Any.class);
         assertEquals(attributes.getScope(), Dependent.class);
         assertEquals(attributes.getName(), "lake");
         assertTrue(attributes.isAlternative());
@@ -148,9 +149,9 @@ public class CreateBeanAttributesTest extends AbstractTest {
 
     @SuppressWarnings("unchecked")
     private void verifyLakeFish(BeanAttributes<?> attributes) {
-        assertTrue(typeSetMatches(attributes.getTypes(), Fish.class, Object.class));
-        assertTrue(typeSetMatches(attributes.getStereotypes(), TundraStereotype.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), Natural.class, Any.class, Named.class));
+        Assert.assertTypesMatch(attributes.getTypes(), Fish.class, Object.class);
+        Assert.assertTypesMatch(attributes.getStereotypes(), TundraStereotype.class);
+        Assert.assertAnnotationsMatch(attributes.getQualifiers(), Natural.class, Any.class, Named.class);
         assertEquals(attributes.getScope(), ApplicationScoped.class);
         assertEquals(attributes.getName(), "fish");
         assertTrue(attributes.isAlternative());
@@ -158,8 +159,8 @@ public class CreateBeanAttributesTest extends AbstractTest {
 
     @SuppressWarnings("unchecked")
     private void verifyDamFish(BeanAttributes<?> attributes) {
-        assertTrue(typeSetMatches(attributes.getTypes(), Fish.class, Animal.class, Object.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), Wild.class, Any.class));
+        Assert.assertTypesMatch(attributes.getTypes(), Fish.class, Animal.class, Object.class);
+        Assert.assertAnnotationsMatch(attributes.getQualifiers(), Wild.class, Any.class);
         assertTrue(attributes.getStereotypes().isEmpty());
         assertEquals(attributes.getScope(), Dependent.class);
         assertNull(attributes.getName());
@@ -168,8 +169,8 @@ public class CreateBeanAttributesTest extends AbstractTest {
 
     @SuppressWarnings("unchecked")
     private void verifyVolume(BeanAttributes<?> attributes) {
-        assertTrue(typeSetMatches(attributes.getTypes(), long.class, Object.class));
-        assertTrue(annotationSetMatches(attributes.getQualifiers(), Any.class, Default.class, Named.class));
+        Assert.assertTypesMatch(attributes.getTypes(), long.class, Object.class);
+        Assert.assertAnnotationsMatch(attributes.getQualifiers(), Any.class, Default.class, Named.class);
         assertTrue(attributes.getStereotypes().isEmpty());
         assertEquals(attributes.getScope(), Dependent.class);
         assertEquals(attributes.getName(), "volume");

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ContainerEventTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/extensions/container/event/ContainerEventTest.java
@@ -34,6 +34,7 @@ import jakarta.enterprise.inject.spi.AnnotatedType;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.EnterpriseArchiveBuilder;
 import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.spec.EnterpriseArchive;
@@ -148,20 +149,20 @@ public class ContainerEventTest extends AbstractTest {
 
     private void validateStatelessSessionBean(Annotated type) {
         assert type.getBaseType().equals(Sheep.class);
-        assert typeSetMatches(type.getTypeClosure(), Sheep.class, SheepLocal.class, Object.class);
+        Assert.assertTypesMatch(type.getTypeClosure(), Sheep.class, SheepLocal.class, Object.class);
         assert type.getAnnotations().size() == 2;
-        assert annotationSetMatches(type.getAnnotations(), Tame.class, Stateless.class);
+        Assert.assertAnnotationsMatch(type.getAnnotations(), Tame.class, Stateless.class);
     }
 
     private void validateStatefulSessionBean(Annotated type) {
         assert type.getBaseType().equals(Cow.class);
-        assert typeSetMatches(type.getTypeClosure(), Cow.class, CowLocal.class, Object.class);
+        Assert.assertTypesMatch(type.getTypeClosure(), Cow.class, CowLocal.class, Object.class);
         assert type.getAnnotations().size() == 0;
     }
 
     private void validateSessionBeanInterceptor(AnnotatedType<SheepInterceptor> type) {
         assert type.getBaseType().equals(SheepInterceptor.class);
-        assert typeSetMatches(type.getTypeClosure(), SheepInterceptor.class, Object.class);
+        Assert.assertTypesMatch(type.getTypeClosure(), SheepInterceptor.class, Object.class);
         assert type.getAnnotations().size() == 0;
         assert type.getFields().size() == 0;
         assert type.getMethods().size() == 1;
@@ -169,7 +170,7 @@ public class ContainerEventTest extends AbstractTest {
 
     private void validateManagedBean(AnnotatedType<Farm> type) {
         assert type.getBaseType().equals(Farm.class);
-        assert typeSetMatches(type.getTypeClosure(), Farm.class, Object.class);
+        Assert.assertTypesMatch(type.getTypeClosure(), Farm.class, Object.class);
         assert type.getFields().size() == 1;
         assert type.getFields().iterator().next().isAnnotationPresent(Produces.class);
         assert type.getMethods().size() == 1;

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/ejb/VerifyValuesTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/extensions/lifecycle/processBeanAttributes/ejb/VerifyValuesTest.java
@@ -29,6 +29,7 @@ import jakarta.inject.Inject;
 import jakarta.inject.Named;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
 import org.jboss.cdi.tck.tests.full.extensions.lifecycle.processBeanAttributes.Alpha;
 import org.jboss.cdi.tck.tests.full.extensions.lifecycle.processBeanAttributes.Bravo;
@@ -107,9 +108,9 @@ public class VerifyValuesTest extends AbstractTest {
         verifyName(deltaAttributes, "delta");
         assertFalse(deltaAttributes.isAlternative());
 
-        assertTrue(typeSetMatches(deltaAttributes.getTypes(), Object.class, Delta.class));
+        Assert.assertTypesMatch(deltaAttributes.getTypes(), Object.class, Delta.class);
         assertTrue(deltaAttributes.getStereotypes().isEmpty());
-        assertTrue(annotationSetMatches(deltaAttributes.getQualifiers(), Named.class, Any.class, Default.class));
+        Assert.assertAnnotationsMatch(deltaAttributes.getQualifiers(), Named.class, Any.class, Default.class);
     }
 
     @Test
@@ -132,7 +133,7 @@ public class VerifyValuesTest extends AbstractTest {
         assertEquals(Dependent.class, attributes.getScope());
         assertFalse(attributes.isAlternative());
 
-        assertTrue(typeSetMatches(attributes.getTypes(), Object.class, BravoInterceptor.class));
+        Assert.assertTypesMatch(attributes.getTypes(), Object.class, BravoInterceptor.class);
         assertTrue(attributes.getStereotypes().isEmpty());
     }
 
@@ -144,7 +145,7 @@ public class VerifyValuesTest extends AbstractTest {
         assertEquals(Dependent.class, attributes.getScope());
         assertFalse(attributes.isAlternative());
 
-        assertTrue(typeSetMatches(attributes.getTypes(), Object.class, BravoDecorator.class, BravoInterface.class));
+        Assert.assertTypesMatch(attributes.getTypes(), Object.class, BravoDecorator.class, BravoInterface.class);
         assertTrue(attributes.getStereotypes().size() == 1);
         assertTrue(attributes.getStereotypes().iterator().next().equals(Decorator.class));
     }

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/RemoteInterfaceNotInAPITypesTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/enterprise/definition/remote/RemoteInterfaceNotInAPITypesTest.java
@@ -17,7 +17,7 @@ package org.jboss.cdi.tck.tests.implementation.enterprise.definition.remote;
 
 import static org.jboss.cdi.tck.TestGroups.JAVAEE_FULL;
 import static org.jboss.cdi.tck.cdi.Sections.SESSION_BEAN_TYPES;
-import static org.jboss.cdi.tck.util.Assert.assertTypeSetMatches;
+import static org.jboss.cdi.tck.util.Assert.assertTypesMatch;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -52,13 +52,13 @@ public class RemoteInterfaceNotInAPITypesTest extends AbstractTest {
         // only remote view
         Bean<Object> collieBean = getUniqueBean(Object.class, new Tame.Literal());
         assertNotNull(collieBean);
-        assertTypeSetMatches(collieBean.getTypes(), Object.class);
+        assertTypesMatch(collieBean.getTypes(), Object.class);
 
         Bean<DogLocal> pitbullBean = getUniqueBean(DogLocal.class);
         assertNotNull(pitbullBean);
         // DogLocal, Bar, SuperBar, Object
         assertEquals(pitbullBean.getTypes().size(), 4);
-        assertTypeSetMatches(pitbullBean.getTypes(), Object.class, DogLocal.class, Bar.class, SuperBar.class);
+        assertTypesMatch(pitbullBean.getTypes(), Object.class, DogLocal.class, Bar.class, SuperBar.class);
     }
 
 }

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/EjbInjectionTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/ejb/EjbInjectionTest.java
@@ -27,6 +27,7 @@ import jakarta.enterprise.util.AnnotationLiteral;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -75,7 +76,7 @@ public class EjbInjectionTest extends AbstractTest {
         @SuppressWarnings("serial")
         Bean<BeanRemote> beanRemote = getBeans(BeanRemote.class, new Lazy.Literal()).iterator().next();
         assert beanRemote.getTypes().size() == 3;
-        assert typeSetMatches(beanRemote.getTypes(), BeanRemote.class, Object.class, AnotherInterface.class);
+        Assert.assertTypesMatch(beanRemote.getTypes(), BeanRemote.class, Object.class, AnotherInterface.class);
     }
 
 }

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/EnvInjectionTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/env/EnvInjectionTest.java
@@ -20,8 +20,12 @@ import static org.jboss.cdi.tck.cdi.Sections.DECLARING_RESOURCE;
 import static org.jboss.cdi.tck.cdi.Sections.RESOURCE_LIFECYCLE;
 import static org.jboss.cdi.tck.cdi.Sections.RESOURCE_TYPES;
 
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 import jakarta.enterprise.context.spi.CreationalContext;
 import jakarta.enterprise.inject.spi.Bean;
@@ -29,6 +33,7 @@ import jakarta.enterprise.util.AnnotationLiteral;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -87,7 +92,14 @@ public class EnvInjectionTest extends AbstractTest {
         Class<?>[] expectedClasses = new Class[classes.size()];
         classes.toArray(expectedClasses);
 
-        assert check.getTypes().size() == expectedClasses.length : "Bean<Boolean> has "+expectedClasses.length+" types: "+check.getTypes();
-        assert rawTypeSetMatches(check.getTypes(), expectedClasses) : "Expected classes are: "+classes;
+        Set<Type> rawTypes = new HashSet<>();
+        for (Type type : check.getTypes()) {
+            if (type instanceof Class<?>) {
+                rawTypes.add(type);
+            } else if (type instanceof ParameterizedType) {
+                rawTypes.add(((ParameterizedType) type).getRawType());
+            }
+        }
+        Assert.assertTypesMatch(rawTypes, expectedClasses);
     }
 }

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/PersistenceContextInjectionTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/implementation/simple/resource/persistenceContext/PersistenceContextInjectionTest.java
@@ -30,6 +30,7 @@ import jakarta.persistence.EntityManagerFactory;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -101,9 +102,9 @@ public class PersistenceContextInjectionTest extends AbstractTest {
     public void testBeanTypesAndBindingTypesOfPersistenceContext() {
         Bean<EntityManager> manager = getBeans(EntityManager.class, new Database.Literal()).iterator().next();
         assert manager.getTypes().size() == 3;
-        assert typeSetMatches(manager.getTypes(), EntityManager.class, Object.class, AutoCloseable.class);
+        Assert.assertTypesMatch(manager.getTypes(), EntityManager.class, Object.class, AutoCloseable.class);
         assert manager.getQualifiers().size() == 2;
-        assert annotationSetMatches(manager.getQualifiers(), Any.class, Database.class);
+        Assert.assertAnnotationsMatch(manager.getQualifiers(), Any.class, Database.class);
     }
 
     @Test
@@ -111,6 +112,6 @@ public class PersistenceContextInjectionTest extends AbstractTest {
     public void testBeanTypesOfPersistenceUnit() {
         Bean<EntityManagerFactory> factory = getBeans(EntityManagerFactory.class, new Database.Literal()).iterator().next();
         assert factory.getTypes().size() == 3;
-        assert typeSetMatches(factory.getTypes(), EntityManagerFactory.class, Object.class, AutoCloseable.class);
+        Assert.assertTypesMatch(factory.getTypes(), EntityManagerFactory.class, Object.class, AutoCloseable.class);
     }
 }

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/EnterpriseBeanSpecializationTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/enterprise/EnterpriseBeanSpecializationTest.java
@@ -19,7 +19,6 @@ import static org.jboss.cdi.tck.TestGroups.INTEGRATION;
 import static org.jboss.cdi.tck.cdi.Sections.DIRECT_AND_INDIRECT_SPECIALIZATION_EE;
 import static org.jboss.cdi.tck.cdi.Sections.SPECIALIZE_SESSION_BEAN;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
@@ -32,6 +31,7 @@ import jakarta.inject.Named;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -62,7 +62,7 @@ public class EnterpriseBeanSpecializationTest extends AbstractTest {
         // Types of specializing bean
         Set<Type> lazyFarmerBeanTypes = lazyFarmerBean.getTypes();
         assertEquals(lazyFarmerBeanTypes.size(), 3);
-        assertTrue(typeSetMatches(lazyFarmerBeanTypes, Object.class, FarmerLocal.class, LazyFarmerLocal.class));
+        Assert.assertTypesMatch(lazyFarmerBeanTypes, Object.class, FarmerLocal.class, LazyFarmerLocal.class);
     }
 
     @SuppressWarnings("unchecked")
@@ -74,7 +74,7 @@ public class EnterpriseBeanSpecializationTest extends AbstractTest {
         Bean<LazyFarmerLocal> lazyFarmerBean = farmerBeans.iterator().next();
         assertEquals(lazyFarmerBean.getQualifiers().size(), 4);
         // LazyFarmer inherits LandOwner and Named from Farmer
-        assertTrue(annotationSetMatches(lazyFarmerBean.getQualifiers(), Landowner.class, Lazy.class, Any.class, Named.class));
+        Assert.assertAnnotationsMatch(lazyFarmerBean.getQualifiers(), Landowner.class, Lazy.class, Any.class, Named.class);
     }
 
     @Test(groups = INTEGRATION)

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/EnterpriseProducerMethodSpecializationTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/inheritance/specialization/producer/method/enterprise/EnterpriseProducerMethodSpecializationTest.java
@@ -22,6 +22,8 @@ import static org.jboss.cdi.tck.cdi.Sections.PRODUCER_METHOD_EE;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 
+import org.jboss.cdi.tck.util.Assert;
+
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 import java.util.Set;
@@ -70,12 +72,12 @@ public class EnterpriseProducerMethodSpecializationTest extends AbstractTest {
         // Check types of specializing bean
         Set<Type> expensiveNecklaceBeanTypes = expensiveNecklaceBean.getTypes();
         assertEquals(expensiveNecklaceBeanTypes.size(), 3);
-        assertTrue(typeSetMatches(expensiveNecklaceBeanTypes, Object.class, Product.class, Necklace.class));
+        Assert.assertTypesMatch(expensiveNecklaceBeanTypes, Object.class, Product.class, Necklace.class);
 
         // Check qualifiers of specializing bean
         Set<Annotation> expensiveNecklaceQualifiers = expensiveNecklaceBean.getQualifiers();
         assertEquals(expensiveNecklaceQualifiers.size(), 4);
-        assertTrue(annotationSetMatches(expensiveNecklaceQualifiers, Expensive.class, Sparkly.class, Any.class, Named.class));
+        Assert.assertAnnotationsMatch(expensiveNecklaceQualifiers, Expensive.class, Sparkly.class, Any.class, Named.class);
 
         // There is only one bean for type Necklace and qualifier Sparkly
         Set<Bean<Necklace>> sparklyNecklaceBeans = getBeans(Necklace.class, SPARKLY_LITERAL);

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/ContainerEventTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/injection/non/contextual/ContainerEventTest.java
@@ -43,6 +43,7 @@ import jakarta.servlet.jsp.tagext.SimpleTagSupport;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.BeanDiscoveryMode;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -149,16 +150,16 @@ public class ContainerEventTest extends AbstractTest {
 
     private void validateTagHandlerAnnotatedType(AnnotatedType<TestTagHandler> type) {
         assertEquals(type.getBaseType(), TestTagHandler.class);
-        assertTrue(typeSetMatches(type.getTypeClosure(), TestTagHandler.class, SimpleTagSupport.class, SimpleTag.class,
-                JspTag.class, Object.class));
+        Assert.assertTypesMatch(type.getTypeClosure(), TestTagHandler.class, SimpleTagSupport.class, SimpleTag.class,
+                JspTag.class, Object.class);
         assertEquals(type.getAnnotations().size(), 1);
         assertTrue(type.isAnnotationPresent(Any.class));
     }
 
     private void validateTagLibraryListenerAnnotatedType(AnnotatedType<TagLibraryListener> type) {
         assertEquals(type.getBaseType(), TagLibraryListener.class);
-        assertTrue(typeSetMatches(type.getTypeClosure(), TagLibraryListener.class, ServletContextListener.class,
-                EventListener.class, Object.class));
+        Assert.assertTypesMatch(type.getTypeClosure(), TagLibraryListener.class, ServletContextListener.class,
+                EventListener.class, Object.class);
         assertEquals(type.getFields().size(), 2);
         assertEquals(type.getConstructors().size(), 1);
         assertTrue(type.getMethods().stream().anyMatch(m -> m.getJavaMember().getName().equals("contextInitialized")));
@@ -166,14 +167,14 @@ public class ContainerEventTest extends AbstractTest {
 
     private void validateServletAnnotatedType(AnnotatedType<TestServlet> type) {
         assertEquals(type.getBaseType(), TestServlet.class);
-        assertTrue(typeSetMatches(type.getTypeClosure(), TestServlet.class, HttpServlet.class, GenericServlet.class,
-                Servlet.class, ServletConfig.class, Serializable.class, Object.class));
+        Assert.assertTypesMatch(type.getTypeClosure(), TestServlet.class, HttpServlet.class, GenericServlet.class,
+                Servlet.class, ServletConfig.class, Serializable.class, Object.class);
         assertTrue(type.getAnnotations().isEmpty());
     }
 
     private void validateFilterAnnotatedType(AnnotatedType<TestFilter> type) {
         assertEquals(type.getBaseType(), TestFilter.class);
-        assertTrue(typeSetMatches(type.getTypeClosure(), TestFilter.class, Filter.class, Object.class));
+        Assert.assertTypesMatch(type.getTypeClosure(), TestFilter.class, Filter.class, Object.class);
         assertEquals(type.getFields().size(), 12);
         assertEquals(type.getConstructors().size(), 1);
         assertTrue(type.getConstructors().iterator().next().getParameters().isEmpty());

--- a/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/EnterpriseResolutionByTypeTest.java
+++ b/tcks/apis/cdi-ee-tck/tck/src/main/java/org/jboss/cdi/tck/tests/lookup/typesafe/resolution/interceptor/ejb/EnterpriseResolutionByTypeTest.java
@@ -22,6 +22,7 @@ import jakarta.enterprise.inject.spi.Bean;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.cdi.tck.AbstractTest;
+import org.jboss.cdi.tck.util.Assert;
 import org.jboss.cdi.tck.shrinkwrap.ee.WebArchiveBuilder;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.jboss.test.audit.annotations.SpecAssertion;
@@ -46,7 +47,7 @@ public class EnterpriseResolutionByTypeTest extends AbstractTest {
         assert getBeans(CapercaillieLocal.class).size() == 1;
         assert getBeans(ScottishBirdLocal.class).isEmpty();
         Bean<CapercaillieLocal> bean = getUniqueBean(CapercaillieLocal.class);
-        assert typeSetMatches(bean.getTypes(), CapercaillieLocal.class, Object.class);
+        Assert.assertTypesMatch(bean.getTypes(), CapercaillieLocal.class, Object.class);
     }
 
 }


### PR DESCRIPTION
There were some changes in the CDI TCK test utils and as it turns out, those are used here as well.
Original TCK PR was https://github.com/jakartaee/cdi-tck/pull/676

These changes adapt tests under platform TCKs accordingly.
There is also a change in the TCK coordinates - all CDI and CDI TCK artifacts changed there coordinates to more sensible ones as part of the 5.0 development.

CC @Ladicek  @Azquelt