### PR TITLE
Add connector-white box readonly changes - do not merge until EE12 integrated

### DIFF
--- a/tcks/apis/connector-whitebox/whitebox/pom.xml
+++ b/tcks/apis/connector-whitebox/whitebox/pom.xml
@@ -16,12 +16,19 @@
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <jakarta.transaction-api.version>2.0.2-SNAPSHOT</jakarta.transaction-api.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>jakarta.authentication</groupId>
             <artifactId>jakarta.authentication-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.transaction</groupId>
+            <artifactId>jakarta.transaction-api</artifactId>
+            <version>${jakarta.transaction-api.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/util/ConnectorStatus.java
+++ b/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/util/ConnectorStatus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -36,6 +36,7 @@ public class ConnectorStatus implements Log {
     private Vector statelog = new Vector();
 
     private boolean logFlag = false;
+    private volatile boolean supportReadOnly = true;
 
     /**
      * Singleton constructor
@@ -107,4 +108,17 @@ public class ConnectorStatus implements Log {
         logFlag = b;
     }
 
+    /**
+     * Retrieves the readOnly support
+     */
+    public boolean isSupportReadOnly() {
+        return supportReadOnly;
+    }
+
+    /**
+     * Sets the readOnly support to true/false
+     */
+    public void setSupportReadOnly(boolean supportReadOnly) {
+        this.supportReadOnly = supportReadOnly;
+    }
 }

--- a/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/whitebox/TSResourceManager.java
+++ b/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/whitebox/TSResourceManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -67,6 +67,14 @@ public class TSResourceManager {
         association.clear();
     }
 
+    public void setReadOnly(Xid xid) throws XAException {
+        sanityCheck(xid, XAResource.TMNOFLAGS, "setReadOnly");
+
+        TSXaTransaction txn = new TSXaTransaction(xid);
+        txn.setReadOnly(true);
+        association.put(xid, txn);
+    }
+
     /**
      * Starts the new Global Transaction branch. transaction can be started in three ways.
      *
@@ -89,7 +97,9 @@ public class TSResourceManager {
         sanityCheck(xid, flags, "start");
 
         if (flags == XAResource.TMNOFLAGS) {
-            TSXaTransaction txn = new TSXaTransaction(xid);
+            TSXaTransaction txn = (TSXaTransaction) association.get(xid);
+            if (txn == null)
+                txn = new TSXaTransaction(xid);
             txn.setStatus(TSXaTransaction.STARTED);
             if (con != null)
                 txn.addConnection(con);
@@ -229,6 +239,28 @@ public class TSResourceManager {
     }
 
     /**
+     * Get the Transaction read-only value of a Connection.
+     *
+     * @param con Connection involved.
+     */
+    boolean isTransactionReadOnly(TSConnection con) {
+        Enumeration e = association.keys();
+        while (e.hasMoreElements()) {
+            Xid id = (Xid) e.nextElement();
+            TSXaTransaction txn = (TSXaTransaction) association.get(id);
+            Hashtable connections = txn.getConnections();
+            Enumeration e1 = connections.keys();
+            while (e1.hasMoreElements()) {
+                TSConnection temp = (TSConnection) e1.nextElement();
+                if (con == temp) {
+                    return txn.isReadOnly();
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
      * Reads a particular key in a distributed transaction.
      *
      * @param key Key to be read.
@@ -257,6 +289,15 @@ public class TSResourceManager {
      * @throws XAExcpetion In case of an invalid XA protocol.
      */
     private void sanityCheck(Xid xid, int flags, String operation) throws XAException {
+        if ((operation != null) && (operation.equals("setReadOnly"))) {
+            if (!(flags == XAResource.TMNOFLAGS)) {
+                throw new XAException(XAException.XAER_INVAL);
+            }
+
+            if (association.containsKey(xid)) {
+                throw new XAException(XAException.XAER_DUPID);
+            }
+        }
         // Sanity checks for the xa_start operation.
         if ((operation != null) && (operation.equals("start"))) {
 
@@ -266,7 +307,8 @@ public class TSResourceManager {
 
             // For TMNOFLAGS xid should not be known to RM.
             if (flags == XAResource.TMNOFLAGS) {
-                if (association.containsKey(xid)) {
+                TSXaTransaction txn = (TSXaTransaction) association.get(xid);
+                if (txn != null && txn.getStatus() != TSXaTransaction.NOTRANSACTION) {
                     throw new XAException(XAException.XAER_DUPID);
                 }
             }

--- a/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/whitebox/TSXaTransaction.java
+++ b/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/whitebox/TSXaTransaction.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -60,6 +60,9 @@ public class TSXaTransaction {
     /** Field storing the status values **/
     private int status = 0;
 
+    /** Field storing the read-only value **/
+    private boolean readOnly = false;
+
     /** Connections involved in one transaction branch. Specifications doesnt **/
     /** stop from having more than one connection in global transaction **/
     private Hashtable connections = new Hashtable();
@@ -110,6 +113,24 @@ public class TSXaTransaction {
      */
     public int getStatus() {
         return this.status;
+    }
+
+    /**
+     * Get the read-only value of the transaction.
+     *
+     * @return Read-only value of the transaction.
+     */
+    public boolean isReadOnly() {
+        return readOnly;
+    }
+
+    /**
+     * Sets the read-only value of the transaction.
+     *
+     * @param readOnly of the transaction
+     */
+    public void setReadOnly(boolean readOnly) {
+        this.readOnly = readOnly;
     }
 
     /**

--- a/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/whitebox/TSeis.java
+++ b/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/whitebox/TSeis.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -160,6 +160,9 @@ public class TSeis {
     }
 
     public void insert(String key, String value, TSConnection con) throws TSEISException {
+        if (getResourceManager().isTransactionReadOnly(con)) {
+            throw new TSEISException("Read only transaction");
+        }
 
         boolean datapresent = false;
 
@@ -187,6 +190,9 @@ public class TSeis {
     }
 
     public void update(String key, String value, TSConnection con) throws TSEISException {
+        if (getResourceManager().isTransactionReadOnly(con)) {
+            throw new TSEISException("Read only transaction");
+        }
         DataElement de = read(key, con);
         de.updateVersion();
         de.setValue(value);
@@ -206,6 +212,9 @@ public class TSeis {
     }
 
     public void delete(String key, TSConnection con) throws TSEISException {
+        if (getResourceManager().isTransactionReadOnly(con)) {
+            throw new TSEISException("Read only transaction");
+        }
         DataElement de = read(key, con);
         if ((getResourceManager().getTransactionStatus(con) == TSXaTransaction.NOTRANSACTION) && con.getAutoCommit()) {
             System.out.println("TSeis.delete.permtable");

--- a/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/whitebox/XAResourceImpl.java
+++ b/tcks/apis/connector-whitebox/whitebox/src/main/java/com/sun/ts/tests/common/connector/whitebox/XAResourceImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2007, 2020 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2007, 2025 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,8 +27,9 @@ import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 
 import com.sun.ts.tests.common.connector.util.ConnectorStatus;
+import jakarta.transaction.xa.ExtendedXAResource;
 
-public class XAResourceImpl implements XAResource {
+public class XAResourceImpl implements ExtendedXAResource {
 
     private TSManagedConnection mc;
 
@@ -50,6 +51,24 @@ public class XAResourceImpl implements XAResource {
         XAException xae = new XAException(ex.toString());
         xae.errorCode = XAException.XAER_RMERR;
         throw xae;
+    }
+
+    @Override
+    public boolean setReadOnly(Xid xid) throws XAException {
+        try {
+            ConnectorStatus.getConnectorStatus().logAPI("ExtendedXAResource.setReadOnly", "", "");
+            if (ConnectorStatus.getConnectorStatus().isSupportReadOnly()) {
+                TSeis.getTSeis().getResourceManager().setReadOnly(xid);
+                return true;
+            } else {
+                return false;
+            }
+        } catch (XAException xe) {
+            throw xe;
+        } catch (Exception ex) {
+            handleResourceException(ex);
+            return false;
+        }
     }
 
     public void commit(Xid xid, boolean onePhase) throws XAException {


### PR DESCRIPTION
Counterpart to https://github.com/jakartaee/transactions/pull/262

Adds readOnly changes from https://github.com/jakartaee/platform-tck/pull/2462 to white box and connector only since the transactions tck has been moved to the transactions repo. 

CC @alwin-joseph @anajosep @arjantijms @cesarhernandezgt @dblevins @m0mus @edbratt @gurunrao @jansupol @jgallimore @kazumura @kwsutter @LanceAndersen @bhatpmk @RohitKumarJain @shighbar @gthoman @brideck @OndroMih @dmatej
@starksm64 @scottmarlow
