### PR TITLE
servlet-tck: share one pool slot across the http+https group

### DIFF
--- a/glassfish-runner/servlet-tck/servlet-tck-run/pom.xml
+++ b/glassfish-runner/servlet-tck/servlet-tck-run/pom.xml
@@ -51,7 +51,8 @@
         <gf.pool.portStride>100</gf.pool.portStride>
         <gf.pool.unpack.skip>false</gf.pool.unpack.skip>
         <gf.pool.restartOnRelease>false</gf.pool.restartOnRelease>
-        
+        <gf.pool.shareGroupSlot>true</gf.pool.shareGroupSlot> <!-- http+https are one server: share a single pool slot rather than two. -->
+
         <tck.test.servlet.version>6.1.0</tck.test.servlet.version>
     </properties>
 
@@ -312,6 +313,7 @@
                         <gf.pool.adminBase>${gf.pool.adminBase}</gf.pool.adminBase>
                         <gf.pool.portStride>${gf.pool.portStride}</gf.pool.portStride>
                         <gf.pool.restartOnRelease>${gf.pool.restartOnRelease}</gf.pool.restartOnRelease>
+                        <gf.pool.shareGroupSlot>${gf.pool.shareGroupSlot}</gf.pool.shareGroupSlot>
 
                         <arquillian.xml>${project.basedir}/arquillian.xml</arquillian.xml>
 


### PR DESCRIPTION
The servlet runner's `<group>` declares `http` and `https` containers, but both address the **same** GlassFish. With the pool container each leases its own slot, so on the size-1 pool the second member collides on the slot lock (and otherwise needs `pool.size=2` = two GlassFish instances for one logical server).

This forwards `gf.pool.shareGroupSlot=true` to the test JVM, so the two group members **share a single leased slot** — one GlassFish serves the whole group, and `pool.size=1` suffices. `http` and `https` keep their own `httpsPortAsDefault`, addressing the same instance on the http vs https port.

No `arquillian.xml` change — the adapter infers the shared `slotGroup` from the `<group>` qualifier when the switch is on.

## Requires

Depends on https://github.com/OmniFish-EE/arquillian-container-glassfish/pull/53 being merged and released into `arquillian-glassfish` **2.2.1-SNAPSHOT** (the version this runner already references). That PR adds the `gf.pool.shareGroupSlot` / shared-lease support this change relies on. Until then this opt-in is a no-op (the property is simply ignored by the current adapter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)