### PR TITLE
Correct download links for GF Runners /jakartaee/platform/11/

### DIFF
--- a/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/cdi-platform-extra-tck/cdi-platform-extra-tck-install/pom.xml
@@ -34,7 +34,7 @@
 
    <properties>
         <tck.test.cdi-extra.file>jakartaeetck-${tck.test.cdi-extra.version}.zip</tck.test.cdi-extra.file>
-        <tck.test.cdi-extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.cdi-extra.file}</tck.test.cdi-extra.url>
+        <tck.test.cdi-extra.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.cdi-extra.file}</tck.test.cdi-extra.url>
 
         <tck.test.cdi-extra.version>11.0.3</tck.test.cdi-extra.version>
     </properties>

--- a/glassfish-runner/cdi-tck/cdi-tck-install/pom.xml
+++ b/glassfish-runner/cdi-tck/cdi-tck-install/pom.xml
@@ -33,9 +33,9 @@
     <name>TCK: Install Jakarta CDI TCK</name>
 
     <properties>
-        <tck.test.cdi.file>cdi-tck-${tck.test.cdi.version}-dist.zip</tck.test.cdi.file>
-        <tck.test.cdi.url>https://download.eclipse.org/ee4j/cdi/4.1/${tck.test.cdi.file}</tck.test.cdi.url>
         <tck.test.cdi.version>4.1.0</tck.test.cdi.version>
+        <tck.test.cdi.file>cdi-tck-${tck.test.cdi.version}-dist.zip</tck.test.cdi.file>
+        <tck.test.cdi.url>https://download.eclipse.org/jakartaee/cdi/4.1/${tck.test.cdi.file}</tck.test.cdi.url>
     </properties>
 
     <build>

--- a/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-install/pom.xml
+++ b/glassfish-runner/enterprise-beans-tck/enterprise-beans-tck-install/pom.xml
@@ -35,7 +35,7 @@
 
    <properties>
         <tck.test.enterprise-beans.file>jakartaeetck-${tck.test.enterprise-beans.version}.zip</tck.test.enterprise-beans.file>
-        <tck.test.enterprise-beans.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.enterprise-beans.file}</tck.test.enterprise-beans.url>
+        <tck.test.enterprise-beans.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.enterprise-beans.file}</tck.test.enterprise-beans.url>
         <!-- If this is set to a SNAPSHOT version you need to enable the -Psnapshots profile and have the snapshot
                 build staged in the download location.
         -->

--- a/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
+++ b/glassfish-runner/expression-language-platform-subst-tck/expression-language-platform-subst-tck-install/pom.xml
@@ -34,7 +34,7 @@
 
    <properties>
         <tck.test.expression-language-extra.file>jakartaeetck-${tck.test.expression-language-extra.version}.zip</tck.test.expression-language-extra.file>
-        <tck.test.expression-language-extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.expression-language-extra.file}</tck.test.expression-language-extra.url>
+        <tck.test.expression-language-extra.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.expression-language-extra.file}</tck.test.expression-language-extra.url>
         <tck.test.expression-language-extra.version>11.0.3</tck.test.expression-language-extra.version>
     </properties>
 

--- a/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/jsonb-platform-extra-tck/jsonb-platform-extra-tck-install/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <tck.test.jsonb.extra.file>jakartaeetck-${tck.test.jsonb.version}.zip</tck.test.jsonb.extra.file>
-        <tck.test.jsonb.extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.jsonb.extra.file}</tck.test.jsonb.extra.url>
+        <tck.test.jsonb.extra.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.jsonb.extra.file}</tck.test.jsonb.extra.url>
         
         <tck.test.jsonb.version>11.0.3</tck.test.jsonb.version>
     </properties>

--- a/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/jsonp-platform-extra-tck/jsonp-platform-extra-tck-install/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <tck.test.jsonp.extra.file>jakartaeetck-${tck.test.jsonp.version}.zip</tck.test.jsonp.extra.file>
-        <tck.test.jsonp.extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.jsonp.extra.file}</tck.test.jsonp.extra.url>
+        <tck.test.jsonp.extra.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.jsonp.extra.file}</tck.test.jsonp.extra.url>
         
         <tck.test.jsonp.version>11.0.3</tck.test.jsonp.version>
     </properties>

--- a/glassfish-runner/mail-platform-tck/mail-platform-tck-install/pom.xml
+++ b/glassfish-runner/mail-platform-tck/mail-platform-tck-install/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <tck.test.mail.file>jakartaeetck-${tck.test.mail.version}.zip</tck.test.mail.file>
-        <tck.test.mail.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.mail.file}</tck.test.mail.url>
+        <tck.test.mail.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.mail.file}</tck.test.mail.url>
         
         <tck.test.mail.version>11.0.3</tck.test.mail.version>
     </properties>

--- a/glassfish-runner/messaging-platform-tck/messaging-platform-tck-install/pom.xml
+++ b/glassfish-runner/messaging-platform-tck/messaging-platform-tck-install/pom.xml
@@ -35,7 +35,7 @@
 
     <properties>
         <tck.test.messaging.platform.file>jakartaeetck-${tck.test.messaging.version}.zip</tck.test.messaging.platform.file>
-        <tck.test.messaging.platform.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.messaging.platform.file}</tck.test.messaging.platform.url>
+        <tck.test.messaging.platform.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.messaging.platform.file}</tck.test.messaging.platform.url>
         <tck.test.messaging.version>11.0.3</tck.test.messaging.version>
     </properties>
 

--- a/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/pages-platform-extra-tck/pages-platform-extra-tck-install/pom.xml
@@ -33,9 +33,9 @@
    <name>TCK: Install Jakarta Pages Platform Extra TCK</name>
 
    <properties>
-        <tck.test.pages-extra.file>jakartaeetck-${tck.test.pages-extra.version}.zip</tck.test.pages-extra.file>
-        <tck.test.pages-extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.pages-extra.file}</tck.test.pages-extra.url>
         <tck.test.pages-extra.version>11.0.3</tck.test.pages-extra.version>
+        <tck.test.pages-extra.file>jakartaeetck-${tck.test.pages-extra.version}.zip</tck.test.pages-extra.file>
+        <tck.test.pages-extra.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.pages-extra.file}</tck.test.pages-extra.url>
 
     </properties>
 

--- a/glassfish-runner/persistence-platform-tck/persistence-platform-tck-install/pom.xml
+++ b/glassfish-runner/persistence-platform-tck/persistence-platform-tck-install/pom.xml
@@ -33,7 +33,7 @@
 
    <properties>
         <tck.test.persistence.file>jakartaeetck-${tck.test.persistence.version}.zip</tck.test.persistence.file>
-        <tck.test.persistence.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.persistence.file}</tck.test.persistence.url>
+        <tck.test.persistence.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.persistence.file}</tck.test.persistence.url>
         <tck.test.persistence.version>11.0.3</tck.test.persistence.version>
     </properties>
 

--- a/glassfish-runner/platform/appclient-platform-tck/appclient-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/appclient-platform-tck/appclient-platform-tck-install/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <tck.test.appclient.file>jakartaeetck-${tck.test.appclient.version}.zip</tck.test.appclient.file>
-        <tck.test.appclient.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.appclient.file}</tck.test.appclient.url>
+        <tck.test.appclient.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.appclient.file}</tck.test.appclient.url>
         
         <tck.test.appclient.version>11.0.3</tck.test.appclient.version>
     </properties>

--- a/glassfish-runner/platform/assembly-tck/assembly-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/assembly-tck/assembly-platform-tck-install/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <tck.test.assembly.file>jakartaeetck-${tck.test.assembly.version}.zip</tck.test.assembly.file>
-        <tck.test.assembly.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.assembly.file}</tck.test.assembly.url>
+        <tck.test.assembly.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.assembly.file}</tck.test.assembly.url>
         
         <tck.test.assembly.version>11.0.3</tck.test.assembly.version>
     </properties>

--- a/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/integration-platform-tck/integration-platform-tck-install/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <tck.test.integration.file>jakartaeetck-${tck.test.integration.version}.zip</tck.test.integration.file>
-        <tck.test.integration.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.integration.file}</tck.test.integration.url>
+        <tck.test.integration.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.integration.file}</tck.test.integration.url>
         
         <tck.test.integration.version>11.0.3</tck.test.integration.version>
     </properties>

--- a/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/javaee-module-tck/javaee-module-platform-tck-install/pom.xml
@@ -34,7 +34,7 @@
 
     <properties>
         <tck.test.javaee.module.file>jakartaeetck-${tck.test.javaee.module.version}.zip</tck.test.javaee.module.file>
-        <tck.test.javaee.module.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.javaee.module.file}</tck.test.javaee.module.url>
+        <tck.test.javaee.module.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.javaee.module.file}</tck.test.javaee.module.url>
         
         <tck.test.javaee.module.version>11.0.3</tck.test.javaee.module.version>
     </properties>

--- a/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-install/pom.xml
+++ b/glassfish-runner/platform/jdbc-platform-tck/jdbc-platform-tck-install/pom.xml
@@ -33,7 +33,7 @@
 
     <properties>
         <tck.test.jdbc.file>jakartaeetck-${tck.test.jdbc.version}.zip</tck.test.jdbc.file>
-        <tck.test.jdbc.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.jdbc.file}</tck.test.jdbc.url>
+        <tck.test.jdbc.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.jdbc.file}</tck.test.jdbc.url>
         <tck.test.jdbc.version>11.0.3</tck.test.jdbc.version>
     </properties>
 

--- a/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/rest-platform-extra-tck/rest-platform-extra-tck-install/pom.xml
@@ -34,7 +34,7 @@
 
    <properties>
         <tck.test.rest-extra.file>jakartaeetck-${tck.test.rest-extra.version}.zip</tck.test.rest-extra.file>
-        <tck.test.rest-extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.rest-extra.file}</tck.test.rest-extra.url>
+        <tck.test.rest-extra.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.rest-extra.file}</tck.test.rest-extra.url>
         <tck.test.rest-extra.version>11.0.3</tck.test.rest-extra.version>
     </properties>
 

--- a/glassfish-runner/tags-tck/tags-tck-install/pom.xml
+++ b/glassfish-runner/tags-tck/tags-tck-install/pom.xml
@@ -34,7 +34,7 @@
 
    <properties>
         <tck.test.tags.file>jakartaeetck-${tck.test.tags.version}.zip</tck.test.tags.file>
-        <tck.test.tags.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.tags.file}</tck.test.tags.url>
+        <tck.test.tags.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.tags.file}</tck.test.tags.url>
         <tck.test.tags.version>11.0.3</tck.test.tags.version>
     </properties>
 

--- a/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
+++ b/glassfish-runner/transactions-tck/transactions-tck-install/pom.xml
@@ -34,7 +34,7 @@
 
    <properties>
         <tck.test.transactions.file>jakartaeetck-${tck.test.transactions.version}.zip</tck.test.transactions.file>
-        <tck.test.transactions.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.transactions.file}</tck.test.transactions.url>
+        <tck.test.transactions.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.transactions.file}</tck.test.transactions.url>
         <tck.test.transactions.version>11.0.3</tck.test.transactions.version>
     </properties>
 

--- a/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
+++ b/glassfish-runner/websocket-platform-extra-tck/websocket-platform-extra-tck-install/pom.xml
@@ -38,7 +38,7 @@
         <tck.test.websocket.url>https://download.eclipse.org/jakartaee/websocket/2.2/${tck.test.websocket.file}</tck.test.websocket.url>
         
         <tck.test.websocket.extra.file>jakartaeetck-${tck.test.websocket.extra.version}.zip</tck.test.websocket.extra.file>
-        <tck.test.websocket.extra.url>https://download.eclipse.org/ee4j/jakartaee-platform/jakartaee11/staged/eftl/${tck.test.websocket.extra.file}</tck.test.websocket.extra.url>
+        <tck.test.websocket.extra.url>https://download.eclipse.org/jakartaee/platform/11/${tck.test.websocket.extra.file}</tck.test.websocket.extra.url>
         
         <tck.test.websocket.version>2.2.0</tck.test.websocket.version>
         <tck.test.websocket.extra.version>11.0.3</tck.test.websocket.extra.version>


### PR DESCRIPTION
Platform and CDI links were to the wrong folder on the Eclipse download site

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
