### PR TITLE
Update GlassFish runners to platform 11.0.3 TCK

### DIFF
--- a/glassfish-runner/annotations-tck/pom.xml
+++ b/glassfish-runner/annotations-tck/pom.xml
@@ -24,7 +24,7 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
     
@@ -34,7 +34,7 @@
     <packaging>jar</packaging>
 
     <properties>
-        <glassfish.version>8.0.0-M9</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <tck.artifactId>jakarta-annotations-tck</tck.artifactId>
         <tck.version>3.0.0</tck.version>

--- a/glassfish-runner/batch-tck/pom.xml
+++ b/glassfish-runner/batch-tck/pom.xml
@@ -40,7 +40,7 @@ Copyright (c) 2022 Contributors to the Eclipse Foundation
 
     <properties>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <jakarta.batch.version>2.1.5</jakarta.batch.version>
     </properties>
 

--- a/glassfish-runner/batch-tck/sigtests/pom.xml
+++ b/glassfish-runner/batch-tck/sigtests/pom.xml
@@ -13,7 +13,7 @@
 
     <properties>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
         <jakarta.batch.version>2.1.5</jakarta.batch.version>
     </properties>

--- a/glassfish-runner/bom/pom.xml
+++ b/glassfish-runner/bom/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -32,14 +32,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.tck</groupId>
     <artifactId>glassfish-runner-bom</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
     <name>Glassfish Runner BOM</name>
 
     <properties>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <tck.version>11.0.2</tck.version>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <tck.version>11.0.3</tck.version>
+        <glassfish.version>8.0.2</glassfish.version>
     </properties>
 
     <dependencyManagement>
@@ -70,7 +70,7 @@
             <dependency>
                 <groupId>ee.omnifish.arquillian</groupId>
                 <artifactId>arquillian-glassfish-server-managed</artifactId>
-                <version>2.1.2</version>
+                <version>2.1.3</version>
                 <scope>test</scope>
             </dependency>
         </dependencies>

--- a/glassfish-runner/cdi-model-tck/pom.xml
+++ b/glassfish-runner/cdi-model-tck/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -19,8 +19,8 @@
         <cdi.tck-4-0.version>4.1.0</cdi.tck-4-0.version>
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0-M15</glassfish.version>
-        <maven.compiler.release>17</maven.compiler.release>
+        <glassfish.version>8.0.2</glassfish.version>
+        <maven.compiler.release>21</maven.compiler.release>
         <weld.version>6.0.3.Final</weld.version>
 
     </properties>
@@ -125,7 +125,7 @@
         <dependency>
             <groupId>ee.omnifish.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>2.1.2</version>
+            <version>2.1.3</version>
         </dependency>
     </dependencies>
 

--- a/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-install/pom.xml
@@ -22,7 +22,7 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -33,10 +33,10 @@
    <name>TCK: Install Jakarta cdi Platform Extra TCK</name>
 
    <properties>
-        <tck.test.cdi-extra.file>jakartaeetck-${tck.test.cdi-extra.version}-dist.zip</tck.test.cdi-extra.file>
+        <tck.test.cdi-extra.file>jakartaeetck-${tck.test.cdi-extra.version}.zip</tck.test.cdi-extra.file>
         <tck.test.cdi-extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.cdi-extra.file}</tck.test.cdi-extra.url>
 
-        <tck.test.cdi-extra.version>11.0.2</tck.test.cdi-extra.version>
+        <tck.test.cdi-extra.version>11.0.3</tck.test.cdi-extra.version>
     </properties>
 
    <build>

--- a/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-run/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath/>
     </parent>
 
@@ -36,15 +36,15 @@
     <properties>
         <cdi.tck-4-1.version>4.1.0</cdi.tck-4-1.version>
         <!-- The CDI EE Platform Integration TCK Version -->
-        <tck.version>11.0.2</tck.version>
+        <tck.version>11.0.3</tck.version>
 
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.root>${project.build.directory}</glassfish.root>
 
         <maven.build.cache.enabled>false</maven.build.cache.enabled>
 
-        <!-- Weld uses 2 versions numbers. Some artefact use one version, other the second. -->
+        <!-- Weld uses 2 versions numbers. Some artefacts use one version, other the second. -->
         <weld.version>6.0.3.Final</weld.version>
         <weld.version2>6.0.Final</weld.version2>
     </properties>

--- a/glassfish-runner/cdi-platform-extra-tck/pom.xml
+++ b/glassfish-runner/cdi-platform-extra-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/cdi-tck/cdi-tck-install/pom.xml
+++ b/glassfish-runner/cdi-tck/cdi-tck-install/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/cdi-tck/cdi-tck-run/pom.xml
+++ b/glassfish-runner/cdi-tck/cdi-tck-run/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -38,7 +38,7 @@
         <cdi.tck-4-1.version>4.1.0</cdi.tck-4-1.version>
         <glassfish.root>${project.build.directory}</glassfish.root>
 
-        <glassfish.version>8.0.0-M15</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
 
         <!-- This matches the htmlunit version in TCK -->
         <htmlunit.version>2.50.0</htmlunit.version>

--- a/glassfish-runner/cdi-tck/pom.xml
+++ b/glassfish-runner/cdi-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/concurrency-tck/pom.xml
+++ b/glassfish-runner/concurrency-tck/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -37,8 +37,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
     </properties>

--- a/glassfish-runner/connector-platform-tck/pom.xml
+++ b/glassfish-runner/connector-platform-tck/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>glassfish.connector-platform-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -40,8 +40,8 @@
         <glassfish.home>${project.build.directory}/glassfish${glassfish.major}</glassfish.home>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
         
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <tck.version>11.0.2</tck.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <tck.version>11.0.3</tck.version>
 
         <whitebox.directory>target/whiteboxes</whitebox.directory>
     </properties>

--- a/glassfish-runner/data-tck/pom.xml
+++ b/glassfish-runner/data-tck/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -36,12 +36,11 @@
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.version.main>8</glassfish.version.main>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
 
-        <!-- Require at least Java 17 to compile -->
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
 
         <jakarta.data.version>1.0.0</jakarta.data.version>
 

--- a/glassfish-runner/di-tck/installer/pom.xml
+++ b/glassfish-runner/di-tck/installer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/di-tck/pom.xml
+++ b/glassfish-runner/di-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/di-tck/runner/pom.xml
+++ b/glassfish-runner/di-tck/runner/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-install/pom.xml
+++ b/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-install/pom.xml
@@ -22,24 +22,24 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
    <groupId>jakarta.tck</groupId>
    <artifactId>enterprise-beans-tck-install</artifactId>
-   <version>11.0.2</version>
+   <version>11.0.3</version>
    <packaging>pom</packaging>
 
    <name>TCK: Install Jakarta enterprise-beans TCK</name>
 
    <properties>
-        <tck.test.enterprise-beans.file>jakartaeetck-${tck.test.enterprise-beans.version}-dist.zip</tck.test.enterprise-beans.file>
+        <tck.test.enterprise-beans.file>jakartaeetck-${tck.test.enterprise-beans.version}.zip</tck.test.enterprise-beans.file>
         <tck.test.enterprise-beans.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.enterprise-beans.file}</tck.test.enterprise-beans.url>
         <!-- If this is set to a SNAPSHOT version you need to enable the -Psnapshots profile and have the snapshot
                 build staged in the download location.
         -->
-        <tck.test.enterprise-beans.version>11.0.2</tck.test.enterprise-beans.version>
+        <tck.test.enterprise-beans.version>11.0.3</tck.test.enterprise-beans.version>
     </properties>
 
    <build>

--- a/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-run/pom.xml
+++ b/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-run/pom.xml
@@ -12,11 +12,11 @@
   
   ejb30 lite env tests:
   
-  mvn clean install -Dglassfish.version=8.0.0-SNAPSHOT -Dmaven.build.cache.enabled=false -Pejb30,exclude-timeout,ejb30_lite_env
+  mvn clean install -Dglassfish.version=8.0.2-SNAPSHOT -Dmaven.build.cache.enabled=false -Pejb30,exclude-timeout,ejb30_lite_env
   
   ejb30 assembly, misc and tx tests:
   
-  mvn clean install -Dglassfish.version=8.0.0-SNAPSHOT -Dmaven.build.cache.enabled=false -Pejb30,exclude-timeout,ejb30_assembly_misc_tx
+  mvn clean install -Dglassfish.version=8.0.2-SNAPSHOT -Dmaven.build.cache.enabled=false -Pejb30,exclude-timeout,ejb30_assembly_misc_tx
   
   etc
   
@@ -27,13 +27,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>enterprise-beans-tck-run</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>jar</packaging>
 
     <name>enterprise-beans-tck</name>
@@ -54,7 +54,7 @@
         <glassfish.root>${project.build.directory}</glassfish.root>
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.version.main>8</glassfish.version.main>
         <glassfish-artifact-id>glassfish</glassfish-artifact-id>
 
@@ -64,7 +64,7 @@
         <ts.home>${basedir}/src/test/resources/jakartaeetck</ts.home>
 
         <tck.version>11.0.1</tck.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
         <version.surefire>3.5.4</version.surefire>
 
         <whitebox.directory>target/whiteboxes</whitebox.directory>

--- a/glassfish-runner/enterprise-beans-tck/pom.xml
+++ b/glassfish-runner/enterprise-beans-tck/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <artifactId>enterprise-beans-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
@@ -22,20 +22,20 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
    <artifactId>expression-language-extra-tck-install</artifactId>
-   <version>11.0.2</version>
+   <version>11.0.3</version>
    <packaging>pom</packaging>
 
    <name>TCK: Install Jakarta Expression Language Platform Substitute TCK</name>
 
    <properties>
-        <tck.test.expression-language-extra.file>jakartaeetck-${tck.test.expression-language-extra.version}-dist.zip</tck.test.expression-language-extra.file>
+        <tck.test.expression-language-extra.file>jakartaeetck-${tck.test.expression-language-extra.version}.zip</tck.test.expression-language-extra.file>
         <tck.test.expression-language-extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.expression-language-extra.file}</tck.test.expression-language-extra.url>
-        <tck.test.expression-language-extra.version>11.0.2</tck.test.expression-language-extra.version>
+        <tck.test.expression-language-extra.version>11.0.3</tck.test.expression-language-extra.version>
     </properties>
 
    <build>

--- a/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-run/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-run/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -31,10 +31,10 @@
     <properties>
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
-        <glassfish.version>8.0.0-JDK17-M12</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <tck.version>11.0.2</tck.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <tck.version>11.0.3</tck.version>
         <ts.home>./jakartaeetck</ts.home>
     </properties>
 

--- a/glassfish-runner/expression-language-platform-subst-tck/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <artifactId>expression-language-platform-subst-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/expression-language-tck/expression-language-tck-install/pom.xml
+++ b/glassfish-runner/expression-language-tck/expression-language-tck-install/pom.xml
@@ -31,9 +31,9 @@
     <name>TCK: Install Jakarta expression-language TCK</name>
 
     <properties>
+        <tck.test.expression-language.version>6.0.1</tck.test.expression-language.version>
         <tck.test.expression-language.file>jakarta-expression-language-tck-${tck.test.expression-language.version}.zip</tck.test.expression-language.file>
         <tck.test.expression-language.url>https://download.eclipse.org/jakartaee/expression-language/6.0/${tck.test.expression-language.file}</tck.test.expression-language.url>
-        <tck.test.expression-language.version>6.0.0</tck.test.expression-language.version>
     </properties>
 
     <build>
@@ -60,7 +60,6 @@
 
             <plugin>
                 <artifactId>maven-install-plugin</artifactId>
-                <version>3.1.4</version>
                 <executions>
                     <execution>
                         <id>install-expression-language-tck-pom</id>

--- a/glassfish-runner/expression-language-tck/expression-language-tck-run/pom.xml
+++ b/glassfish-runner/expression-language-tck/expression-language-tck-run/pom.xml
@@ -33,7 +33,7 @@
             GlassFish properties 
             
         -->
-        <glassfish.version>8.0.0-JDK17-M7</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
     </properties>
 
@@ -53,8 +53,8 @@
         <!-- Jakarta Expression Language TCK -->
         <dependency>
             <groupId>jakarta.tck</groupId>
-            <artifactId>jakarta-expression-language-tck</artifactId>
-            <version>6.0.2-SNAPSHOT</version>
+            <artifactId>expression-language-tck</artifactId>
+            <version>6.0.1</version>
             <scope>test</scope>
             <!-- Specially exclude el-api. Otherwise the test will test that one instead of the GF provided one.  -->
             <exclusions>
@@ -124,7 +124,7 @@
                                 <additionalClasspathElement>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/expressly.jar</additionalClasspathElement>
                             </additionalClasspathElements>
 
-                            <dependenciesToScan>jakarta.tck:jakarta-expression-language-tck</dependenciesToScan>
+                            <dependenciesToScan>jakarta.tck:expression-language-tck</dependenciesToScan>
 
                             <systemPropertyVariables>
                                 <el.classes>${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/jakarta.el-api.jar:${project.build.directory}/${glassfish.toplevel.dir}/glassfish/modules/expressly.jar</el.classes>

--- a/glassfish-runner/expression-language-tck/pom.xml
+++ b/glassfish-runner/expression-language-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-install/pom.xml
@@ -22,22 +22,22 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonb-tck-install</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <name>TCK: Install Jakarta JSON-B Extra TCK</name>
 
     <properties>
-        <tck.test.jsonb.extra.file>jakartaeetck-${tck.test.jsonb.version}-dist.zip</tck.test.jsonb.extra.file>
+        <tck.test.jsonb.extra.file>jakartaeetck-${tck.test.jsonb.version}.zip</tck.test.jsonb.extra.file>
         <tck.test.jsonb.extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.jsonb.extra.file}</tck.test.jsonb.extra.url>
         
-        <tck.test.jsonb.version>11.0.2</tck.test.jsonb.version>
+        <tck.test.jsonb.version>11.0.3</tck.test.jsonb.version>
     </properties>
 
     <build>

--- a/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-run/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsonb-platform-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -38,9 +38,9 @@
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
-        <glassfish.version>8.0.0-M11</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
 
         <tck.artifactId>jsonb-platform-tck</tck.artifactId>
         <ts.home>./jakartaeetck</ts.home>
@@ -126,7 +126,7 @@
         <dependency>
             <groupId>ee.omnifish.arquillian</groupId>
             <artifactId>glassfish-client-ee11</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/glassfish-runner/jsonb-platform-extra-tck/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonb-platform-extra-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/jsonb-tck/pom.xml
+++ b/glassfish-runner/jsonb-tck/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -20,7 +20,7 @@
     
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
-        <glassfish.version>8.0.0-M9</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
     </properties>
 
     <dependencies>

--- a/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-install/pom.xml
@@ -22,22 +22,22 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonp-tck-install</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <name>TCK: Install Jakarta JSON-P Extra TCK</name>
 
     <properties>
-        <tck.test.jsonp.extra.file>jakartaeetck-${tck.test.jsonp.version}-dist.zip</tck.test.jsonp.extra.file>
+        <tck.test.jsonp.extra.file>jakartaeetck-${tck.test.jsonp.version}.zip</tck.test.jsonp.extra.file>
         <tck.test.jsonp.extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.jsonp.extra.file}</tck.test.jsonp.extra.url>
         
-        <tck.test.jsonp.version>11.0.2</tck.test.jsonp.version>
+        <tck.test.jsonp.version>11.0.3</tck.test.jsonp.version>
     </properties>
 
     <build>

--- a/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-run/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsonp-platform-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
 
     <name>TCK: Run Jakarta JSON-P Extra TCK</name>
 
@@ -40,9 +40,9 @@
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
 
-        <glassfish.version>8.0.0</glassfish.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <tck.version>11.0.2</tck.version>
+        <glassfish.version>8.0.2</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <tck.version>11.0.3</tck.version>
         
         <ts.home>./jakartaeetck</ts.home>
     </properties>

--- a/glassfish-runner/jsonp-platform-extra-tck/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>jsonp-platform-extra-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <name>TCK: Jakarta JSON-P Extra TCK parent</name>

--- a/glassfish-runner/jsonp-tck/pom.xml
+++ b/glassfish-runner/jsonp-tck/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -34,7 +34,7 @@
     <properties>
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0-M9</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/glassfish-runner/mail-platform-tck/mail-platform-tck-install/pom.xml
+++ b/glassfish-runner/mail-platform-tck/mail-platform-tck-install/pom.xml
@@ -22,22 +22,22 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>mail-tck-install</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <name>TCK: Install Jakarta Mail TCK</name>
 
     <properties>
-        <tck.test.mail.file>jakartaeetck-${tck.test.mail.version}-dist.zip</tck.test.mail.file>
+        <tck.test.mail.file>jakartaeetck-${tck.test.mail.version}.zip</tck.test.mail.file>
         <tck.test.mail.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.mail.file}</tck.test.mail.url>
         
-        <tck.test.mail.version>11.0.2</tck.test.mail.version>
+        <tck.test.mail.version>11.0.3</tck.test.mail.version>
     </properties>
 
     <build>

--- a/glassfish-runner/mail-platform-tck/mail-platform-tck-run/pom.xml
+++ b/glassfish-runner/mail-platform-tck/mail-platform-tck-run/pom.xml
@@ -27,7 +27,7 @@
     
     Run with e.g.
     
-    mvn clean install -Pfull,mailserver-docker -Dglassfish.version=8.0.0-SNAPSHOT    
+    mvn clean install -Pfull,mailserver-docker -Dglassfish.version=8.0.2-SNAPSHOT    
     
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -36,24 +36,24 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.mail-platform-tck-run</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
     
         <glassfish.home>${project.build.directory}/glassfish8</glassfish.home>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
         <glassfish.module.dir>${glassfish.home}/glassfish/modules</glassfish.module.dir>
         
-        <glassfish.version>8.0.0</glassfish.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <tck.version>11.0.2</tck.version>
+        <glassfish.version>8.0.2</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <tck.version>11.0.3</tck.version>
         
         <destinationURL>imap://${escaped.javamail.username}:${javamail.password}@${javamail.server}:${imap.port}</destinationURL>
         <escaped.javamail.username>user01%40james.local</escaped.javamail.username>
@@ -431,7 +431,7 @@
                     <plugin>
                         <groupId>io.fabric8</groupId>
                         <artifactId>docker-maven-plugin</artifactId>
-                        <version>0.44.0</version>
+                        <version>0.48.1</version>
                         <configuration>
                             <!-- optional: mimic k8s Always -->
                             <imagePullPolicy>Always</imagePullPolicy>

--- a/glassfish-runner/mail-platform-tck/pom.xml
+++ b/glassfish-runner/mail-platform-tck/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>mail-platform-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/messaging-platform-tck/messaging-platform-tck-install/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/messaging-platform-tck-install/pom.xml
@@ -22,21 +22,21 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>messaging-tck-install</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <name>TCK: Install Jakarta Messaging Platform TCK</name>
 
     <properties>
-        <tck.test.messaging.platform.file>jakartaeetck-${tck.test.messaging.version}-dist.zip</tck.test.messaging.platform.file>
+        <tck.test.messaging.platform.file>jakartaeetck-${tck.test.messaging.version}.zip</tck.test.messaging.platform.file>
         <tck.test.messaging.platform.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.messaging.platform.file}</tck.test.messaging.platform.url>
-        <tck.test.messaging.version>11.0.2</tck.test.messaging.version>
+        <tck.test.messaging.version>11.0.3</tck.test.messaging.version>
     </properties>
 
     <build>

--- a/glassfish-runner/messaging-platform-tck/messaging-platform-tck-run/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/messaging-platform-tck-run/pom.xml
@@ -19,13 +19,13 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
    <groupId>jakarta.tck</groupId>
    <artifactId>messaging-platform-tck-run</artifactId>
-   <version>11.0.2</version>
+   <version>11.0.3</version>
    <packaging>jar</packaging>
 
    <properties>
@@ -36,9 +36,9 @@
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <glassfish-artifact-id>glassfish</glassfish-artifact-id>
 
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <glassfish.version>8.0.0</glassfish.version>
-        <tck.version>11.0.2</tck.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
+        <tck.version>11.0.3</tck.version>
         <jakarta.platform.version>11.0.0</jakarta.platform.version>
 
         <admin.pass>admin</admin.pass>

--- a/glassfish-runner/messaging-platform-tck/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/pom.xml
@@ -21,13 +21,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>messaging-platform-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/messaging-tck/pom.xml
+++ b/glassfish-runner/messaging-tck/pom.xml
@@ -26,7 +26,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -38,11 +38,11 @@
     <properties>
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0-M9</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.version.main>8</glassfish.version.main>
         
         <tck.artifactId>jakarta.jms-tck</tck.artifactId>
-        <tck.version>11.0.0-M14</tck.version>
+        <tck.version>11.0.3</tck.version>
         <admin.user>admin</admin.user>
         <admin.pass>admin</admin.pass>
         <admin.pass.file>/tmp/ripassword</admin.pass.file>
@@ -91,7 +91,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>jms-tck</artifactId>
-            <version>11.0.0-SNAPSHOT</version>
+            <version>11.0.3</version>
         </dependency>
         <dependency>
             <groupId>jakarta.tck</groupId>
@@ -115,9 +115,9 @@
             The Arquillian connector that starts GlassFish and deploys archives to it.
         -->
         <dependency>
-            <groupId>org.omnifaces.arquillian</groupId>
+            <groupId>ee.omnifish.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>1.7</version>
+            <version>2.1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/glassfish-runner/pages-debugging-other-tck/pages-debugging-other-tck-install/pom.xml
+++ b/glassfish-runner/pages-debugging-other-tck/pages-debugging-other-tck-install/pom.xml
@@ -22,7 +22,7 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/pages-debugging-other-tck/pages-debugging-other-tck-run/pom.xml
+++ b/glassfish-runner/pages-debugging-other-tck/pages-debugging-other-tck-run/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -41,7 +41,7 @@
         <tck.home>${project.build.directory}</tck.home>
 
         <glassfish.home>${project.build.directory}/glassfish8</glassfish.home>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.asadmin>${glassfish.home}/glassfish/bin/asadmin</glassfish.asadmin>
 
         <jacoco.includes>org/glassfish/**\:com/sun/enterprise/**</jacoco.includes>

--- a/glassfish-runner/pages-debugging-other-tck/pom.xml
+++ b/glassfish-runner/pages-debugging-other-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-install/pom.xml
@@ -22,20 +22,20 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
    <artifactId>pages-extra-tck-install</artifactId>
-   <version>11.0.2</version>
+   <version>11.0.3</version>
    <packaging>pom</packaging>
 
    <name>TCK: Install Jakarta Pages Platform Extra TCK</name>
 
    <properties>
-        <tck.test.pages-extra.file>jakartaeetck-${tck.test.pages-extra.version}-dist.zip</tck.test.pages-extra.file>
+        <tck.test.pages-extra.file>jakartaeetck-${tck.test.pages-extra.version}.zip</tck.test.pages-extra.file>
         <tck.test.pages-extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.pages-extra.file}</tck.test.pages-extra.url>
-        <tck.test.pages-extra.version>11.0.2</tck.test.pages-extra.version>
+        <tck.test.pages-extra.version>11.0.3</tck.test.pages-extra.version>
 
     </properties>
 

--- a/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-run/pom.xml
@@ -19,24 +19,24 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jsp-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>jar</packaging>
 
     <properties>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
         
         <jakarta.platform.version>11.0.0</jakarta.platform.version>
         <junit.jupiter.version>5.9.1</junit.jupiter.version>
         <tck.artifactId>pages-platform-tck</tck.artifactId>
-        <tck.version>11.0.2</tck.version>
+        <tck.version>11.0.3</tck.version>
     </properties>
 
     <!-- The Junit5 test frameworks -->
@@ -63,6 +63,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <dependencies>
         <!-- Jakarta EE APIs -->
         <dependency>
@@ -106,7 +107,7 @@
         <dependency>
             <groupId>ee.omnifish.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -149,7 +150,7 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.5</version>
                 <executions>
                     <execution>
                         <id>gf-tests</id>

--- a/glassfish-runner/pages-platform-extra-tck/pom.xml
+++ b/glassfish-runner/pages-platform-extra-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/pages-tck/pages-tck-install/pom.xml
+++ b/glassfish-runner/pages-tck/pages-tck-install/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/pages-tck/pages-tck-run/pom.xml
+++ b/glassfish-runner/pages-tck/pages-tck-run/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -35,7 +35,7 @@
     <properties>
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -66,6 +66,7 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+
     <dependencies>
         <!-- Jakarta EE APIs -->
         <dependency>
@@ -188,7 +189,7 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.5</version>
                 <configuration>
                     <dependenciesToScan>
                         <dependenciesToScan>jakarta.tck:jakarta-pages-tck</dependenciesToScan>

--- a/glassfish-runner/pages-tck/pom.xml
+++ b/glassfish-runner/pages-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-install/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-install/pom.xml
@@ -22,7 +22,7 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -32,9 +32,9 @@
    <name>TCK: Install Jakarta persistence Platform Tests</name>
 
    <properties>
-        <tck.test.persistence.file>jakartaeetck-${tck.test.persistence.version}-dist.zip</tck.test.persistence.file>
+        <tck.test.persistence.file>jakartaeetck-${tck.test.persistence.version}.zip</tck.test.persistence.file>
         <tck.test.persistence.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.persistence.file}</tck.test.persistence.url>
-        <tck.test.persistence.version>11.0.2</tck.test.persistence.version>
+        <tck.test.persistence.version>11.0.3</tck.test.persistence.version>
     </properties>
 
    <build>

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/parent-pom/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/parent-pom/pom.xml
@@ -1,0 +1,288 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.eclipse.ee4j</groupId>
+        <artifactId>project</artifactId>
+        <version>2.0.3</version>
+        <relativePath />
+    </parent>
+
+    <groupId>jakarta</groupId>
+    <artifactId>glassfish.jpa-platform-tck-parent</artifactId>
+    <version>11.0.0</version>
+    <packaging>pom</packaging>
+
+    <properties>
+        <maven.compiler.release>21</maven.compiler.release>
+
+        <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+        <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
+        <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
+        <jakarta.platform.version>11.0.0</jakarta.platform.version>
+
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
+        <tck.test.persistence.version>11.0.3</tck.test.persistence.version>
+
+        <ts.home>./jakartaeetck</ts.home>
+        
+        <includeGroups>platform</includeGroups>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>jakarta.tck</groupId>
+                <artifactId>glassfish-runner-bom</artifactId>
+                <version>${glassfish.runner.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.inject</groupId>
+            <artifactId>jakarta.inject-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.persistence</groupId>
+            <artifactId>jakarta.persistence-api</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>persistence-platform-tck-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>persistence-platform-tck-spec-tests</artifactId>
+            <version>${tck.test.persistence.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>persistence-platform-tck-tests</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>persistence-platform-tck-dbprocedures</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>jakarta.persistence</groupId>
+                    <artifactId>jakarta.persistence-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.tck</groupId>
+            <artifactId>common</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-launcher</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.vintage</groupId>
+            <artifactId>junit-vintage-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-test-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-spi</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.test</groupId>
+            <artifactId>arquillian-test-impl-base</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-container</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit5</groupId>
+            <artifactId>arquillian-junit5-core</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>ee.omnifish.arquillian</groupId>
+            <artifactId>arquillian-glassfish-server-managed</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ee.omnifish.arquillian</groupId>
+            <artifactId>glassfish-client-ee11</artifactId>
+            <version>2.1.3</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-javatest</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>arquillian-protocol-lib</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.tck.arquillian</groupId>
+            <artifactId>tck-porting-lib</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <resources>
+            <resource>
+                <targetPath>${project.build.directory}/sql</targetPath>
+                <filtering>true</filtering>
+                <directory>${project.basedir}/sql/derby</directory>
+                <includes>
+                    <include>*.sql</include>
+                </includes>
+            </resource>
+            <resource>
+                <directory>src/main/resources</directory>
+            </resource>
+        </resources>
+
+        <plugins>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.8.1</version>
+                <executions>
+                    <execution>
+                        <id>001-unpack</id>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>org.glassfish.main.distributions</groupId>
+                                    <artifactId>glassfish</artifactId>
+                                    <version>${glassfish.version}</version>
+                                    <type>zip</type>
+                                    <overWrite>false</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>004-copy-lib</id>
+                        <goals>
+                            <goal>copy</goal>
+                        </goals>
+                        <phase>generate-resources</phase>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>persistence-platform-tck-dbprocedures</artifactId>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>${project.build.directory}</outputDirectory>
+                                    <destFileName>dbprocedures.jar</destFileName>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <version>3.5.0</version>
+                <configuration>
+                    <trimStackTrace>false</trimStackTrace>
+                    <dependenciesToScan>jakarta.tck:persistence-platform-tck-tests</dependenciesToScan>
+                    <excludes>
+                        <exclude>ee.jakarta.tck.persistence.core.relationship.bidironexone.ClientPmservletTest</exclude>
+                    </excludes>
+
+                    <systemPropertyVariables>
+                        <glassfish.maxHeapSize>2048m</glassfish.maxHeapSize>
+                        <glassfish.enableDerby>true</glassfish.enableDerby>
+                        <glassfish.derbyDatabaseName>${glassfish.home}/glassfish/domains/domain1/config/derbyDB;create=true</glassfish.derbyDatabaseName>
+                        <glassfish.derbySQLFile>${project.build.directory}/sql/derby.ddl.sql</glassfish.derbySQLFile>
+                        <glassfish.derbyUser>cts1</glassfish.derbyUser>
+                        <glassfish.derbyPasswordFile>${basedir}/sql/derby/password.txt</glassfish.derbyPasswordFile>
+                        <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
+                        <glassfish.postBootCommands>
+                            set server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true
+                            --passwordfile ${project.basedir}/javajoe.pass create-file-user --groups guest javajoe
+                            --passwordfile ${project.basedir}/j2ee.pass create-file-user --groups staff:mgr j2ee
+                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=${glassfish.home}/glassfish/domains/domain1/config/derbyDB:serverName=localhost:portNumber=1527:user=cts1:password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool
+                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=${glassfish.home}/glassfish/domains/domain1/config/derbyDB:serverName=localhost:PortNumber=1527:User=cts1:Password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool_no_tx
+                            create-jdbc-resource --connectionpoolid cts-derby-pool jdbc/DB1
+                            create-jdbc-resource --connectionpoolid cts-derby-pool_no_tx jdbc/DB_no_tx
+                            list-jdbc-connection-pools
+                            list-jdbc-resources
+                            list-file-users
+                        </glassfish.postBootCommands>
+
+                        <junit.log.traceflag>false</junit.log.traceflag>
+                        <harness.log.traceflag>false</harness.log.traceflag>
+                        <cts.harness.debug>false</cts.harness.debug>
+                        <project.basedir>${project.basedir}</project.basedir>
+                        <log.file.location>/tmp</log.file.location>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <artifactId>maven-surefire-report-plugin</artifactId>
+                <version>3.5.2</version>
+                <configuration>
+                    <linkXRef>false</linkXRef>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>generate-failsafe-html-report</id>
+                        <goals>
+                            <goal>failsafe-report-only</goal>
+                        </goals>
+                        <phase>post-integration-test</phase>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/test-reports</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    
+</project>

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/platform_pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/platform_pom.xml
@@ -1,344 +1,42 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
-    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
-    
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License v. 2.0, which is available at
-    http://www.eclipse.org/legal/epl-2.0.
-    
-    This Source Code may also be made available under the following Secondary
-    Licenses when the conditions for such availability set forth in the
-    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
-    version 2 with the GNU Classpath Exception, which is available at
-    https://www.gnu.org/software/classpath/license.html.
-    
-    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.9</version>
-        <relativePath />
+        <groupId>jakarta</groupId>
+        <artifactId>glassfish.jpa-platform-tck-parent</artifactId>
+        <version>11.0.0</version>
+        <relativePath>parent-pom</relativePath>
     </parent>
 
-    <groupId>jakarta</groupId>
-    <artifactId>glassfish.jpa-platform-tck</artifactId>
-    <version>11.0.0</version>
-
-    <properties>
-        <!-- Require at least Java 17 to compile -->
-        <maven.compiler.release>17</maven.compiler.release>
-
-        <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
-        <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
-        <!-- Use JDK21 to run with GF 8.0.0-M9 -->
-        <!-- <glassfish.version>8.0.0-M9</glassfish.version> -->
-        <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
-        <jakarta.platform.version>11.0.0</jakarta.platform.version>
-
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <glassfish.version>8.0.0</glassfish.version>
-        <tck.test.persistence.version>11.0.2</tck.test.persistence.version>
-        
-        <ts.home>./jakartaeetck</ts.home>
-    </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>jakarta.tck</groupId>
-                <artifactId>glassfish-runner-bom</artifactId>
-                <version>${glassfish.runner.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-
+    <artifactId>glassfish.jpa-platform-tck-appclient</artifactId>
+    
     <dependencies>
-        <!-- Jakarta EE dependencies -->
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.persistence</groupId>
-            <artifactId>jakarta.persistence-api</artifactId>
-        </dependency>
-
-        <!-- The TCK itself -->
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>persistence-platform-tck-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>persistence-platform-tck-spec-tests</artifactId>
-            <version>${tck.test.persistence.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>persistence-platform-tck-tests</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>persistence-platform-tck-dbprocedures</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.persistence</groupId>
-                    <artifactId>jakarta.persistence-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        
-        <!-- TCK tools dependencies (the TCK above depends on these) -->
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>common</artifactId>
-        </dependency>
-
-        <!-- Junit -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.platform</groupId>
-            <artifactId>junit-platform-launcher</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Arquillian -->
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-container-test-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-container-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.core</groupId>
-            <artifactId>arquillian-core-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.test</groupId>
-            <artifactId>arquillian-test-impl-base</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit5</groupId>
-            <artifactId>arquillian-junit5-container</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit5</groupId>
-            <artifactId>arquillian-junit5-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>ee.omnifish.arquillian</groupId>
-            <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ee.omnifish.arquillian</groupId>
-            <artifactId>glassfish-client-ee11</artifactId>
-            <version>2.1.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Arquillian extensions for TCK  -->
         <dependency>
             <groupId>jakarta.tck.arquillian</groupId>
-            <artifactId>arquillian-protocol-javatest</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck.arquillian</groupId>
-            <artifactId>arquillian-protocol-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck.arquillian</groupId>
-            <artifactId>arquillian-protocol-lib</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck.arquillian</groupId>
-            <artifactId>tck-porting-lib</artifactId>
+            <artifactId>arquillian-protocol-appclient</artifactId>
         </dependency>
     </dependencies>
 
     <build>
-        <resources>
-            <resource>
-                <targetPath>${project.build.directory}/sql</targetPath>
-                <filtering>true</filtering>
-                <directory>${project.basedir}/sql/derby</directory>
-                <includes>
-                    <include>*.sql</include>
-                </includes>
-            </resource>
-            <resource>
-                <directory>src/main/resources</directory>
-            </resource>
-        </resources>
-
         <plugins>
             <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.1</version>
-                <executions>
-                    <execution>
-                        <id>001-unpack</id>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.glassfish.main.distributions</groupId>
-                                    <artifactId>${glassfish-artifact-id}</artifactId>
-                                    <version>${glassfish.version}</version>
-                                    <type>zip</type>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>004-copy-lib</id>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>jakarta.tck</groupId>
-                                    <artifactId>persistence-platform-tck-dbprocedures</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <destFileName>dbprocedures.jar</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.0</version>
-                <configuration>
-                    <trimStackTrace>false</trimStackTrace>
-                    <dependenciesToScan>jakarta.tck:persistence-platform-tck-tests</dependenciesToScan>
-                    <excludes>
-                        <exclude>ee.jakarta.tck.persistence.core.relationship.bidironexone.ClientPmservletTest</exclude>
-                    </excludes>
-
-                    <systemPropertyVariables>
-                        <glassfish.maxHeapSize>2048m</glassfish.maxHeapSize>
-                        <glassfish.enableDerby>true</glassfish.enableDerby>
-                        <glassfish.derbyDatabaseName>${glassfish.home}/glassfish/domains/domain1/config/derbyDB;create=true</glassfish.derbyDatabaseName>
-                        <glassfish.derbySQLFile>${project.build.directory}/sql/derby.ddl.sql</glassfish.derbySQLFile>
-                        <glassfish.derbyUser>cts1</glassfish.derbyUser>
-                        <glassfish.derbyPasswordFile>${basedir}/sql/derby/password.txt</glassfish.derbyPasswordFile>
-                        <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
-                        <glassfish.postBootCommands>
-                            set server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true
-                            --passwordfile ${project.basedir}/javajoe.pass create-file-user --groups guest javajoe
-                            --passwordfile ${project.basedir}/j2ee.pass create-file-user --groups staff:mgr j2ee
-                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=${glassfish.home}/glassfish/domains/domain1/config/derbyDB:serverName=localhost:portNumber=1527:user=cts1:password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool
-                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=${glassfish.home}/glassfish/domains/domain1/config/derbyDB:serverName=localhost:PortNumber=1527:User=cts1:Password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool_no_tx
-                            create-jdbc-resource --connectionpoolid cts-derby-pool jdbc/DB1
-                            create-jdbc-resource --connectionpoolid cts-derby-pool_no_tx jdbc/DB_no_tx
-                            list-jdbc-connection-pools
-                            list-jdbc-resources
-                            list-file-users
-                        </glassfish.postBootCommands>
-                        
-                        <junit.log.traceflag>false</junit.log.traceflag>
-                        <harness.log.traceflag>false</harness.log.traceflag>
-                        <cts.harness.debug>false</cts.harness.debug>
-                        <project.basedir>${project.basedir}</project.basedir>
-                        <log.file.location>/tmp</log.file.location>
-                    </systemPropertyVariables>
-                </configuration>
-
                 <executions>
                     <execution>
-                        <id>jpa-tests-cdi</id>
+                        <id>jpa-tests-appclient</id>
                         <goals>
                             <goal>integration-test</goal>
                             <goal>verify</goal>
                         </goals>
                         <configuration>
-                            <includes>
-                                <include>ee/jakarta/tck/persistence/ee/cdi/*Test.java</include>
-                            </includes>
-
-                            <skipITs>${cdi.skip}</skipITs>
-
+                            <groups>platform</groups>
                             <systemPropertyVariables>
-                                <arquillian.xml>rest-arquillian.xml</arquillian.xml>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>jpa-tests-javatest</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>ee/jakarta/tck/persistence/**/*Test.java</include>
-                            </includes>
-                            <groups>${includeGroups}&amp;tck-javatest</groups>
-
-                            <skipITs>${javatest.skip}</skipITs>
-
-                            <systemPropertyVariables>
-                                <arquillian.xml>arquillian.xml</arquillian.xml>
+                                <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
                                 <ts.home>${ts.home}</ts.home>
                             </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.5.2</version>
-                <configuration>
-                    <linkXRef>false</linkXRef>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>generate-failsafe-html-report</id>
-                        <goals>
-                            <goal>failsafe-report-only</goal>
-                        </goals>
-                        <phase>post-integration-test</phase>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/test-reports</outputDirectory>
                         </configuration>
                     </execution>
                 </executions>
@@ -347,47 +45,24 @@
     </build>
 
     <profiles>
+        <!-- App client profiles -->
+    
         <profile>
             <id>ee</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/ee/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -401,42 +76,17 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/entitytest/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -450,42 +100,17 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/jpa/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -499,42 +124,17 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/jpa22/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -548,42 +148,17 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/annotations/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -591,48 +166,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corebasic</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/basic/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -640,49 +190,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corecache</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/cache/**/*Test.java</include>
-
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -690,48 +214,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corecallback</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/callback/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -739,54 +238,23 @@
                 </plugins>
             </build>
         </profile>
-        
-        <!-- 
-            620 tests
-         -->
+
         <profile>
             <id>corecriteriaapi1</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-                <cdi.skip>true</cdi.skip>
-                <javatest.skip>true</javatest.skip>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/CriteriaBuilder/**/*Test.java</include>
-
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -794,56 +262,25 @@
                 </plugins>
             </build>
         </profile>
-        
-        <!-- 
-            220 tests
-            08:27 min execution time
-         -->
+
         <profile>
             <id>corecriteriaapi2</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-                <cdi.skip>true</cdi.skip>
-                <javatest.skip>true</javatest.skip>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/CriteriaDelete/**/*Test.java</include>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/CriteriaQuery/**/*Test.java</include>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/CriteriaUpdate/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -851,57 +288,25 @@
                 </plugins>
             </build>
         </profile>
-        
-        <!-- 
-            360 tests 
-            12:56 min execution
-         -->
+
         <profile>
             <id>corecriteriaapi3</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-                <cdi.skip>true</cdi.skip>
-                <javatest.skip>true</javatest.skip>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/From/**/*Test.java</include>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/Join/**/*Test.java</include>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/Root/**/*Test.java</include>
-
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -909,55 +314,23 @@
                 </plugins>
             </build>
         </profile>
-        
-        <!-- 
-            604 tests
-            20:21 min execution
-         -->
+
         <profile>
             <id>corecriteriaapi4</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-                <cdi.skip>true</cdi.skip>
-                <javatest.skip>true</javatest.skip>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/metamodelquery/**/*Test.java</include>
-
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -965,57 +338,25 @@
                 </plugins>
             </build>
         </profile>
-        
-        <!-- 
-            680 tests
-         -->
+
         <profile>
             <id>corecriteriaapi5</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-                <cdi.skip>true</cdi.skip>
-                <javatest.skip>true</javatest.skip>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/misc/**/*Test.java</include>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/parameter/**/*Test.java</include>
                                         <include>ee/jakarta/tck/persistence/core/criteriaapi/strquery/**/*Test.java</include>
-
                                     </includes>
-                                    
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1023,49 +364,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corederivedid</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/derivedid/**/*Test.java</include>
-
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1073,49 +388,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreEntityGraph</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/EntityGraph/**/*Test.java</include>
-
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1123,48 +412,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreentityManager</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/entityManager/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1172,48 +436,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreentityManager2</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/entityManager2/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1221,48 +460,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreentityManagerFactory</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/entityManagerFactory/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1270,48 +484,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreentityManagerFactoryCloseExceptions</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/entityManagerFactoryCloseExceptions/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1319,48 +508,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreentitytest</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/entitytest/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1368,48 +532,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreentityTransaction</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/entityTransaction/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1417,48 +556,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreenums</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/enums/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1466,50 +580,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreexceptions</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-
-                </dependency>
-            </dependencies>
-
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/exceptions/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1517,47 +604,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreinheritance</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/inheritance/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1565,47 +628,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corelock</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/lock/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1613,47 +652,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coremetamodelapi</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/metamodelapi/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1661,47 +676,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corenestedembedding</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/nestedembedding/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1709,47 +700,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreoverride</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/override/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1757,47 +724,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corepersistenceUnitUtil</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/persistenceUnitUtil/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1805,47 +748,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corepersistenceUtil</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/persistenceUtil/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1853,47 +772,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corequery</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/query/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1901,47 +796,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>corerelationship</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/relationship/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1949,47 +820,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreStoredProcedureQuery</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/StoredProcedureQuery/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -1997,47 +844,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coretypes</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/types/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>
@@ -2045,47 +868,23 @@
                 </plugins>
             </build>
         </profile>
-        
+
         <profile>
             <id>coreversioning</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
                                 <id>jpa-tests-appclient</id>
-                                <goals>
-                                    <goal>integration-test</goal>
-                                    <goal>verify</goal>
-                                </goals>
                                 <configuration>
                                     <includes>
                                         <include>ee/jakarta/tck/persistence/core/versioning/**/*Test.java</include>
                                     </includes>
-                                    <groups>platform</groups>
-                                    
-                                    <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
-                                        <ts.home>${ts.home}</ts.home>
-                                    </systemPropertyVariables>
                                 </configuration>
                             </execution>
                         </executions>

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-run/pom.xml
@@ -1,355 +1,30 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!--
-    Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
-    Copyright (c) 2024 Oracle and/or its affiliates. All rights reserved.
-    
-    This program and the accompanying materials are made available under the
-    terms of the Eclipse Public License v. 2.0, which is available at
-    http://www.eclipse.org/legal/epl-2.0.
-    
-    This Source Code may also be made available under the following Secondary
-    Licenses when the conditions for such availability set forth in the
-    Eclipse Public License v. 2.0 are satisfied: GNU General Public License,
-    version 2 with the GNU Classpath Exception, which is available at
-    https://www.gnu.org/software/classpath/license.html.
-    
-    SPDX-License-Identifier: EPL-2.0 OR GPL-2.0 WITH Classpath-exception-2.0
--->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>org.eclipse.ee4j</groupId>
-        <artifactId>project</artifactId>
-        <version>1.0.9</version>
-        <relativePath />
+        <groupId>jakarta</groupId>
+        <artifactId>glassfish.jpa-platform-tck-parent</artifactId>
+        <version>11.0.0</version>
+        <relativePath>parent-pom</relativePath>
     </parent>
 
-    <groupId>jakarta</groupId>
     <artifactId>glassfish.jpa-platform-tck</artifactId>
-    <version>11.0.0</version>
 
     <properties>
-        <!-- Require at least Java 17 to compile -->
-        <maven.compiler.release>17</maven.compiler.release>
-
-        <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
-        <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
-        <!-- Use JDK21 to run with GF 8.0.0-M9 -->
-        <!-- <glassfish.version>8.0.0-M9</glassfish.version> -->
-        <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
-        <jakarta.platform.version>11.0.0</jakarta.platform.version>
-
-        <glassfish.version>8.0.0</glassfish.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <tck.test.persistence.version>11.0.2</tck.test.persistence.version>
-        
-        <ts.home>./jakartaeetck</ts.home>
+        <includeGroups>platform</includeGroups>
     </properties>
-
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>jakarta.tck</groupId>
-                <artifactId>glassfish-runner-bom</artifactId>
-                <version>${glassfish.runner.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-    <dependencies>
-        <!-- Jakarta EE dependencies -->
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.persistence</groupId>
-            <artifactId>jakarta.persistence-api</artifactId>
-        </dependency>
-
-        <!-- The TCK itself -->
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>persistence-platform-tck-common</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>persistence-platform-tck-spec-tests</artifactId>
-            <version>${tck.test.persistence.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>persistence-platform-tck-tests</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>persistence-platform-tck-dbprocedures</artifactId>
-            <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>jakarta.persistence</groupId>
-                    <artifactId>jakarta.persistence-api</artifactId>
-                </exclusion>
-            </exclusions>
-        </dependency>
-        
-        <!-- TCK tools dependencies (the TCK above depends on these) -->
-        <dependency>
-            <groupId>jakarta.tck</groupId>
-            <artifactId>common</artifactId>
-        </dependency>
-
-        <!-- Junit -->
-        <dependency>
-            <groupId>org.junit.jupiter</groupId>
-            <artifactId>junit-jupiter</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.junit.vintage</groupId>
-            <artifactId>junit-vintage-engine</artifactId>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Arquillian -->
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-container-test-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>arquillian-container-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.core</groupId>
-            <artifactId>arquillian-core-spi</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.test</groupId>
-            <artifactId>arquillian-test-impl-base</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit5</groupId>
-            <artifactId>arquillian-junit5-container</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit5</groupId>
-            <artifactId>arquillian-junit5-core</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>ee.omnifish.arquillian</groupId>
-            <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ee.omnifish.arquillian</groupId>
-            <artifactId>glassfish-client-ee11</artifactId>
-            <version>2.1.1</version>
-            <scope>test</scope>
-        </dependency>
-
-        <!-- Arquillian extensions for TCK  -->
-        <dependency>
-            <groupId>jakarta.tck.arquillian</groupId>
-            <artifactId>arquillian-protocol-javatest</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck.arquillian</groupId>
-            <artifactId>arquillian-protocol-common</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck.arquillian</groupId>
-            <artifactId>arquillian-protocol-lib</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.tck.arquillian</groupId>
-            <artifactId>tck-porting-lib</artifactId>
-        </dependency>
-    </dependencies>
-
-    <build>
-        <resources>
-            <resource>
-                <targetPath>${project.build.directory}/sql</targetPath>
-                <filtering>true</filtering>
-                <directory>${project.basedir}/sql/derby</directory>
-                <includes>
-                    <include>*.sql</include>
-                </includes>
-            </resource>
-            <resource>
-                <directory>src/main/resources</directory>
-            </resource>
-        </resources>
-        <plugins>
-            <plugin>
-                <artifactId>maven-dependency-plugin</artifactId>
-                <version>3.8.1</version>
-                <executions>
-                    <execution>
-                        <id>001-unpack</id>
-                        <goals>
-                            <goal>unpack</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>org.glassfish.main.distributions</groupId>
-                                    <artifactId>${glassfish-artifact-id}</artifactId>
-                                    <version>${glassfish.version}</version>
-                                    <type>zip</type>
-                                    <overWrite>false</overWrite>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>004-copy-lib</id>
-                        <goals>
-                            <goal>copy</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                        <configuration>
-                            <artifactItems>
-                                <artifactItem>
-                                    <groupId>jakarta.tck</groupId>
-                                    <artifactId>persistence-platform-tck-dbprocedures</artifactId>
-                                    <overWrite>true</overWrite>
-                                    <outputDirectory>${project.build.directory}</outputDirectory>
-                                    <destFileName>dbprocedures.jar</destFileName>
-                                </artifactItem>
-                            </artifactItems>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.0</version>
-                <configuration>
-                    <trimStackTrace>false</trimStackTrace>
-                    <dependenciesToScan>jakarta.tck:persistence-platform-tck-tests</dependenciesToScan>
-                    <excludes>
-                        <exclude>ee.jakarta.tck.persistence.core.relationship.bidironexone.ClientPmservletTest</exclude>
-                    </excludes>
-
-                    <systemPropertyVariables>
-                        <glassfish.maxHeapSize>2048m</glassfish.maxHeapSize>
-                        <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
-                        
-                        <glassfish.enableDerby>true</glassfish.enableDerby>
-                        <glassfish.derbyDatabaseName>${glassfish.home}/glassfish/domains/domain1/config/derbyDB;create=true</glassfish.derbyDatabaseName>
-                        <glassfish.derbySQLFile>${project.build.directory}/sql/derby.ddl.sql</glassfish.derbySQLFile>
-                        <glassfish.derbyUser>cts1</glassfish.derbyUser>
-                        <glassfish.derbyPasswordFile>${basedir}/sql/derby/password.txt</glassfish.derbyPasswordFile>
-                        
-                        <glassfish.postBootCommands>
-                            set server-config.network-config.protocols.protocol.http-listener-1.http.trace-enabled=true
-                            --passwordfile ${project.basedir}/javajoe.pass create-file-user --groups guest javajoe
-                            --passwordfile ${project.basedir}/j2ee.pass create-file-user --groups staff:mgr j2ee
-                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=${glassfish.home}/glassfish/domains/domain1/config/derbyDB:serverName=localhost:portNumber=1527:user=cts1:password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool
-                            create-jdbc-connection-pool --restype javax.sql.DataSource --datasourceclassname org.apache.derby.jdbc.ClientDataSource --property DatabaseName=${glassfish.home}/glassfish/domains/domain1/config/derbyDB:serverName=localhost:PortNumber=1527:User=cts1:Password=cts1 --steadypoolsize 32 --maxpoolsize 64 cts-derby-pool_no_tx
-                            create-jdbc-resource --connectionpoolid cts-derby-pool jdbc/DB1
-                            create-jdbc-resource --connectionpoolid cts-derby-pool_no_tx jdbc/DB_no_tx
-                            list-jdbc-connection-pools
-                            list-jdbc-resources
-                            list-file-users
-                        </glassfish.postBootCommands>
-                        
-                        <junit.log.traceflag>false</junit.log.traceflag>
-                        <harness.log.traceflag>false</harness.log.traceflag>
-                        <cts.harness.debug>false</cts.harness.debug>
-                        <project.basedir>${project.basedir}</project.basedir>
-                        <log.file.location>/tmp</log.file.location>
-                    </systemPropertyVariables>
-                </configuration>
-
-                <executions>
-                    <execution>
-                        <id>jpa-tests-cdi</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <include>ee/jakarta/tck/persistence/ee/cdi/*Test.java</include>
-                            </includes>
-
-                            <skipITs>${cdi.skip}</skipITs>
-
-                            <systemPropertyVariables>
-                                <arquillian.xml>rest-arquillian.xml</arquillian.xml>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-
-                    <execution>
-                        <id>jpa-tests-javatest</id>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                        <configuration>
-                            <includes>
-                                <!--
-                                <include>ee.jakarta.tck.persistence.ee.entityManager.ClientPmservletTest</include>
-                                -->
-                                <include>ee/jakarta/tck/persistence/**/*Test.java</include>
-                            </includes>
-                            <groups>${includeGroups}&amp;tck-javatest</groups>
-                            
-                            <skipITs>${javatest.skip}</skipITs>
-
-                            <systemPropertyVariables>
-                                <arquillian.xml>arquillian.xml</arquillian.xml>
-                                <ts.home>${ts.home}</ts.home>
-                            </systemPropertyVariables>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-surefire-report-plugin</artifactId>
-                <version>3.5.3</version>
-                <configuration>
-                    <linkXRef>false</linkXRef>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>generate-failsafe-html-report</id>
-                        <goals>
-                            <goal>failsafe-report-only</goal>
-                        </goals>
-                        <phase>post-integration-test</phase>
-                        <configuration>
-                            <outputDirectory>${project.build.directory}/test-reports</outputDirectory>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-        </plugins>
-    </build>
-
+   
     <profiles>
         <profile>
             <id>web</id>
             <properties>
-                <glassfish-artifact-id>web</glassfish-artifact-id>
+                <!-- 
+                    Actually unnecssary, as ALL tests for tck-javatest are tagged both and web and full.
+                    In other words, setting groups to web or full gives the same amount of tests.
+                -->
                 <includeGroups>web</includeGroups>
             </properties>
         </profile>
@@ -359,49 +34,63 @@
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <glassfish-artifact-id>glassfish</glassfish-artifact-id>
-                <includeGroups>platform</includeGroups>
-            </properties>
-            
-            <dependencies>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-appclient</artifactId>
-                </dependency>
-                <dependency>
-                    <groupId>jakarta.tck.arquillian</groupId>
-                    <artifactId>arquillian-protocol-lib</artifactId>
-                </dependency>
-            </dependencies>
-
+        </profile>
+    
+    
+        <profile>
+            <id>cdi-all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
             <build>
                 <plugins>
                     <plugin>
                         <artifactId>maven-failsafe-plugin</artifactId>
-                        <version>3.5.0</version>
                         <executions>
                             <execution>
-                                <id>jpa-tests-appclient</id>
+                                <id>jpa-tests-cdi</id>
                                 <goals>
                                     <goal>integration-test</goal>
                                     <goal>verify</goal>
                                 </goals>
                                 <configuration>
                                     <includes>
-                                        <!--
-                                        <include>ee.jakarta.tck.persistence.ee.entityManager.ClientAppmanagedTest</include>
-                                        <include>ee.jakarta.tck.persistence.ee.packaging.appclient.annotation.ClientTest</include>
-                                        <include>ee.jakarta.tck.persistence.core.EntityGraph.ClientAppmanagedTest</include>
-                                        <include>ee.jakarta.tck.persistence.core.basic.ClientStateful3Test</include>
-                                        -->
+                                        <include>ee/jakarta/tck/persistence/ee/cdi/*Test.java</include>
+                                    </includes>
+                                    <systemPropertyVariables>
+                                        <arquillian.xml>rest-arquillian.xml</arquillian.xml>
+                                    </systemPropertyVariables>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        
+        <profile>
+            <id>javatest-all</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>jpa-tests-javatest</id>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                                <configuration>
+                                    <includes>
                                         <include>ee/jakarta/tck/persistence/**/*Test.java</include>
                                     </includes>
-                                    <groups>${includeGroups}&amp;tck-appclient</groups>
-                                    <excludedGroups>web</excludedGroups>
-                                    
+                                    <groups>${includeGroups}&amp;tck-javatest</groups>
                                     <systemPropertyVariables>
-                                        <arquillian.xml>appclient-arquillian.xml</arquillian.xml>
+                                        <arquillian.xml>arquillian.xml</arquillian.xml>
                                         <ts.home>${ts.home}</ts.home>
                                     </systemPropertyVariables>
                                 </configuration>

--- a/glassfish-runner/persistence-platform-tck/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/persistence-tck/persistence-tck-arquillian-extension/pom.xml
+++ b/glassfish-runner/persistence-tck/persistence-tck-arquillian-extension/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/persistence-tck/persistence-tck-install/pom.xml
+++ b/glassfish-runner/persistence-tck/persistence-tck-install/pom.xml
@@ -22,7 +22,7 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/persistence-tck/persistence-tck-run-ee/pom.xml
+++ b/glassfish-runner/persistence-tck/persistence-tck-run-ee/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -33,10 +33,10 @@
     <packaging>jar</packaging>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>21</maven.compiler.release>
     
         <!--Glassfish properties-->
-        <glassfish.version>8.0.0-M15</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.home>${project.build.directory}/glassfish8</glassfish.home>
         <glassfish.module.dir>${glassfish.home}/glassfish/modules</glassfish.module.dir>
         

--- a/glassfish-runner/persistence-tck/persistence-tck-run-se/pom.xml
+++ b/glassfish-runner/persistence-tck/persistence-tck-run-se/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
     </parent>
 
     <groupId>jakarta.tck</groupId>
@@ -33,7 +33,7 @@
 
     <properties>
         <!--Glassfish properties-->
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.home>${project.build.directory}/glassfish8</glassfish.home>
         <glassfish.module.dir>${glassfish.home}/glassfish/modules</glassfish.module.dir>
         
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>jakarta.tck</groupId>
             <artifactId>common</artifactId>
-            <version>11.0.2</version>
+            <version>11.0.3</version>
             <scope>test</scope>
         </dependency>
         

--- a/glassfish-runner/persistence-tck/pom.xml
+++ b/glassfish-runner/persistence-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/platform/appclient-platform-tck/appclient-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/appclient-platform-tck/appclient-platform-tck-install/pom.xml
@@ -22,21 +22,21 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>appclient-tck-install</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Appclient TCK</name>
 
     <properties>
-        <tck.test.appclient.file>jakartaeetck-${tck.test.appclient.version}-dist.zip</tck.test.appclient.file>
+        <tck.test.appclient.file>jakartaeetck-${tck.test.appclient.version}.zip</tck.test.appclient.file>
         <tck.test.appclient.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.appclient.file}</tck.test.appclient.url>
         
-        <tck.test.appclient.version>11.0.2</tck.test.appclient.version>
+        <tck.test.appclient.version>11.0.3</tck.test.appclient.version>
     </properties>
 
     <build>

--- a/glassfish-runner/platform/appclient-platform-tck/appclient-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/appclient-platform-tck/appclient-platform-tck-run/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -64,9 +64,9 @@
         <jndi.fs.dir>/tmp/ri_admin_objects</jndi.fs.dir>
         <jndi.provider.url>java.naming.provider.url=file:///${jndi.fs.dir}</jndi.provider.url>
 
-        <glassfish.version>8.0.0</glassfish.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <jakarta.tck.version>11.0.2</jakarta.tck.version>
+        <glassfish.version>8.0.2</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <jakarta.tck.version>11.0.3</jakarta.tck.version>
     </properties>
     
     <dependencyManagement>

--- a/glassfish-runner/platform/appclient-platform-tck/pom.xml
+++ b/glassfish-runner/platform/appclient-platform-tck/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>glassfish.appclient-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/platform/assembly-tck/assembly-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/assembly-tck/assembly-platform-tck-install/pom.xml
@@ -22,21 +22,21 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>assembly-tck-install</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Assembly TCK</name>
 
     <properties>
-        <tck.test.assembly.file>jakartaeetck-${tck.test.assembly.version}-dist.zip</tck.test.assembly.file>
+        <tck.test.assembly.file>jakartaeetck-${tck.test.assembly.version}.zip</tck.test.assembly.file>
         <tck.test.assembly.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.assembly.file}</tck.test.assembly.url>
         
-        <tck.test.assembly.version>11.0.2</tck.test.assembly.version>
+        <tck.test.assembly.version>11.0.3</tck.test.assembly.version>
     </properties>
 
     <build>

--- a/glassfish-runner/platform/assembly-tck/assembly-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/assembly-tck/assembly-platform-tck-run/pom.xml
@@ -20,13 +20,13 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.assembly-tck-run</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -36,10 +36,10 @@
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <jakarta.platform.version>11.0.0</jakarta.platform.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <tck.artifactId>assembly-tck</tck.artifactId>
-        <tck.version>11.0.2</tck.version>
+        <tck.version>11.0.3</tck.version>
         <ts.home>./jakartaeetck</ts.home>
     </properties>
 

--- a/glassfish-runner/platform/assembly-tck/pom.xml
+++ b/glassfish-runner/platform/assembly-tck/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-install/pom.xml
@@ -22,21 +22,21 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>integration-tck-install</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Integration TCK</name>
 
     <properties>
-        <tck.test.integration.file>jakartaeetck-${tck.test.integration.version}-dist.zip</tck.test.integration.file>
+        <tck.test.integration.file>jakartaeetck-${tck.test.integration.version}.zip</tck.test.integration.file>
         <tck.test.integration.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.integration.file}</tck.test.integration.url>
         
-        <tck.test.integration.version>11.0.2</tck.test.integration.version>
+        <tck.test.integration.version>11.0.3</tck.test.integration.version>
     </properties>
 
     <build>

--- a/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-run/pom.xml
@@ -19,23 +19,23 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.integration-platform-tck-run</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>jar</packaging>
 
     <properties>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
         
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <tck.version>11.0.2</tck.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <tck.version>11.0.3</tck.version>
         <maven.compiler.release>17</maven.compiler.release>
     </properties>
 

--- a/glassfish-runner/platform/integration-platform-tck/pom.xml
+++ b/glassfish-runner/platform/integration-platform-tck/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-install/pom.xml
@@ -22,21 +22,21 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta.tck</groupId>
     <artifactId>javaee-module-tck-install</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
     <name>TCK: Install Jakarta Javaee Module TCK</name>
 
     <properties>
-        <tck.test.javaee.module.file>jakartaeetck-${tck.test.javaee.module.version}-dist.zip</tck.test.javaee.module.file>
+        <tck.test.javaee.module.file>jakartaeetck-${tck.test.javaee.module.version}.zip</tck.test.javaee.module.file>
         <tck.test.javaee.module.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.javaee.module.file}</tck.test.javaee.module.url>
         
-        <tck.test.javaee.module.version>11.0.2</tck.test.javaee.module.version>
+        <tck.test.javaee.module.version>11.0.3</tck.test.javaee.module.version>
     </properties>
 
     <build>

--- a/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-run/pom.xml
@@ -19,22 +19,22 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
     
     <groupId>jakarta</groupId>
     <artifactId>glassfish.javaee-module-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>jar</packaging>
 
     <properties>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <jakarta.platform.version>11.0.0</jakarta.platform.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <tck.artifactId>javaee-tck</tck.artifactId>
-        <tck.version>11.0.2</tck.version>
+        <tck.version>11.0.3</tck.version>
     </properties>
 
     <dependencyManagement>

--- a/glassfish-runner/platform/javaee-module-tck/pom.xml
+++ b/glassfish-runner/platform/javaee-module-tck/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-install/pom.xml
@@ -22,7 +22,7 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -32,9 +32,9 @@
     <name>TCK: Install Jakarta JDBC Platform Tests</name>
 
     <properties>
-        <tck.test.jdbc.file>jakartaeetck-${tck.test.jdbc.version}-dist.zip</tck.test.jdbc.file>
+        <tck.test.jdbc.file>jakartaeetck-${tck.test.jdbc.version}.zip</tck.test.jdbc.file>
         <tck.test.jdbc.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.jdbc.file}</tck.test.jdbc.url>
-        <tck.test.jdbc.version>11.0.2</tck.test.jdbc.version>
+        <tck.test.jdbc.version>11.0.3</tck.test.jdbc.version>
     </properties>
 
     <build>

--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-run/pom.xml
@@ -22,13 +22,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish.jdbc-platform-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     
     <properties>
         <maven.compiler.release>17</maven.compiler.release>
@@ -37,9 +37,9 @@
         <glassfish.home>${project.build.directory}/glassfish8</glassfish.home>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
         
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <glassfish.version>8.0.0</glassfish.version>
-        <tck.version>11.0.2</tck.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
+        <tck.version>11.0.3</tck.version>
         
         <exec.asadmin>${glassfish.home}/glassfish/bin/asadmin</exec.asadmin>
         <jdbc.db>derby</jdbc.db>

--- a/glassfish-runner/platform/jdbc-platform-tck/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/pom.xml
@@ -22,12 +22,12 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <artifactId>jdbc-platform-tck</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
     <packaging>pom</packaging>
 
     <modules>

--- a/glassfish-runner/platform/xa-platform-tck/pom.xml
+++ b/glassfish-runner/platform/xa-platform-tck/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath/>
     </parent>
     
@@ -39,10 +39,10 @@
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
         <javadb.lib>${glassfish.home}/javadb/lib</javadb.lib>
         
-        <glassfish.version>8.0.0</glassfish.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
         <tck.artifactId>jakarta.tck.jdbc</tck.artifactId>
-        <tck.version>11.0.2</tck.version>
+        <tck.version>11.0.3</tck.version>
 
 
         <!-- JDBC properties -->

--- a/glassfish-runner/pom.xml
+++ b/glassfish-runner/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -58,6 +58,14 @@
         <module>pages-tck</module>
         <module>persistence-platform-tck</module>
         <module>persistence-tck</module>
+        
+        <module>platform/appclient-platform-tck</module>
+        <module>platform/assembly-tck</module>
+        <module>platform/integration-platform-tck</module>
+        <module>platform/javaee-module-tck</module>
+        <module>platform/jdbc-platform-tck</module>
+        <module>platform/xa-platform-tck</module>
+        
         <module>rest-platform-extra-tck</module>
         <module>rest-tck</module>
         <module>servlet-tck</module>

--- a/glassfish-runner/rest-platform-extra-tck/pom.xml
+++ b/glassfish-runner/rest-platform-extra-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-install/pom.xml
@@ -22,20 +22,20 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
    <artifactId>rest-extra-tck-install</artifactId>
-   <version>11.0.2</version>
+   <version>11.0.3</version>
    <packaging>pom</packaging>
 
    <name>TCK: Install Jakarta REST Platform Extra TCK</name>
 
    <properties>
-        <tck.test.rest-extra.file>jakartaeetck-${tck.test.rest-extra.version}-dist.zip</tck.test.rest-extra.file>
+        <tck.test.rest-extra.file>jakartaeetck-${tck.test.rest-extra.version}.zip</tck.test.rest-extra.file>
         <tck.test.rest-extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.rest-extra.file}</tck.test.rest-extra.url>
-        <tck.test.rest-extra.version>11.0.2</tck.test.rest-extra.version>
+        <tck.test.rest-extra.version>11.0.3</tck.test.rest-extra.version>
     </properties>
 
    <build>

--- a/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-run/pom.xml
@@ -23,13 +23,13 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <groupId>jakarta</groupId>
     <artifactId>glassfish-restful-tests</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
 
     <name>TCK: Run Jakarta REST Platform Extra TCK</name>
     <description>
@@ -40,10 +40,10 @@
     <properties>
         <glassfish.toplevel.dir>glassfish8</glassfish.toplevel.dir>
         <glassfish.home>${project.build.directory}/${glassfish.toplevel.dir}</glassfish.home>
-        <glassfish.version>8.0.0</glassfish.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
 
-        <tck.version>11.0.2</tck.version>
+        <tck.version>11.0.3</tck.version>
     </properties>
 
     <!-- The Junit5 test frameworks -->

--- a/glassfish-runner/rest-tck/pom.xml
+++ b/glassfish-runner/rest-tck/pom.xml
@@ -50,7 +50,7 @@ mvn clean install -Dgroups=security
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -63,7 +63,7 @@ mvn clean install -Dgroups=security
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
 
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>

--- a/glassfish-runner/servlet-tck/pom.xml
+++ b/glassfish-runner/servlet-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/servlet-tck/servlet-tck-install/pom.xml
+++ b/glassfish-runner/servlet-tck/servlet-tck-install/pom.xml
@@ -22,7 +22,7 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/servlet-tck/servlet-tck-run/pom.xml
+++ b/glassfish-runner/servlet-tck/servlet-tck-run/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -39,7 +39,7 @@
         
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         
         <tck.test.servlet.version>6.1.0</tck.test.servlet.version>
     </properties>

--- a/glassfish-runner/signature/pom.xml
+++ b/glassfish-runner/signature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -32,7 +32,7 @@
     <properties>
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.version.main>8</glassfish.version.main>
         <glassfish-artifact-id>glassfish</glassfish-artifact-id>
         
@@ -47,9 +47,9 @@
         <!-- Note that currently, this must have src as the first directory as it is hard-coded in the test -->
         <signature.file.dir>${base.tck.dir}/src</signature.file.dir>
         
-        <tck.version>11.0.2</tck.version>
+        <tck.version>11.0.3</tck.version>
         
-        <version.jakarta.tck>11.0.2</version.jakarta.tck>
+        <version.jakarta.tck>11.0.3</version.jakarta.tck>
         <version.jakarta.tck.sigtest-maven-plugin>2.6</version.jakarta.tck.sigtest-maven-plugin>
     </properties>
     

--- a/glassfish-runner/tags-tck/pom.xml
+++ b/glassfish-runner/tags-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/tags-tck/tags-tck-install/pom.xml
+++ b/glassfish-runner/tags-tck/tags-tck-install/pom.xml
@@ -22,20 +22,20 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
    <artifactId>tags-tck-install</artifactId>
-   <version>11.0.2</version>
+   <version>11.0.3</version>
    <packaging>pom</packaging>
 
    <name>TCK: Install Jakarta tags TCK</name>
 
    <properties>
-        <tck.test.tags.file>jakartaeetck-${tck.test.tags.version}-dist.zip</tck.test.tags.file>
+        <tck.test.tags.file>jakartaeetck-${tck.test.tags.version}.zip</tck.test.tags.file>
         <tck.test.tags.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.tags.file}</tck.test.tags.url>
-        <tck.test.tags.version>11.0.2</tck.test.tags.version>
+        <tck.test.tags.version>11.0.3</tck.test.tags.version>
     </properties>
 
    <build>

--- a/glassfish-runner/tags-tck/tags-tck-run/pom.xml
+++ b/glassfish-runner/tags-tck/tags-tck-run/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2024, 2025 Contributors to the Eclipse Foundation.
+    Copyright (c) 2024, 2026 Contributors to the Eclipse Foundation.
     Copyright (c) 2023 Oracle and/or its affiliates. All rights reserved.
     
     This program and the accompanying materials are made available under the
@@ -21,7 +21,7 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -31,11 +31,11 @@
    <properties>
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.version.main>8</glassfish.version.main>
         
         <jakarta.platform.version>11.0.0</jakarta.platform.version>
-        <tck.version>11.0.2</tck.version>
+        <tck.version>11.0.3</tck.version>
         <jakarta.tck.tags.version>${tck.version}</jakarta.tck.tags.version>
     </properties>
 
@@ -92,7 +92,7 @@
         <dependency>
             <groupId>ee.omnifish.arquillian</groupId>
             <artifactId>arquillian-glassfish-server-managed</artifactId>
-            <version>2.1.1</version>
+            <version>2.1.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -126,7 +126,7 @@
 
             <plugin>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.5.4</version>
+                <version>3.5.5</version>
                 <executions>
                     <execution>
                         <id>gf-tests</id>

--- a/glassfish-runner/transactions-tck/pom.xml
+++ b/glassfish-runner/transactions-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
+++ b/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
@@ -22,20 +22,20 @@
    <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
    <artifactId>transactions-tck-install</artifactId>
-   <version>11.0.2</version>
+   <version>11.0.3</version>
    <packaging>pom</packaging>
 
    <name>TCK: Install Jakarta Transactions TCK</name>
 
    <properties>
-        <tck.test.transactions.file>jakartaeetck-${tck.test.transactions.version}-dist.zip</tck.test.transactions.file>
+        <tck.test.transactions.file>jakartaeetck-${tck.test.transactions.version}.zip</tck.test.transactions.file>
         <tck.test.transactions.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.transactions.file}</tck.test.transactions.url>
-        <tck.test.transactions.version>11.0.2</tck.test.transactions.version>
+        <tck.test.transactions.version>11.0.3</tck.test.transactions.version>
     </properties>
 
    <build>

--- a/glassfish-runner/transactions-tck/transactions-tck-run/pom.xml
+++ b/glassfish-runner/transactions-tck/transactions-tck-run/pom.xml
@@ -21,12 +21,12 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
     <artifactId>transactions-tck-run</artifactId>
-    <version>11.0.2</version>
+    <version>11.0.3</version>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -36,15 +36,15 @@
         <glassfish.home>${glassfish.root}/glassfish${glassfish.version.main}</glassfish.home>
         <glassfish.lib.dir>${glassfish.home}/glassfish/lib</glassfish.lib.dir>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
         <glassfish.version.main>8</glassfish.version.main>
         <glassfish-artifact-id>glassfish</glassfish-artifact-id>
 
         <jakarta.platform.version>11.0.0</jakarta.platform.version>
         <ts.home>${basedir}/jakartaeetck</ts.home>
 
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
-        <tck.version>11.0.2</tck.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
+        <tck.version>11.0.3</tck.version>
         <jakarta.tck.transactions.version>${tck.version}</jakarta.tck.transactions.version>
     </properties>
 

--- a/glassfish-runner/validation-tck/pom.xml
+++ b/glassfish-runner/validation-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/validation-tck/validation-tck-install/pom.xml
+++ b/glassfish-runner/validation-tck/validation-tck-install/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/validation-tck/validation-tck-run/pom.xml
+++ b/glassfish-runner/validation-tck/validation-tck-run/pom.xml
@@ -35,7 +35,7 @@
     
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
         <glassfish.root>${project.build.directory}</glassfish.root>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
     </properties>
 
     <dependencyManagement>

--- a/glassfish-runner/websocket-platform-extra-tck/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -37,11 +37,11 @@
         <tck.test.websocket.file>jakarta-websocket-tck-${tck.test.websocket.version}.zip</tck.test.websocket.file>
         <tck.test.websocket.url>https://download.eclipse.org/jakartaee/websocket/2.2/${tck.test.websocket.file}</tck.test.websocket.url>
         
-        <tck.test.websocket.extra.file>jakartaeetck-${tck.test.websocket.extra.version}-dist.zip</tck.test.websocket.extra.file>
+        <tck.test.websocket.extra.file>jakartaeetck-${tck.test.websocket.extra.version}.zip</tck.test.websocket.extra.file>
         <tck.test.websocket.extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.websocket.extra.file}</tck.test.websocket.extra.url>
         
         <tck.test.websocket.version>2.2.0</tck.test.websocket.version>
-        <tck.test.websocket.extra.version>11.0.2</tck.test.websocket.extra.version>
+        <tck.test.websocket.extra.version>11.0.3</tck.test.websocket.extra.version>
     </properties>
 
     <build>

--- a/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-run/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-run/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -38,10 +38,10 @@
     
         <glassfish.root>${project.build.directory}</glassfish.root>
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
-        <glassfish.version>8.0.0</glassfish.version>
-        <glassfish.runner.version>11.0.2</glassfish.runner.version>
+        <glassfish.version>8.0.2</glassfish.version>
+        <glassfish.runner.version>11.0.3</glassfish.runner.version>
 
-        <tck.version>11.0.2</tck.version>
+        <tck.version>11.0.3</tck.version>
         <jakarta.tck.websocket.version>2.2.0</jakarta.tck.websocket.version>
         <tck.test.websocket.extra.version>${tck.version}</tck.test.websocket.extra.version>
         

--- a/glassfish-runner/websocket-tck/pom.xml
+++ b/glassfish-runner/websocket-tck/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/websocket-tck/websocket-tck-install/pom.xml
+++ b/glassfish-runner/websocket-tck/websocket-tck-install/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 

--- a/glassfish-runner/websocket-tck/websocket-tck-run/pom.xml
+++ b/glassfish-runner/websocket-tck/websocket-tck-run/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.eclipse.ee4j</groupId>
         <artifactId>project</artifactId>
-        <version>1.0.9</version>
+        <version>2.0.3</version>
         <relativePath />
     </parent>
 
@@ -37,7 +37,7 @@
         <arquillian.version>1.10.0.Final</arquillian.version>
         <glassfish.root>${project.build.directory}</glassfish.root>
         <glassfish.home>${glassfish.root}/glassfish8</glassfish.home>
-        <glassfish.version>8.0.0</glassfish.version>
+        <glassfish.version>8.0.2</glassfish.version>
 
         <tck.version>2.2.0</tck.version>
     </properties>

--- a/tcks/apis/persistence/persistence-outside-container/bin/pom.xml
+++ b/tcks/apis/persistence/persistence-outside-container/bin/pom.xml
@@ -34,7 +34,7 @@
     <properties>
         <!--glassfish properties-->
         <jakarta.ee.version>11.0.0-RC4</jakarta.ee.version>
-        <glassfish.version>8.0.0-M2</glassfish.version>
+        <glassfish.version>8.0.2-M2</glassfish.version>
         <glassfish.toplevel.dir>${project.build.directory}/glassfish8</glassfish.toplevel.dir>
         <glassfish.module.dir>${glassfish.toplevel.dir}/glassfish/modules</glassfish.module.dir>
         <exec.asadmin>${glassfish.toplevel.dir}/bin/asadmin</exec.asadmin>


### PR DESCRIPTION
Poms updated to use the 11.0.3 TCK and its new filename. Updated default GlassFish to 8.0.2,EE4J  parent to 2.0.3 and fixed several issues in the runners (mainly in the persistence runners).

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
