### PR TITLE
added downloader profile to allow toggling of tck downloading for the transactions TCK(main)

### DIFF
--- a/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
+++ b/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
@@ -37,51 +37,59 @@
         <tck.test.transactions.version>11.0.1-SNAPSHOT</tck.test.transactions.version>
     </properties>
 
-    <build>
-        <plugins>
-            <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
-                <artifactId>download-maven-plugin</artifactId>
-                <version>1.13.0</version>
-                <configuration>
-                    <url>${tck.test.transactions.url}</url>
-                    <unpack>true</unpack>
-                    <outputDirectory>${project.build.directory}</outputDirectory>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>download-transactions-tck</id>
-                        <goals>
-                            <goal>wget</goal>
-                        </goals>
-                        <phase>generate-resources</phase>
-                    </execution>
-                </executions>
-            </plugin>
-
-            <plugin>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>3.1.3</version>
-                <executions>
-                    <execution>
-                        <id>install-transactions-tck-pom</id>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                        <phase>process-resources</phase>
+    <profiles>
+        <profile>
+            <id>download-tck</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.googlecode.maven-download-plugin</groupId>
+                        <artifactId>download-maven-plugin</artifactId>
+                        <version>1.13.0</version>
                         <configuration>
-                            <file>${project.build.directory}/jakartaeetck/artifacts/transactions-tck-${tck.test.transactions.version}.jar</file>
-                            <sources>${project.build.directory}/jakartaeetck/artifacts/transactions-tck-${tck.test.transactions.version}-sources.jar</sources>
-                            <groupId>jakarta.tck</groupId>
-                            <artifactId>transactions-tck</artifactId>
-                            <version>${tck.test.transactions.version}</version>
-                            <packaging>jar</packaging>
+                            <url>${tck.test.transactions.url}</url>
+                            <unpack>true</unpack>
+                            <outputDirectory>${project.build.directory}</outputDirectory>
                         </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+                        <executions>
+                            <execution>
+                                <id>download-transactions-tck</id>
+                                <goals>
+                                    <goal>wget</goal>
+                                </goals>
+                                <phase>generate-resources</phase>
+                            </execution>
+                        </executions>
+                    </plugin>
 
-        </plugins>
-    </build>
+                    <plugin>
+                        <artifactId>maven-install-plugin</artifactId>
+                        <version>3.1.3</version>
+                        <executions>
+                            <execution>
+                                <id>install-transactions-tck-pom</id>
+                                <goals>
+                                    <goal>install-file</goal>
+                                </goals>
+                                <phase>process-resources</phase>
+                                <configuration>
+                                    <file>${project.build.directory}/jakartaeetck/artifacts/transactions-tck-${tck.test.transactions.version}.jar</file>
+                                    <sources>${project.build.directory}/jakartaeetck/artifacts/transactions-tck-${tck.test.transactions.version}-sources.jar</sources>
+                                    <groupId>jakarta.tck</groupId>
+                                    <artifactId>transactions-tck</artifactId>
+                                    <version>${tck.test.transactions.version}</version>
+                                    <packaging>jar</packaging>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
Wraps code in glassfish transactions tck runner to download transactions-tck from remote in a profile.

This allows for running with a local build of the transactions tck.

add -P !download-tck (on Mac) to use a local copy of the transaction tck.

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow